### PR TITLE
cart: Split up balance of giftcards

### DIFF
--- a/cart/domain/cart/cart.go
+++ b/cart/domain/cart/cart.go
@@ -134,8 +134,9 @@ type (
 
 	// AppliedGiftCard value object
 	AppliedGiftCard struct {
-		Code    string
-		Balance domain.Price
+		Code      string
+		Applied   domain.Price // how much of the gift card has been subtracted from cart price
+		Remaining domain.Price // how much of the gift card is still available
 	}
 )
 

--- a/cart/infrastructure/InMemoryBehaviour.go
+++ b/cart/infrastructure/InMemoryBehaviour.go
@@ -384,8 +384,9 @@ func (cob *InMemoryBehaviour) ApplyGiftCard(ctx context.Context, cart *domaincar
 	}
 
 	giftCard := domaincart.AppliedGiftCard{
-		Code:    giftCardCode,
-		Balance: priceDomain.NewFromInt(10, 100, "$"),
+		Code:      giftCardCode,
+		Applied:   priceDomain.NewFromInt(10, 100, "$"),
+		Remaining: priceDomain.NewFromInt(0, 100, "$"),
 	}
 	cart.AppliedGiftCards = append(cart.AppliedGiftCards, giftCard)
 	err := cob.cartStorage.StoreCart(cart)

--- a/cart/infrastructure/InMemoryBehaviour_test.go
+++ b/cart/infrastructure/InMemoryBehaviour_test.go
@@ -307,8 +307,9 @@ func TestInMemoryBehaviour_ApplyGiftCard(t *testing.T) {
 			want: &domaincart.Cart{
 				AppliedGiftCards: []domaincart.AppliedGiftCard{
 					{
-						Code:    "valid",
-						Balance: priceDomain.NewFromInt(10, 100, "$"),
+						Code:      "valid",
+						Applied:   priceDomain.NewFromInt(10, 100, "$"),
+						Remaining: priceDomain.NewFromInt(0, 100, "$"),
 					},
 				},
 			},
@@ -366,12 +367,14 @@ func TestInMemoryBehaviour_RemoveGiftCard(t *testing.T) {
 				cart: &domaincart.Cart{
 					AppliedGiftCards: []domaincart.AppliedGiftCard{
 						{
-							Code:    "to-remove",
-							Balance: priceDomain.NewFromInt(10, 100, "$"),
+							Code:      "to-remove",
+							Applied:   priceDomain.NewFromInt(10, 100, "$"),
+							Remaining: priceDomain.NewFromInt(0, 100, "$"),
 						},
 						{
-							Code:    "valid",
-							Balance: priceDomain.NewFromInt(10, 100, "$"),
+							Code:      "valid",
+							Applied:   priceDomain.NewFromInt(10, 100, "$"),
+							Remaining: priceDomain.NewFromInt(0, 100, "$"),
 						},
 					},
 				},
@@ -380,8 +383,9 @@ func TestInMemoryBehaviour_RemoveGiftCard(t *testing.T) {
 			want: &domaincart.Cart{
 				AppliedGiftCards: []domaincart.AppliedGiftCard{
 					{
-						Code:    "valid",
-						Balance: priceDomain.NewFromInt(10, 100, "$"),
+						Code:      "valid",
+						Applied:   priceDomain.NewFromInt(10, 100, "$"),
+						Remaining: priceDomain.NewFromInt(0, 100, "$"),
 					},
 				},
 			},


### PR DESCRIPTION
The balance was an incomplete first idea, it is much clearer for the gift card to include an applied price and a remaining price. With this any client can differ between those two values for his logic. 