### PR TITLE
commerce/cart: Fix possible nil pointer during cart cache update

### DIFF
--- a/cart/application/cartService.go
+++ b/cart/application/cartService.go
@@ -391,8 +391,8 @@ func (cs *CartService) BuildAddRequest(ctx context.Context, marketplaceCode stri
 	}
 
 	return cartDomain.AddRequest{
-		MarketplaceCode: marketplaceCode,
-		Qty:             qty,
+		MarketplaceCode:        marketplaceCode,
+		Qty:                    qty,
 		VariantMarketplaceCode: variantMarketplaceCode,
 	}
 }
@@ -528,7 +528,7 @@ func (cs *CartService) publishAddtoCartEvent(ctx context.Context, currentCart ca
 }
 
 func (cs *CartService) updateCartInCacheIfCacheIsEnabled(ctx context.Context, session *web.Session, cart *cartDomain.Cart) {
-	if cs.cartCache != nil {
+	if cs.cartCache != nil && cart != nil {
 		id, err := cs.cartCache.BuildIdentifier(ctx, session)
 		if err != nil {
 			return


### PR DESCRIPTION
The `updateCartInCacheIfCacheIsEnabled ` function is called during cart operations. In the event of a cart error this can lead to a call with a nil pointer which currently isn't handled properly.

Changes on line 394/395 are caused by go fmt.