### PR TITLE
cart: Add event that fires when the payment selection was reset

### DIFF
--- a/cart/application/cartReceiver_test.go
+++ b/cart/application/cartReceiver_test.go
@@ -143,7 +143,7 @@ func (m *MockEventPublisher) PublishChangedQtyInCartEvent(ctx context.Context, i
 func (m *MockEventPublisher) PublishOrderPlacedEvent(ctx context.Context, cart *cartDomain.Cart, placedOrderInfos cartDomain.PlacedOrderInfos) {
 }
 
-func (m *MockEventPublisher) PublishPaymentSelectionHasBeenResetEvent(ctx context.Context) {
+func (m *MockEventPublisher) PublishPaymentSelectionHasBeenResetEvent(ctx context.Context, cart *cartDomain.Cart) {
 }
 
 // MockCartValidator

--- a/cart/application/cartReceiver_test.go
+++ b/cart/application/cartReceiver_test.go
@@ -26,7 +26,7 @@ var (
 	_ cartDomain.GuestCartService = (*MockGuestCartServiceAdapter)(nil)
 )
 
-func (m *MockGuestCartServiceAdapter) GetCart(ctx context.Context, cartId string) (*cartDomain.Cart, error) {
+func (m *MockGuestCartServiceAdapter) GetCart(ctx context.Context, cartID string) (*cartDomain.Cart, error) {
 	return &cartDomain.Cart{
 		ID: "mock_guest_cart",
 	}, nil
@@ -47,7 +47,7 @@ type (
 	MockGuestCartServiceAdapterError struct{}
 )
 
-func (m *MockGuestCartServiceAdapterError) GetCart(ctx context.Context, cartId string) (*cartDomain.Cart, error) {
+func (m *MockGuestCartServiceAdapterError) GetCart(ctx context.Context, cartID string) (*cartDomain.Cart, error) {
 	return nil, errors.New("defective")
 }
 
@@ -74,7 +74,7 @@ func (m *MockCustomerCartService) GetModifyBehaviour(context.Context, domain.Aut
 	return new(cartInfrastructure.InMemoryBehaviour), nil
 }
 
-func (m *MockCustomerCartService) GetCart(ctx context.Context, auth domain.Auth, cartId string) (*cartDomain.Cart, error) {
+func (m *MockCustomerCartService) GetCart(ctx context.Context, auth domain.Auth, cartID string) (*cartDomain.Cart, error) {
 	return &cartDomain.Cart{
 		ID: "mock_customer_cart",
 	}, nil
@@ -141,6 +141,9 @@ func (m *MockEventPublisher) PublishChangedQtyInCartEvent(ctx context.Context, i
 }
 
 func (m *MockEventPublisher) PublishOrderPlacedEvent(ctx context.Context, cart *cartDomain.Cart, placedOrderInfos cartDomain.PlacedOrderInfos) {
+}
+
+func (m *MockEventPublisher) PublishPaymentSelectionHasBeenResetEvent(ctx context.Context) {
 }
 
 // MockCartValidator

--- a/cart/application/eventPublishing.go
+++ b/cart/application/eventPublishing.go
@@ -33,11 +33,16 @@ type (
 		QtyAfter               int
 	}
 
+	// PaymentSelectionHasBeenResetEvent defines event properties
+	PaymentSelectionHasBeenResetEvent struct {
+	}
+
 	//EventPublisher - technology free interface to publish events that might be interesting for outside (Publish)
 	EventPublisher interface {
 		PublishAddToCartEvent(ctx context.Context, marketPlaceCode string, variantMarketPlaceCode string, qty int)
 		PublishChangedQtyInCartEvent(ctx context.Context, item *cartDomain.Item, qtyBefore int, qtyAfter int, cartID string)
 		PublishOrderPlacedEvent(ctx context.Context, cart *cartDomain.Cart, placedOrderInfos cartDomain.PlacedOrderInfos)
+		PublishPaymentSelectionHasBeenResetEvent(ctx context.Context)
 	}
 
 	//DefaultEventPublisher implements the event publisher of the domain and uses the framework event router
@@ -108,4 +113,11 @@ func (d *DefaultEventPublisher) PublishOrderPlacedEvent(ctx context.Context, car
 
 	//For now we publish only to Flamingo default Event Router
 	d.eventRouter.Dispatch(ctx, &eventObject)
+}
+
+// PublishPaymentSelectionHasBeenResetEvent publishes an event that is triggered if an invalid payment selection is found and a reset is done
+func (d *DefaultEventPublisher) PublishPaymentSelectionHasBeenResetEvent(ctx context.Context) {
+	d.logger.Info("Publish Event PaymentSelectionHasBeenResetEvent")
+
+	d.eventRouter.Dispatch(ctx, &PaymentSelectionHasBeenResetEvent{})
 }

--- a/cart/application/eventPublishing.go
+++ b/cart/application/eventPublishing.go
@@ -35,6 +35,7 @@ type (
 
 	// PaymentSelectionHasBeenResetEvent defines event properties
 	PaymentSelectionHasBeenResetEvent struct {
+		Cart *cartDomain.Cart
 	}
 
 	//EventPublisher - technology free interface to publish events that might be interesting for outside (Publish)
@@ -42,7 +43,7 @@ type (
 		PublishAddToCartEvent(ctx context.Context, marketPlaceCode string, variantMarketPlaceCode string, qty int)
 		PublishChangedQtyInCartEvent(ctx context.Context, item *cartDomain.Item, qtyBefore int, qtyAfter int, cartID string)
 		PublishOrderPlacedEvent(ctx context.Context, cart *cartDomain.Cart, placedOrderInfos cartDomain.PlacedOrderInfos)
-		PublishPaymentSelectionHasBeenResetEvent(ctx context.Context)
+		PublishPaymentSelectionHasBeenResetEvent(ctx context.Context, cart *cartDomain.Cart)
 	}
 
 	//DefaultEventPublisher implements the event publisher of the domain and uses the framework event router
@@ -56,6 +57,9 @@ type (
 var (
 	_ EventPublisher = (*DefaultEventPublisher)(nil)
 	_ flamingo.Event = (*OrderPlacedEvent)(nil)
+	_ flamingo.Event = (*AddToCartEvent)(nil)
+	_ flamingo.Event = (*PaymentSelectionHasBeenResetEvent)(nil)
+	_ flamingo.Event = (*ChangedQtyInCartEvent)(nil)
 )
 
 // Inject dependencies
@@ -116,8 +120,8 @@ func (d *DefaultEventPublisher) PublishOrderPlacedEvent(ctx context.Context, car
 }
 
 // PublishPaymentSelectionHasBeenResetEvent publishes an event that is triggered if an invalid payment selection is found and a reset is done
-func (d *DefaultEventPublisher) PublishPaymentSelectionHasBeenResetEvent(ctx context.Context) {
+func (d *DefaultEventPublisher) PublishPaymentSelectionHasBeenResetEvent(ctx context.Context, cart *cartDomain.Cart) {
 	d.logger.Info("Publish Event PaymentSelectionHasBeenResetEvent")
 
-	d.eventRouter.Dispatch(ctx, &PaymentSelectionHasBeenResetEvent{})
+	d.eventRouter.Dispatch(ctx, &PaymentSelectionHasBeenResetEvent{Cart: cart})
 }

--- a/cart/infrastructure/InMemoryBehaviour.go
+++ b/cart/infrastructure/InMemoryBehaviour.go
@@ -377,8 +377,10 @@ func (cob *InMemoryBehaviour) resetPaymentSelectionIfInvalid(ctx context.Context
 	}
 	err := cob.checkPaymentSelection(ctx, cart, cart.PaymentSelection)
 	if err != nil {
+
+		cart, err := cob.UpdatePaymentSelection(ctx, cart, nil)
 		cob.eventPublisher.PublishPaymentSelectionHasBeenResetEvent(ctx, cart)
-		return cob.UpdatePaymentSelection(ctx, cart, nil)
+		return cart, err
 	}
 	return cart, nil
 }

--- a/cart/infrastructure/InMemoryBehaviour.go
+++ b/cart/infrastructure/InMemoryBehaviour.go
@@ -377,7 +377,7 @@ func (cob *InMemoryBehaviour) resetPaymentSelectionIfInvalid(ctx context.Context
 	}
 	err := cob.checkPaymentSelection(ctx, cart, cart.PaymentSelection)
 	if err != nil {
-		cob.eventPublisher.PublishPaymentSelectionHasBeenResetEvent(ctx)
+		cob.eventPublisher.PublishPaymentSelectionHasBeenResetEvent(ctx, cart)
 		return cob.UpdatePaymentSelection(ctx, cart, nil)
 	}
 	return cart, nil

--- a/cart/infrastructure/InMemoryBehaviour_test.go
+++ b/cart/infrastructure/InMemoryBehaviour_test.go
@@ -41,6 +41,7 @@ func TestInMemoryBehaviour_CleanCart(t *testing.T) {
 					return &domaincart.Builder{}
 				},
 				nil,
+				nil,
 			)
 			cart := &domaincart.Cart{
 				ID: "17",
@@ -159,6 +160,7 @@ func TestInMemoryBehaviour_CleanDelivery(t *testing.T) {
 				func() *domaincart.Builder {
 					return &domaincart.Builder{}
 				},
+				nil,
 				nil,
 			)
 			if err := cob.cartStorage.StoreCart(tt.args.cart); err != nil {


### PR DESCRIPTION
If the payment selection is reset, we should dispatch an event to inform the frontend to generate a new payment selection.

fixed some linting errors in cartReceiver_test.go as well.