### PR TITLE
cart: Add delivery code to restrictors

### DIFF
--- a/cart/application/cartService.go
+++ b/cart/application/cartService.go
@@ -258,7 +258,7 @@ func (cs *CartService) UpdateItemQty(ctx context.Context, session *web.Session, 
 		return err
 	}
 
-	err = cs.checkProductQtyRestrictions(ctx, product, cart, qty-qtyBefore)
+	err = cs.checkProductQtyRestrictions(ctx, product, cart, qty-qtyBefore, deliveryCode)
 	if err != nil {
 		cs.logger.WithContext(ctx).WithField("subCategory", "UpdateItemQty").Error(err)
 
@@ -500,7 +500,7 @@ func (cs *CartService) AddProduct(ctx context.Context, session *web.Session, del
 		return nil, err
 	}
 
-	err = cs.checkProductQtyRestrictions(ctx, product, cart, addRequest.Qty)
+	err = cs.checkProductQtyRestrictions(ctx, product, cart, addRequest.Qty, deliveryCode)
 	if err != nil {
 		cs.logger.WithContext(ctx).WithField(flamingo.LogKeySubCategory, "AddProduct").Error(err)
 
@@ -605,8 +605,8 @@ func (cs *CartService) checkProductForAddRequest(ctx context.Context, session *w
 	return addRequest, product, nil
 }
 
-func (cs *CartService) checkProductQtyRestrictions(ctx context.Context, product productDomain.BasicProduct, cart *cartDomain.Cart, qtyToCheck int) error {
-	restrictionResult := cs.restrictionService.RestrictQty(ctx, product, cart)
+func (cs *CartService) checkProductQtyRestrictions(ctx context.Context, product productDomain.BasicProduct, cart *cartDomain.Cart, qtyToCheck int, deliveryCode string) error {
+	restrictionResult := cs.restrictionService.RestrictQty(ctx, product, cart, deliveryCode)
 
 	if restrictionResult.IsRestricted {
 		if qtyToCheck > restrictionResult.RemainingDifference {

--- a/cart/domain/validation/restrictionService.go
+++ b/cart/domain/validation/restrictionService.go
@@ -29,7 +29,7 @@ type (
 		Name() string
 		// Restrict must return a `RestrictionResult` which contains information regarding if a restriction is
 		// applied and whats the max allowed quantity
-		Restrict(ctx context.Context, product domain.BasicProduct, cart *cart.Cart) *RestrictionResult
+		Restrict(ctx context.Context, product domain.BasicProduct, cart *cart.Cart, deliveryCode string) *RestrictionResult
 	}
 )
 
@@ -44,7 +44,7 @@ func (rs *RestrictionService) Inject(
 
 // RestrictQty checks if there is an qty restriction present and returns an according result containing the max allowed
 // quantity and the quantity difference to the current cart
-func (rs *RestrictionService) RestrictQty(ctx context.Context, product domain.BasicProduct, currentCart *cart.Cart) *RestrictionResult {
+func (rs *RestrictionService) RestrictQty(ctx context.Context, product domain.BasicProduct, currentCart *cart.Cart, deliveryCode string) *RestrictionResult {
 	restrictionResult := &RestrictionResult{
 		IsRestricted:        false,
 		MaxAllowed:          math.MaxInt32,
@@ -52,7 +52,7 @@ func (rs *RestrictionService) RestrictQty(ctx context.Context, product domain.Ba
 	}
 
 	for _, r := range rs.qtyRestrictors {
-		currentResult := r.Restrict(ctx, product, currentCart)
+		currentResult := r.Restrict(ctx, product, currentCart, deliveryCode)
 
 		if currentResult.IsRestricted {
 			restrictionResult.IsRestricted = true

--- a/cart/domain/validation/restrictionService_test.go
+++ b/cart/domain/validation/restrictionService_test.go
@@ -2,15 +2,18 @@ package validation_test
 
 import (
 	"context"
-	"flamingo.me/flamingo-commerce/v3/cart/domain/validation"
 	"fmt"
 	"math"
 	"reflect"
 	"testing"
 
+	"flamingo.me/flamingo-commerce/v3/cart/domain/validation"
+
 	"flamingo.me/flamingo-commerce/v3/cart/domain/cart"
 	"flamingo.me/flamingo-commerce/v3/product/domain"
 )
+
+var _ validation.MaxQuantityRestrictor = (*MockRestrictor)(nil)
 
 type MockRestrictor struct {
 	IsRestricted  bool
@@ -22,7 +25,7 @@ func (r *MockRestrictor) Name() string {
 	return fmt.Sprintf("MockRestrictor")
 }
 
-func (r *MockRestrictor) Restrict(ctx context.Context, product domain.BasicProduct, currentCart *cart.Cart) *validation.RestrictionResult {
+func (r *MockRestrictor) Restrict(ctx context.Context, product domain.BasicProduct, currentCart *cart.Cart, deliveryCode string) *validation.RestrictionResult {
 	return &validation.RestrictionResult{
 		IsRestricted:        r.IsRestricted,
 		MaxAllowed:          r.MaxQty,
@@ -35,9 +38,10 @@ func TestRestrictionService_RestrictQty(t *testing.T) {
 		qtyRestrictors []validation.MaxQuantityRestrictor
 	}
 	type args struct {
-		ctx     context.Context
-		product domain.BasicProduct
-		cart    *cart.Cart
+		ctx          context.Context
+		product      domain.BasicProduct
+		cart         *cart.Cart
+		deliveryCode string
 	}
 	tests := []struct {
 		name                      string
@@ -113,7 +117,7 @@ func TestRestrictionService_RestrictQty(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			rs := &validation.RestrictionService{}
 			rs.Inject(tt.fields.qtyRestrictors)
-			got := rs.RestrictQty(tt.args.ctx, tt.args.product, tt.args.cart)
+			got := rs.RestrictQty(tt.args.ctx, tt.args.product, tt.args.cart, tt.args.deliveryCode)
 			if !reflect.DeepEqual(got, tt.expectedRestrictionResult) {
 				t.Errorf("RestrictionService.RestrictQty() got = %v, expected = %v", got, tt.expectedRestrictionResult)
 			}

--- a/order/domain/order.go
+++ b/order/domain/order.go
@@ -38,8 +38,10 @@ type (
 		Price        float64
 		PriceInclTax float64
 
-		// Source Id where the item shoudl be picked
+		// Source Id where the item should be picked
 		SourceID string
+
+		Attributes Attributes
 	}
 
 	// Attributes map
@@ -47,6 +49,4 @@ type (
 
 	// Attribute interface
 	Attribute interface{}
-
-
 )


### PR DESCRIPTION
Allow restrictors to restrict quantities based on delivery code.
This PR also adds Attributes to OrderItems to be more flexible in the future.