### PR TITLE
commerce/cart: Fix cart.PaymentSelection not serialisable during place order

### DIFF
--- a/cart/module.go
+++ b/cart/module.go
@@ -140,6 +140,7 @@ func (r *routes) Routes(registry *web.RouterRegistry) {
 	registry.HandleAny("cart.deleteItem", r.viewController.DeleteAndViewAction)
 	registry.Route("/cart/delete/:id", `cart.deleteItem(id,deliveryCode?="")`)
 	gob.Register(cart.Cart{})
+	gob.Register(cart.PaymentSelection{})
 	r.apiRoutes(registry)
 }
 


### PR DESCRIPTION
After a successful order, a flash message is added to the session to display a success page with all order details in the frontend. Due to the refactoring of the payment, the current implementation cannot be saved in the session. Therefore the successAction displays the template as if the session was expired. This PR registers the cart.PaymentSelection structure with gob.Register to make it serializable in the session.