### PR TITLE
cart: use preallocated slices where possible

### DIFF
--- a/cart/domain/cart/cart.go
+++ b/cart/domain/cart/cart.go
@@ -187,7 +187,7 @@ func (c Cart) HasDeliveryForCode(deliveryCode string) bool {
 
 // GetDeliveryCodes returns a slice of all delivery codes in cart that have at least one cart item
 func (c Cart) GetDeliveryCodes() []string {
-	var deliveryCodes []string
+	deliveryCodes := make([]string, 0, len(c.Deliveries))
 
 	for _, delivery := range c.Deliveries {
 		if len(delivery.Cartitems) > 0 {
@@ -300,7 +300,7 @@ func (c Cart) GetAllPaymentRequiredItems() PricedItems {
 
 // SumShippingNet - returns net sum price of deliveries ShippingItems
 func (c Cart) SumShippingNet() domain.Price {
-	var prices []domain.Price
+	prices := make([]domain.Price, 0, len(c.Deliveries))
 
 	for _, del := range c.Deliveries {
 		prices = append(prices, del.ShippingItem.PriceNet)
@@ -318,7 +318,7 @@ func (c Cart) HasShippingCosts() bool {
 
 // AllShippingTitles - returns all ShippingItem titles
 func (c Cart) AllShippingTitles() []string {
-	var label []string
+	label := make([]string, 0, len(c.Deliveries))
 
 	for _, del := range c.Deliveries {
 		label = append(label, del.ShippingItem.Title)
@@ -329,7 +329,7 @@ func (c Cart) AllShippingTitles() []string {
 
 // SubTotalGross - returns sum price of deliveries SubTotalGross
 func (c Cart) SubTotalGross() domain.Price {
-	var prices []domain.Price
+	prices := make([]domain.Price, 0, len(c.Deliveries))
 
 	for _, del := range c.Deliveries {
 		prices = append(prices, del.SubTotalGross())
@@ -361,7 +361,7 @@ func (c Cart) SumTotalTaxAmount() domain.Price {
 
 // SubTotalNet - returns sum price of deliveries SubTotalNet
 func (c Cart) SubTotalNet() domain.Price {
-	var prices []domain.Price
+	prices := make([]domain.Price, 0, len(c.Deliveries))
 
 	for _, del := range c.Deliveries {
 		prices = append(prices, del.SubTotalNet())
@@ -374,7 +374,7 @@ func (c Cart) SubTotalNet() domain.Price {
 
 // SubTotalGrossWithDiscounts - returns sum price of deliveries SubTotalGrossWithDiscounts
 func (c Cart) SubTotalGrossWithDiscounts() domain.Price {
-	var prices []domain.Price
+	prices := make([]domain.Price, 0, len(c.Deliveries))
 
 	for _, del := range c.Deliveries {
 		prices = append(prices, del.SubTotalGrossWithDiscounts())
@@ -387,17 +387,19 @@ func (c Cart) SubTotalGrossWithDiscounts() domain.Price {
 
 // SubTotalNetWithDiscounts - returns sum price of deliveries SubTotalNetWithDiscounts
 func (c Cart) SubTotalNetWithDiscounts() domain.Price {
-	var prices []domain.Price
+	prices := make([]domain.Price, 0, len(c.Deliveries))
+
 	for _, del := range c.Deliveries {
 		prices = append(prices, del.SubTotalNetWithDiscounts())
 	}
 	price, _ := domain.SumAll(prices...)
+
 	return price
 }
 
 // SumTotalDiscountAmount - returns sum price of deliveries SumTotalDiscountAmount
 func (c Cart) SumTotalDiscountAmount() domain.Price {
-	var prices []domain.Price
+	prices := make([]domain.Price, 0, len(c.Deliveries))
 
 	for _, del := range c.Deliveries {
 		prices = append(prices, del.SumTotalDiscountAmount())
@@ -410,7 +412,7 @@ func (c Cart) SumTotalDiscountAmount() domain.Price {
 
 // SumNonItemRelatedDiscountAmount - returns sum price of deliveries SumNonItemRelatedDiscountAmount
 func (c Cart) SumNonItemRelatedDiscountAmount() domain.Price {
-	var prices []domain.Price
+	prices := make([]domain.Price, 0, len(c.Deliveries))
 
 	for _, del := range c.Deliveries {
 		prices = append(prices, del.SumNonItemRelatedDiscountAmount())
@@ -423,7 +425,7 @@ func (c Cart) SumNonItemRelatedDiscountAmount() domain.Price {
 
 // SumItemRelatedDiscountAmount - returns sum price of deliveries SumItemRelatedDiscountAmount
 func (c Cart) SumItemRelatedDiscountAmount() domain.Price {
-	var prices []domain.Price
+	prices := make([]domain.Price, 0, len(c.Deliveries))
 
 	for _, del := range c.Deliveries {
 		prices = append(prices, del.SumItemRelatedDiscountAmount())
@@ -458,7 +460,7 @@ func (c Cart) GetPaymentReference() string {
 
 // GetTotalItemsByType gets a slice of all Totalitems by typeCode
 func (c Cart) GetTotalItemsByType(typeCode string) []Totalitem {
-	var totalitems []Totalitem
+	totalitems := make([]Totalitem, 0, len(c.Totalitems))
 
 	for _, item := range c.Totalitems {
 		if item.Type == typeCode {
@@ -537,7 +539,7 @@ func (t Taxes) AddTaxesWithMerge(taxes Taxes) Taxes {
 
 // TotalAmount - returns the sum of all taxes as price
 func (t Taxes) TotalAmount() domain.Price {
-	var prices []domain.Price
+	prices := make([]domain.Price, 0, len(t))
 
 	for _, tax := range t {
 		prices = append(prices, tax.Amount)
@@ -668,7 +670,8 @@ func (b *Builder) reset(err error) (*Cart, error) {
 
 //Sum - returns Sum of all items in this struct
 func (p PricedItems) Sum() domain.Price {
-	prices := make([]domain.Price, len(p.cartItems)+len(p.shippingItems)+len(p.totalItems))
+	prices := make([]domain.Price, 0, len(p.cartItems)+len(p.shippingItems)+len(p.totalItems))
+
 	for _, p := range p.totalItems {
 		prices = append(prices, p)
 	}
@@ -679,6 +682,7 @@ func (p PricedItems) Sum() domain.Price {
 		prices = append(prices, p)
 	}
 	sum, _ := domain.SumAll(prices...)
+
 	return sum
 }
 

--- a/cart/domain/cart/delivery.go
+++ b/cart/domain/cart/delivery.go
@@ -110,25 +110,33 @@ func (di *DeliveryInfo) LoadAdditionalInfo(key string, info AdditionalDeliverInf
 
 //SubTotalGross - returns SubTotalGross
 func (d Delivery) SubTotalGross() priceDomain.Price {
-	var prices []priceDomain.Price
+	prices := make([]priceDomain.Price, 0, len(d.Cartitems))
+
 	for _, item := range d.Cartitems {
 		prices = append(prices, item.RowPriceGross)
 	}
 	result, _ := priceDomain.SumAll(prices...)
+
 	return result
 }
 
 //GrandTotal - returns SubTotalGross inlcuding shipping and discounts - for the Delivery
 func (d Delivery) GrandTotal() priceDomain.Price {
-	var prices []priceDomain.Price
+	// we need a capacity of cartitems + 2
+	prices := make([]priceDomain.Price, 0, len(d.Cartitems)+2)
+
 	for _, item := range d.Cartitems {
 		prices = append(prices, item.RowPriceGross)
 	}
+
 	prices = append(prices, d.SumTotalDiscountAmount())
+
 	if !d.ShippingItem.TotalWithDiscountInclTax().IsZero() {
 		prices = append(prices, d.ShippingItem.TotalWithDiscountInclTax())
 	}
+
 	result, _ := priceDomain.SumAll(prices...)
+
 	return result
 }
 
@@ -145,63 +153,75 @@ func (d Delivery) SumRowTaxes() Taxes {
 
 //SumTotalTaxAmount - returns SumTotalTaxAmount
 func (d Delivery) SumTotalTaxAmount() priceDomain.Price {
-	var prices []priceDomain.Price
+	prices := make([]priceDomain.Price, 0, len(d.Cartitems))
+
 	for _, item := range d.Cartitems {
 		prices = append(prices, item.TotalTaxAmount())
 	}
 	result, _ := priceDomain.SumAll(prices...)
+
 	return result
 }
 
 //SubTotalNet - returns SubTotalNet
 func (d Delivery) SubTotalNet() priceDomain.Price {
-	var prices []priceDomain.Price
+	prices := make([]priceDomain.Price, 0, len(d.Cartitems))
+
 	for _, item := range d.Cartitems {
 		prices = append(prices, item.RowPriceNet)
 	}
 	result, _ := priceDomain.SumAll(prices...)
+
 	return result
 }
 
 //SumTotalDiscountAmount - returns SumTotalDiscountAmount
 func (d Delivery) SumTotalDiscountAmount() priceDomain.Price {
-	var prices []priceDomain.Price
+	prices := make([]priceDomain.Price, 0, len(d.Cartitems))
+
 	for _, item := range d.Cartitems {
 		prices = append(prices, item.TotalDiscountAmount())
 	}
 	result, _ := priceDomain.SumAll(prices...)
+
 	return result
 }
 
 //SumNonItemRelatedDiscountAmount returns SumNonItemRelatedDiscountAmount
 func (d Delivery) SumNonItemRelatedDiscountAmount() priceDomain.Price {
-	var prices []priceDomain.Price
+	prices := make([]priceDomain.Price, 0, len(d.Cartitems))
+
 	for _, item := range d.Cartitems {
 		prices = append(prices, item.NonItemRelatedDiscountAmount())
 	}
 	result, _ := priceDomain.SumAll(prices...)
+
 	return result
 }
 
 //SumItemRelatedDiscountAmount - returns SumItemRelatedDiscountAmount
 func (d Delivery) SumItemRelatedDiscountAmount() priceDomain.Price {
-	var prices []priceDomain.Price
+	prices := make([]priceDomain.Price, 0, len(d.Cartitems))
+
 	for _, item := range d.Cartitems {
 		prices = append(prices, item.ItemRelatedDiscountAmount())
 	}
 	result, _ := priceDomain.SumAll(prices...)
+
 	return result
 }
 
 //SubTotalGrossWithDiscounts returns SubTotalGrossWithDiscounts
 func (d Delivery) SubTotalGrossWithDiscounts() priceDomain.Price {
 	price, _ := d.SubTotalGross().Add(d.SumTotalDiscountAmount())
+
 	return price
 }
 
 //SubTotalNetWithDiscounts - returns SubTotalNet With Discounts
 func (d Delivery) SubTotalNetWithDiscounts() priceDomain.Price {
 	price, _ := d.SubTotalNet().Add(d.SumTotalDiscountAmount())
+
 	return price
 }
 
@@ -270,7 +290,6 @@ func (f *DeliveryBuilder) reset() {
 	f.deliveryInBuilding = nil
 }
 
-
 // TotalWithDiscountInclTax - the price the customer need to pay for the shipping
 func (s ShippingItem) TotalWithDiscountInclTax() priceDomain.Price {
 	price, _ := s.PriceNet.Add(s.TaxAmount)
@@ -278,11 +297,10 @@ func (s ShippingItem) TotalWithDiscountInclTax() priceDomain.Price {
 	return price.GetPayable()
 }
 
-
 // Tax - the Tax of the shipping
 func (s ShippingItem) Tax() Tax {
 	return Tax{
-		Type: "tax",
-		Amount:s.TaxAmount,
+		Type:   "tax",
+		Amount: s.TaxAmount,
 	}
 }

--- a/cart/domain/cart/item.go
+++ b/cart/domain/cart/item.go
@@ -77,56 +77,67 @@ func (i Item) TotalTaxAmount() priceDomain.Price {
 // TotalDiscountAmount gets the savings by item
 func (i Item) TotalDiscountAmount() priceDomain.Price {
 	result, _ := i.NonItemRelatedDiscountAmount().Add(i.ItemRelatedDiscountAmount())
+
 	return result
 }
 
 // ItemRelatedDiscountAmount = Sum of AppliedDiscounts where IsItemRelated = True
 func (i Item) ItemRelatedDiscountAmount() priceDomain.Price {
-	var prices []priceDomain.Price
+	prices := make([]priceDomain.Price, 0, len(i.AppliedDiscounts))
+
 	for _, discount := range i.AppliedDiscounts {
 		if !discount.IsItemRelated {
 			continue
 		}
 		prices = append(prices, discount.Amount)
 	}
+
 	result, _ := priceDomain.SumAll(prices...)
+
 	return result.GetPayable()
 }
 
 // NonItemRelatedDiscountAmount = Sum of AppliedDiscounts where IsItemRelated = false
 func (i Item) NonItemRelatedDiscountAmount() priceDomain.Price {
-	var prices []priceDomain.Price
+	prices := make([]priceDomain.Price, 0, len(i.AppliedDiscounts))
+
 	for _, discount := range i.AppliedDiscounts {
 		if discount.IsItemRelated {
 			continue
 		}
 		prices = append(prices, discount.Amount)
 	}
+
 	result, _ := priceDomain.SumAll(prices...)
+
 	return result.GetPayable()
 }
 
 // RowPriceGrossWithDiscount = RowPriceGross-TotalDiscountAmount()
 func (i Item) RowPriceGrossWithDiscount() priceDomain.Price {
 	result, _ := i.RowPriceGross.Add(i.TotalDiscountAmount())
+
 	return result
 }
 
 // RowPriceNetWithDiscount = RowPriceNet-TotalDiscountAmount()
 func (i Item) RowPriceNetWithDiscount() priceDomain.Price {
 	result, _ := i.RowPriceNet.Add(i.TotalDiscountAmount())
+
 	return result
 }
 
 // RowPriceGrossWithItemRelatedDiscount = RowPriceGross-ItemRelatedDiscountAmount()
 func (i Item) RowPriceGrossWithItemRelatedDiscount() priceDomain.Price {
 	result, _ := i.RowPriceGross.Add(i.ItemRelatedDiscountAmount())
+
 	return result
 }
 
 // RowPriceNetWithItemRelatedDiscount =RowTotal-ItemRelatedDiscountAmount
 func (i Item) RowPriceNetWithItemRelatedDiscount() priceDomain.Price {
 	result, _ := i.RowPriceNet.Add(i.ItemRelatedDiscountAmount())
+
 	return result
 }
 


### PR DESCRIPTION
Use preallocated slices in cart where possible for loop/append operations to reduce slice growth.

The affected methods may be called rather often for cart pages.