### PR TITLE
Adding Name to Restrictor Interface

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,5 @@
+[![Build Status](https://api.travis-ci.org/i-love-flamingo/flamingo-commerce.svg?branch=master)](https://travis-ci.org/i-love-flamingo/flamingo-commerce)
+
 # Flamingo Commerce
 
 Contains modules that helps building powerful and flexible ecommerce websites.

--- a/cart/domain/validation/restrictionService.go
+++ b/cart/domain/validation/restrictionService.go
@@ -13,16 +13,20 @@ type (
 	RestrictionService struct {
 		qtyRestrictors []MaxQuantityRestrictor
 	}
+
 	// RestrictionResult contains the result of a restriction
 	RestrictionResult struct {
 		IsRestricted        bool
 		MaxAllowed          int
 		RemainingDifference int
+		RestrictorName      string
 	}
 
 	// MaxQuantityRestrictor returns the maximum qty allowed for a given product and cart
 	// it is possible to register many (MultiBind) MaxQuantityRestrictor implementations
 	MaxQuantityRestrictor interface {
+		// Name returns the code of the restrictor
+		Name() string
 		// Restrict must return a `RestrictionResult` which contains information regarding if a restriction is
 		// applied and whats the max allowed quantity
 		Restrict(ctx context.Context, product domain.BasicProduct, cart *cart.Cart) *RestrictionResult
@@ -43,8 +47,8 @@ func (rs *RestrictionService) Inject(
 func (rs *RestrictionService) RestrictQty(ctx context.Context, product domain.BasicProduct, currentCart *cart.Cart) *RestrictionResult {
 	restrictionResult := &RestrictionResult{
 		IsRestricted:        false,
-		RemainingDifference: math.MaxInt32,
 		MaxAllowed:          math.MaxInt32,
+		RemainingDifference: math.MaxInt32,
 	}
 
 	for _, r := range rs.qtyRestrictors {
@@ -55,6 +59,7 @@ func (rs *RestrictionService) RestrictQty(ctx context.Context, product domain.Ba
 
 			if currentResult.MaxAllowed < restrictionResult.MaxAllowed {
 				restrictionResult.MaxAllowed = currentResult.MaxAllowed
+				restrictionResult.RestrictorName = currentResult.RestrictorName
 			}
 
 			if currentResult.RemainingDifference < restrictionResult.RemainingDifference {

--- a/cart/domain/validation/restrictionService_test.go
+++ b/cart/domain/validation/restrictionService_test.go
@@ -3,6 +3,7 @@ package validation_test
 import (
 	"context"
 	"flamingo.me/flamingo-commerce/v3/cart/domain/validation"
+	"fmt"
 	"math"
 	"reflect"
 	"testing"
@@ -15,6 +16,10 @@ type MockRestrictor struct {
 	IsRestricted  bool
 	MaxQty        int
 	DifferenceQty int
+}
+
+func (r *MockRestrictor) Name() string {
+	return fmt.Sprintf("MockRestrictor")
 }
 
 func (r *MockRestrictor) Restrict(ctx context.Context, product domain.BasicProduct, currentCart *cart.Cart) *validation.RestrictionResult {


### PR DESCRIPTION
Name is eventually needed to discern which restrictor changed the max (aka the "strictest") and show it in the frontend.