### PR TITLE
cart: Fix loyalty charges

### DIFF
--- a/cart/domain/decorator/cartDecorator.go
+++ b/cart/domain/decorator/cartDecorator.go
@@ -171,7 +171,8 @@ func (dci DecoratedCartItem) GetVariantsVariationAttributeCodes() []string {
 
 // GetChargesToPay getter
 func (dci DecoratedCartItem) GetChargesToPay(wishedToPaySum *domain.WishedToPay) priceDomain.Charges {
-	return dci.Product.SaleableData().GetLoyaltyChargeSplit(nil, wishedToPaySum, dci.Item.Qty)
+	price := dci.Item.RowPriceNet
+	return dci.Product.SaleableData().GetLoyaltyChargeSplit(&price, wishedToPaySum, dci.Item.Qty)
 }
 
 // GetGroupedBy legacy function

--- a/cart/domain/decorator/cartDecorator.go
+++ b/cart/domain/decorator/cartDecorator.go
@@ -171,7 +171,7 @@ func (dci DecoratedCartItem) GetVariantsVariationAttributeCodes() []string {
 
 // GetChargesToPay getter
 func (dci DecoratedCartItem) GetChargesToPay(wishedToPaySum *domain.WishedToPay) priceDomain.Charges {
-	priceToPayForItem := dci.Item.RowPriceNetWithDiscount()
+	priceToPayForItem := dci.Item.RowPriceGrossWithDiscount()
 	return dci.Product.SaleableData().GetLoyaltyChargeSplit(&priceToPayForItem, wishedToPaySum, dci.Item.Qty)
 }
 

--- a/cart/domain/decorator/cartDecorator.go
+++ b/cart/domain/decorator/cartDecorator.go
@@ -2,8 +2,9 @@ package decorator
 
 import (
 	"context"
-	"flamingo.me/flamingo-commerce/v3/cart/domain/cart"
 	"sort"
+
+	"flamingo.me/flamingo-commerce/v3/cart/domain/cart"
 
 	priceDomain "flamingo.me/flamingo-commerce/v3/price/domain"
 	"flamingo.me/flamingo-commerce/v3/product/domain"
@@ -170,11 +171,7 @@ func (dci DecoratedCartItem) GetVariantsVariationAttributeCodes() []string {
 
 // GetChargesToPay getter
 func (dci DecoratedCartItem) GetChargesToPay(wishedToPaySum *domain.WishedToPay) priceDomain.Charges {
-	priceToPayForItem := dci.Item.RowPriceGrossWithDiscount()
-	if wishedToPaySum == nil {
-		return dci.Product.SaleableData().GetLoyaltyChargeSplit(&priceToPayForItem, nil)
-	}
-	return dci.Product.SaleableData().GetLoyaltyChargeSplit(&priceToPayForItem, wishedToPaySum)
+	return dci.Product.SaleableData().GetLoyaltyChargeSplit(nil, wishedToPaySum, dci.Item.Qty)
 }
 
 // GetGroupedBy legacy function

--- a/cart/domain/decorator/cartDecorator.go
+++ b/cart/domain/decorator/cartDecorator.go
@@ -171,8 +171,8 @@ func (dci DecoratedCartItem) GetVariantsVariationAttributeCodes() []string {
 
 // GetChargesToPay getter
 func (dci DecoratedCartItem) GetChargesToPay(wishedToPaySum *domain.WishedToPay) priceDomain.Charges {
-	price := dci.Item.RowPriceNet
-	return dci.Product.SaleableData().GetLoyaltyChargeSplit(&price, wishedToPaySum, dci.Item.Qty)
+	priceToPayForItem := dci.Item.RowPriceNetWithDiscount()
+	return dci.Product.SaleableData().GetLoyaltyChargeSplit(&priceToPayForItem, wishedToPaySum, dci.Item.Qty)
 }
 
 // GetGroupedBy legacy function

--- a/product/domain/productBasics.go
+++ b/product/domain/productBasics.go
@@ -312,13 +312,14 @@ func (p Saleable) GetLoyaltyPriceByType(ltype string) (*LoyaltyPriceInfo, bool) 
 	return nil, false
 }
 
-// GetLoyaltyChargeSplit  Gets the Charges that need to be payed by type:
+// GetLoyaltyChargeSplit gets the Charges that need to be payed by type:
 // Type "main" is the remaining charge in the main currency and the other charges returned are the loyalty price charges that need to be payed.
-// The method takes the min, max and the caluclated loyalty conversion rate into account
+// The method takes the min, max and the calculated loyalty conversion rate into account
 //
-// @param valuedPriceToPay  Optional the price that need to be payed - if not given the products final price will be used
-// @param loyaltyPointsWishedToPay   Optional a list of loyaltyPrices that the (customer) wants to spend. Its used as a wish and may not be fullfilled because of min, max properties on the products loyaltyPrices
-func (p Saleable) GetLoyaltyChargeSplit(valuedPriceToPay *priceDomain.Price, loyaltyPointsWishedToPay *WishedToPay) priceDomain.Charges {
+// @param valuedPriceToPay Optional the price that need to be payed - if not given the products final price will be used
+// @param loyaltyPointsWishedToPay Optional a list of loyaltyPrices that the (customer) wants to spend. Its used as a wish and may not be fulfilled because of min, max properties on the products loyaltyPrices
+// @param qty Quantity of the product, needed to calculate min / max
+func (p Saleable) GetLoyaltyChargeSplit(valuedPriceToPay *priceDomain.Price, loyaltyPointsWishedToPay *WishedToPay, qty int) priceDomain.Charges {
 	if valuedPriceToPay == nil {
 		finalPrice := p.ActivePrice.GetFinalPrice()
 		valuedPriceToPay = &finalPrice
@@ -338,24 +339,13 @@ func (p Saleable) GetLoyaltyChargeSplit(valuedPriceToPay *priceDomain.Price, loy
 
 		rateLoyaltyFinalPriceToRealFinalPrice := loyaltyPrice.GetRate(p.ActivePrice.GetFinalPrice())
 
-		/**
-		   We need to adjust min and max evaluation according to passed valuedPriceToPay (rule of three - direct proportional)
-			activePrice -> loyaltyPrice    100€  -> 50Miles
-			valuedPriceToPay  -> x  		90€  -> 45Miles
-
-			x = ((valuedPriceToPay * loyaltyPrice)  / activePrice )
-
-			rateForMilesAdjustment = x / loyaltyPrice
-		*/
-		rateForMilesAdjustment := big.NewFloat(valuedPriceToPay.FloatAmount() / p.ActivePrice.GetFinalPrice().FloatAmount())
-
 		//loyaltyAmountToSpent - set as default without potential wish
-		loyaltyAmountToSpent := loyaltyPrice.GetAmountToSpendRelative(nil, rateForMilesAdjustment)
+		loyaltyAmountToSpent := loyaltyPrice.GetAmountToSpendWithQty(nil, qty)
 		if loyaltyPointsWishedToPay != nil {
 			wishedPrice := loyaltyPointsWishedToPay.GetByType(chargeType)
 			if wishedPrice != nil && wishedPrice.Currency() == loyaltyPrice.GetFinalPrice().Currency() {
 				//Use the passed wishedPrice of that type
-				loyaltyAmountToSpent = loyaltyPrice.GetAmountToSpendRelative(wishedPrice.Amount(), rateForMilesAdjustment)
+				loyaltyAmountToSpent = loyaltyPrice.GetAmountToSpendWithQty(wishedPrice.Amount(), qty)
 			}
 		}
 
@@ -455,7 +445,7 @@ func (l LoyaltyPriceInfo) GetFinalPrice() priceDomain.Price {
 	return l.Default
 }
 
-//GetAmountToSpendWithQty - takes the whishedamaount and qty and returns the Price in points that need to be payed based on this.
+//GetAmountToSpendWithQty - takes the wishedAmount and qty and returns the Price in points that need to be payed based on this.
 // - method evaluates min and max and returns the loyalty points amount that need/Can to be payed
 func (l LoyaltyPriceInfo) GetAmountToSpendWithQty(wishedAmount *big.Float, qty int) big.Float {
 	//less or equal - return min
@@ -478,7 +468,7 @@ func (l LoyaltyPriceInfo) GetAmountToSpendWithQty(wishedAmount *big.Float, qty i
 	return *wishedAmount
 }
 
-//GetAmountToSpendRelative - takes the whishedamaount and an adjustmentRate
+//GetAmountToSpendRelative - takes the wishedAmount and an adjustmentRate
 // evaluates min and max according to the adjustmentRate and returns the loyalty points amount that need to be payed.
 func (l LoyaltyPriceInfo) GetAmountToSpendRelative(wishedAmount *big.Float, adjustmentRate *big.Float) big.Float {
 	if adjustmentRate == nil {


### PR DESCRIPTION
Use net prices to ignore taxes for minimum spend, use item qty to calculate min instead of relative rate