### PR TITLE
cart: add possibility to dictate events for later dispatching

### DIFF
--- a/cart/application/cartReceiver_test.go
+++ b/cart/application/cartReceiver_test.go
@@ -143,9 +143,6 @@ func (m *MockEventPublisher) PublishChangedQtyInCartEvent(ctx context.Context, i
 func (m *MockEventPublisher) PublishOrderPlacedEvent(ctx context.Context, cart *cartDomain.Cart, placedOrderInfos cartDomain.PlacedOrderInfos) {
 }
 
-func (m *MockEventPublisher) PublishPaymentSelectionHasBeenResetEvent(ctx context.Context, cart *cartDomain.Cart) {
-}
-
 // MockCartValidator
 type (
 	MockCartValidator struct{}
@@ -409,112 +406,6 @@ func TestCartReceiverService_ViewGuestCart(t *testing.T) {
 
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("CartReceiverService.ViewGuestCart() = %v, wantType0 %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestCartService_DeleteSavedSessionGuestCartID(t *testing.T) {
-	type fields struct {
-		CartReceiverService *cartApplication.CartReceiverService
-		ProductService      productDomain.ProductService
-		Logger              flamingo.Logger
-		EventPublisher      cartApplication.EventPublisher
-		RestrictionService  *cartApplication.RestrictionService
-		config              *struct {
-			DefaultDeliveryCode string `inject:"config:commerce.cart.defaultDeliveryCode,optional"`
-			DeleteEmptyDelivery bool   `inject:"config:commerce.cart.deleteEmptyDelivery,optional"`
-		}
-		DeliveryInfoBuilder cartDomain.DeliveryInfoBuilder
-		CartCache           cartApplication.CartCache
-		PlaceOrderService   cartDomain.PlaceOrderService
-	}
-	type args struct {
-		session *web.Session
-	}
-	tests := []struct {
-		name          string
-		fields        fields
-		args          args
-		wantErr       bool
-		valuesCleared bool
-	}{
-		{
-			name: "basic clearing of guest cart session value",
-			fields: fields{
-				CartReceiverService: func() *cartApplication.CartReceiverService {
-					result := &cartApplication.CartReceiverService{}
-					result.Inject(
-						new(MockGuestCartServiceAdapter),
-						new(MockCustomerCartService),
-						func() *cartDomain.DecoratedCartFactory {
-							result := &cartDomain.DecoratedCartFactory{}
-							result.Inject(
-								&MockProductService{},
-								flamingo.NullLogger{},
-							)
-
-							return result
-						}(),
-						&authApplication.AuthManager{},
-						&authApplication.UserService{},
-						flamingo.NullLogger{},
-						nil,
-						&struct {
-							CartCache cartApplication.CartCache `inject:",optional"`
-						}{
-							CartCache: new(MockCartCache),
-						},
-					)
-					return result
-				}(),
-				ProductService: &MockProductService{},
-				Logger:         flamingo.NullLogger{},
-				EventPublisher: new(MockEventPublisher),
-				config: &struct {
-					DefaultDeliveryCode string `inject:"config:commerce.cart.defaultDeliveryCode,optional"`
-					DeleteEmptyDelivery bool   `inject:"config:commerce.cart.deleteEmptyDelivery,optional"`
-				}{
-					DefaultDeliveryCode: "default_delivery_code",
-					DeleteEmptyDelivery: false,
-				},
-				DeliveryInfoBuilder: new(MockDeliveryInfoBuilder),
-				CartCache:           new(MockCartCache),
-			},
-			args: args{
-				session: web.EmptySession().Store(cartApplication.GuestCartSessionKey, "some_guest_id"),
-			},
-			wantErr:       false,
-			valuesCleared: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cs := &cartApplication.CartService{}
-			cs.Inject(
-				tt.fields.CartReceiverService,
-				tt.fields.ProductService,
-				tt.fields.EventPublisher,
-				tt.fields.DeliveryInfoBuilder,
-				tt.fields.RestrictionService,
-				tt.fields.Logger,
-				tt.fields.config,
-				nil,
-			)
-
-			err := cs.DeleteSavedSessionGuestCartID(tt.args.session)
-
-			if (err != nil) != tt.wantErr {
-				t.Errorf("CartService.DeleteSavedSessionGuestCartID() error = %v, wantErr %v", err, tt.wantErr)
-
-				return
-			}
-
-			if tt.valuesCleared == true {
-				if len(tt.args.session.Keys()) > 0 {
-					t.Error("Session Values should be empty, but aren't")
-				}
 			}
 		})
 	}

--- a/cart/application/cartService_test.go
+++ b/cart/application/cartService_test.go
@@ -1,0 +1,120 @@
+package application_test
+
+import (
+	"testing"
+
+	cartApplication "flamingo.me/flamingo-commerce/v3/cart/application"
+	cartDomain "flamingo.me/flamingo-commerce/v3/cart/domain/cart"
+	productDomain "flamingo.me/flamingo-commerce/v3/product/domain"
+	authApplication "flamingo.me/flamingo/v3/core/oauth/application"
+	"flamingo.me/flamingo/v3/framework/flamingo"
+	"flamingo.me/flamingo/v3/framework/web"
+)
+
+func TestCartService_DeleteSavedSessionGuestCartID(t *testing.T) {
+	type fields struct {
+		CartReceiverService *cartApplication.CartReceiverService
+		ProductService      productDomain.ProductService
+		Logger              flamingo.Logger
+		EventPublisher      cartApplication.EventPublisher
+		EventRouter         flamingo.EventRouter
+		RestrictionService  *cartApplication.RestrictionService
+		config              *struct {
+			DefaultDeliveryCode string `inject:"config:commerce.cart.defaultDeliveryCode,optional"`
+			DeleteEmptyDelivery bool   `inject:"config:commerce.cart.deleteEmptyDelivery,optional"`
+		}
+		DeliveryInfoBuilder cartDomain.DeliveryInfoBuilder
+		CartCache           cartApplication.CartCache
+		PlaceOrderService   cartDomain.PlaceOrderService
+	}
+	type args struct {
+		session *web.Session
+	}
+	tests := []struct {
+		name          string
+		fields        fields
+		args          args
+		wantErr       bool
+		valuesCleared bool
+	}{
+		{
+			name: "basic clearing of guest cart session value",
+			fields: fields{
+				CartReceiverService: func() *cartApplication.CartReceiverService {
+					result := &cartApplication.CartReceiverService{}
+					result.Inject(
+						new(MockGuestCartServiceAdapter),
+						new(MockCustomerCartService),
+						func() *cartDomain.DecoratedCartFactory {
+							result := &cartDomain.DecoratedCartFactory{}
+							result.Inject(
+								&MockProductService{},
+								flamingo.NullLogger{},
+							)
+
+							return result
+						}(),
+						&authApplication.AuthManager{},
+						&authApplication.UserService{},
+						flamingo.NullLogger{},
+						nil,
+						&struct {
+							CartCache cartApplication.CartCache `inject:",optional"`
+						}{
+							CartCache: new(MockCartCache),
+						},
+					)
+					return result
+				}(),
+				ProductService: &MockProductService{},
+				Logger:         flamingo.NullLogger{},
+				EventPublisher: new(MockEventPublisher),
+				config: &struct {
+					DefaultDeliveryCode string `inject:"config:commerce.cart.defaultDeliveryCode,optional"`
+					DeleteEmptyDelivery bool   `inject:"config:commerce.cart.deleteEmptyDelivery,optional"`
+				}{
+					DefaultDeliveryCode: "default_delivery_code",
+					DeleteEmptyDelivery: false,
+				},
+				DeliveryInfoBuilder: new(MockDeliveryInfoBuilder),
+				CartCache:           new(MockCartCache),
+			},
+			args: args{
+				session: web.EmptySession().Store(cartApplication.GuestCartSessionKey, "some_guest_id"),
+			},
+			wantErr:       false,
+			valuesCleared: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := &cartApplication.CartService{}
+			cs.Inject(
+				tt.fields.CartReceiverService,
+				tt.fields.ProductService,
+				tt.fields.EventPublisher,
+				tt.fields.EventRouter,
+				tt.fields.DeliveryInfoBuilder,
+				tt.fields.RestrictionService,
+				tt.fields.Logger,
+				tt.fields.config,
+				nil,
+			)
+
+			err := cs.DeleteSavedSessionGuestCartID(tt.args.session)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CartService.DeleteSavedSessionGuestCartID() error = %v, wantErr %v", err, tt.wantErr)
+
+				return
+			}
+
+			if tt.valuesCleared == true {
+				if len(tt.args.session.Keys()) > 0 {
+					t.Error("Session Values should be empty, but aren't")
+				}
+			}
+		})
+	}
+}

--- a/cart/application/eventPublishing.go
+++ b/cart/application/eventPublishing.go
@@ -43,7 +43,6 @@ type (
 		PublishAddToCartEvent(ctx context.Context, marketPlaceCode string, variantMarketPlaceCode string, qty int)
 		PublishChangedQtyInCartEvent(ctx context.Context, item *cartDomain.Item, qtyBefore int, qtyAfter int, cartID string)
 		PublishOrderPlacedEvent(ctx context.Context, cart *cartDomain.Cart, placedOrderInfos cartDomain.PlacedOrderInfos)
-		PublishPaymentSelectionHasBeenResetEvent(ctx context.Context, cart *cartDomain.Cart)
 	}
 
 	//DefaultEventPublisher implements the event publisher of the domain and uses the framework event router
@@ -117,11 +116,4 @@ func (d *DefaultEventPublisher) PublishOrderPlacedEvent(ctx context.Context, car
 
 	//For now we publish only to Flamingo default Event Router
 	d.eventRouter.Dispatch(ctx, &eventObject)
-}
-
-// PublishPaymentSelectionHasBeenResetEvent publishes an event that is triggered if an invalid payment selection is found and a reset is done
-func (d *DefaultEventPublisher) PublishPaymentSelectionHasBeenResetEvent(ctx context.Context, cart *cartDomain.Cart) {
-	d.logger.Info("Publish Event PaymentSelectionHasBeenResetEvent")
-
-	d.eventRouter.Dispatch(ctx, &PaymentSelectionHasBeenResetEvent{Cart: cart})
 }

--- a/cart/domain/cart/cartServicePorts.go
+++ b/cart/domain/cart/cartServicePorts.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 
 	"flamingo.me/flamingo/v3/core/oauth/domain"
+	"flamingo.me/flamingo/v3/framework/flamingo"
+
 	"github.com/pkg/errors"
 )
 
