### PR TITLE
cart: Fix failing cart tests due to incomplete config struct

### DIFF
--- a/cart/application/cartReceiver_test.go
+++ b/cart/application/cartReceiver_test.go
@@ -420,6 +420,7 @@ func TestCartService_DeleteSavedSessionGuestCartID(t *testing.T) {
 		RestrictionService  *cartApplication.RestrictionService
 		config              *struct {
 			DefaultDeliveryCode string `inject:"config:commerce.cart.defaultDeliveryCode,optional"`
+			DeleteEmptyDelivery bool   `inject:"config:commerce.cart.deleteEmptyDelivery,optional"`
 		}
 		DeliveryInfoBuilder cartDomain.DeliveryInfoBuilder
 		CartCache           cartApplication.CartCache
@@ -469,6 +470,7 @@ func TestCartService_DeleteSavedSessionGuestCartID(t *testing.T) {
 				EventPublisher: new(MockEventPublisher),
 				config: &struct {
 					DefaultDeliveryCode string `inject:"config:commerce.cart.defaultDeliveryCode,optional"`
+					DeleteEmptyDelivery bool   `inject:"config:commerce.cart.deleteEmptyDelivery,optional"`
 				}{
 					DefaultDeliveryCode: "default_delivery_code",
 				},


### PR DESCRIPTION
Config struct of cartService was updated in #8, change wasn't applied to the test cases. 