### PR TITLE
Fix cart decorator issue in case of missing product

### DIFF
--- a/cart/domain/decorator/cartDecorator.go
+++ b/cart/domain/decorator/cartDecorator.go
@@ -90,6 +90,8 @@ func (df *DecoratedCartFactory) decorateCartItem(ctx context.Context, cartitem c
 					Title: cartitem.ProductName + "[outdated]",
 				},
 			}
+
+			decorateditem.Product = product
 		}
 		return decorateditem
 	}


### PR DESCRIPTION
The cart decorator does not return a usable decorated item in case the product service was not able to fetch an product.

This scenario can arise as soon as a product is added to the cart and later removed from storage.
The decorator must provide a valid fallback product.