@@ -26,21 +28,24 @@ type (
 		GetCart(ctx context.Context, auth domain.Auth, cartID string) (*Cart, error)
 	}
 
+	// DeferEvents represents events that should be dispatched after a cart modify call
+	DeferEvents []flamingo.Event
+
 	// ModifyBehaviour is a interface that can be implemented by other packages to provide cart actions
 	// This port can not be registered directly but is provided by the registered "GuestCartService"
 	ModifyBehaviour interface {
-		DeleteItem(ctx context.Context, cart *Cart, itemID string, deliveryCode string) (*Cart, error)
-		UpdateItem(ctx context.Context, cart *Cart, itemID string, deliveryCode string, itemUpdateCommand ItemUpdateCommand) (*Cart, error)
-		AddToCart(ctx context.Context, cart *Cart, deliveryCode string, addRequest AddRequest) (*Cart, error)
-		CleanCart(ctx context.Context, cart *Cart) (*Cart, error)
-		CleanDelivery(ctx context.Context, cart *Cart, deliveryCode string) (*Cart, error)
-		UpdatePurchaser(ctx context.Context, cart *Cart, purchaser *Person, additionalData *AdditionalData) (*Cart, error)
-		UpdateAdditionalData(ctx context.Context, cart *Cart, additionalData *AdditionalData) (*Cart, error)
-		UpdatePaymentSelection(ctx context.Context, cart *Cart, paymentSelection *PaymentSelection) (*Cart, error)
-		UpdateDeliveryInfo(ctx context.Context, cart *Cart, deliveryCode string, deliveryInfo DeliveryInfoUpdateCommand) (*Cart, error)
-		UpdateBillingAddress(ctx context.Context, cart *Cart, billingAddress Address) (*Cart, error)
-		UpdateDeliveryInfoAdditionalData(ctx context.Context, cart *Cart, deliveryCode string, additionalData *AdditionalData) (*Cart, error)
-		ApplyVoucher(ctx context.Context, cart *Cart, couponCode string) (*Cart, error)
+		DeleteItem(ctx context.Context, cart *Cart, itemID string, deliveryCode string) (*Cart, DeferEvents, error)
+		UpdateItem(ctx context.Context, cart *Cart, itemID string, deliveryCode string, itemUpdateCommand ItemUpdateCommand) (*Cart, DeferEvents, error)
+		AddToCart(ctx context.Context, cart *Cart, deliveryCode string, addRequest AddRequest) (*Cart, DeferEvents, error)
+		CleanCart(ctx context.Context, cart *Cart) (*Cart, DeferEvents, error)
+		CleanDelivery(ctx context.Context, cart *Cart, deliveryCode string) (*Cart, DeferEvents, error)
+		UpdatePurchaser(ctx context.Context, cart *Cart, purchaser *Person, additionalData *AdditionalData) (*Cart, DeferEvents, error)
+		UpdateAdditionalData(ctx context.Context, cart *Cart, additionalData *AdditionalData) (*Cart, DeferEvents, error)
+		UpdatePaymentSelection(ctx context.Context, cart *Cart, paymentSelection *PaymentSelection) (*Cart, DeferEvents, error)
+		UpdateDeliveryInfo(ctx context.Context, cart *Cart, deliveryCode string, deliveryInfo DeliveryInfoUpdateCommand) (*Cart, DeferEvents, error)
+		UpdateBillingAddress(ctx context.Context, cart *Cart, billingAddress Address) (*Cart, DeferEvents, error)
+		UpdateDeliveryInfoAdditionalData(ctx context.Context, cart *Cart, deliveryCode string, additionalData *AdditionalData) (*Cart, DeferEvents, error)
+		ApplyVoucher(ctx context.Context, cart *Cart, couponCode string) (*Cart, DeferEvents, error)
 	}
 
 	// AddRequest defines add to cart requeset
@@ -68,7 +73,7 @@ type (
 	PlaceOrderService interface {
 		PlaceGuestCart(ctx context.Context, cart *Cart, payment *Payment) (PlacedOrderInfos, error)
 		PlaceCustomerCart(ctx context.Context, auth domain.Auth, cart *Cart, payment *Payment) (PlacedOrderInfos, error)
-		ReserveOrderID(ctx context.Context, cart *Cart) (string,error)
+		ReserveOrderID(ctx context.Context, cart *Cart) (string, error)
 	}
 )
 

--- a/cart/infrastructure/InMemoryBehaviour_test.go
+++ b/cart/infrastructure/InMemoryBehaviour_test.go
@@ -11,9 +11,10 @@ import (
 
 func TestInMemoryBehaviour_CleanCart(t *testing.T) {
 	tests := []struct {
-		name    string
-		want    *domaincart.Cart
-		wantErr bool
+		name       string
+		want       *domaincart.Cart
+		wantDefers domaincart.DeferEvents
+		wantErr    bool
 	}{
 		{
 			name: "clean cart",
@@ -21,7 +22,8 @@ func TestInMemoryBehaviour_CleanCart(t *testing.T) {
 				ID:         "17",
 				Deliveries: []domaincart.Delivery{},
 			},
-			wantErr: false,
+			wantDefers: nil,
+			wantErr:    false,
 		},
 	}
 	for _, tt := range tests {
@@ -59,13 +61,16 @@ func TestInMemoryBehaviour_CleanCart(t *testing.T) {
 				t.Fatalf("cart could not be initialized")
 			}
 
-			got, err := cob.CleanCart(context.Background(), cart)
+			got, gotDefers, err := cob.CleanCart(context.Background(), cart)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("InMemoryCartOrderBehaviour.CleanCart() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if diff := deep.Equal(got, tt.want); diff != nil {
 				t.Errorf("InMemoryCartOrderBehaviour.CleanCart() got!=want, diff: %#v", diff)
+			}
+			if diff := deep.Equal(gotDefers, tt.wantDefers); diff != nil {
+				t.Errorf("InMemoryCartOrderBehaviour.CleanCart() gotDefers!=wantDefers, diff: %#v", diff)
 			}
 		})
 	}
@@ -78,10 +83,11 @@ func TestInMemoryBehaviour_CleanDelivery(t *testing.T) {
 		deliveryCode string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    *domaincart.Cart
-		wantErr bool
+		name       string
+		args       args
+		want       *domaincart.Cart
+		wantDefers domaincart.DeferEvents
+		wantErr    bool
 	}{
 		{
 			name: "clean dev-1",
@@ -116,7 +122,8 @@ func TestInMemoryBehaviour_CleanDelivery(t *testing.T) {
 					},
 				},
 			},
-			wantErr: false,
+			wantDefers: nil,
+			wantErr:    false,
 		},
 		{
 			name: "delivery not found",
@@ -140,8 +147,9 @@ func TestInMemoryBehaviour_CleanDelivery(t *testing.T) {
 				},
 				deliveryCode: "dev-3",
 			},
-			want:    nil,
-			wantErr: true,
+			want:       nil,
+			wantDefers: nil,
+			wantErr:    true,
 		},
 	}
 	for _, tt := range tests {
@@ -167,13 +175,16 @@ func TestInMemoryBehaviour_CleanDelivery(t *testing.T) {
 				t.Fatalf("cart could not be initialized")
 			}
 
-			got, err := cob.CleanDelivery(context.Background(), tt.args.cart, tt.args.deliveryCode)
+			got, gotDefers, err := cob.CleanDelivery(context.Background(), tt.args.cart, tt.args.deliveryCode)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("InMemoryCartOrderBehaviour.CleanDelivery() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if diff := deep.Equal(got, tt.want); diff != nil {
 				t.Errorf("InMemoryCartOrderBehaviour.CleanDelivery() got!=want, diff: %#v", diff)
+			}
+			if diff := deep.Equal(gotDefers, tt.wantDefers); diff != nil {
+				t.Errorf("InMemoryCartOrderBehaviour.CleanCart() gotDefers!=wantDefers, diff: %#v", diff)
 			}
 		})
 	}


### PR DESCRIPTION
All cart modify behaviour functions can return a list of events that the
cart service shall dispatch in the end.