### PR TITLE
cart: add json de-/serialization of PaymentSplit

### DIFF
--- a/cart/domain/cart/paymentselection.go
+++ b/cart/domain/cart/paymentselection.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	splitQualifierSeperator = "___"
+	splitQualifierSeparator = "-"
 )
 
 type (
@@ -169,7 +169,7 @@ func (s PaymentSplit) MarshalJSON() ([]byte, error) {
 			return nil, errors.New("Method or ChargeType is empty")
 		}
 		// SplitQualifier is parsed to a string method___chargetype
-		result[qualifier.Method+splitQualifierSeperator+qualifier.ChargeType] = charge
+		result[qualifier.Method+splitQualifierSeparator+qualifier.ChargeType] = charge
 	}
 	return json.Marshal(result)
 }
@@ -183,7 +183,7 @@ func (s *PaymentSplit) UnmarshalJSON(data []byte) error {
 	result := PaymentSplit{}
 	// parse string method___chargetype back to splitqualifier
 	for key, charge := range input {
-		splitted := strings.Split(key, splitQualifierSeperator)
+		splitted := strings.Split(key, splitQualifierSeparator)
 		// guard in case cannot be splitted
 		if len(splitted) < 2 {
 			return errors.New("SplitQualifier cannot be parsed for paymentsplit")

--- a/cart/domain/cart/paymentselection.go
+++ b/cart/domain/cart/paymentselection.go
@@ -29,9 +29,6 @@ type (
 		Method     string
 	}
 
-	// PaymentSplitJSON - representation of complete payment split
-	PaymentSplitJSON map[string]price.Charge
-
 	//PaymentSplit - the Charges qualified by Type and PaymentMethod
 	PaymentSplit map[SplitQualifier]price.Charge
 
@@ -165,7 +162,7 @@ func (s PaymentSplit) ChargesByType() price.Charges {
 
 // MarshalJSON serialize to json
 func (s PaymentSplit) MarshalJSON() ([]byte, error) {
-	result := PaymentSplitJSON{}
+	result := make(map[string]price.Charge)
 	for qualifier, charge := range s {
 		// explicit method and chargetype is necessary, otherwise keys could be overwritten
 		if qualifier.Method == "" || qualifier.ChargeType == "" {
@@ -179,7 +176,7 @@ func (s PaymentSplit) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON deserialize from json
 func (s *PaymentSplit) UnmarshalJSON(data []byte) error {
-	var input PaymentSplitJSON
+	var input map[string]price.Charge
 	if err := json.Unmarshal(data, &input); err != nil {
 		return err
 	}

--- a/cart/domain/cart/paymentselection_test.go
+++ b/cart/domain/cart/paymentselection_test.go
@@ -3,10 +3,12 @@ package cart_test
 import (
 	"bytes"
 	"encoding/gob"
+	"reflect"
+	"testing"
+
 	"flamingo.me/flamingo-commerce/v3/cart/domain/cart"
 	"flamingo.me/flamingo-commerce/v3/price/domain"
 	"gopkg.in/go-playground/assert.v1"
-	"testing"
 )
 
 func TestPrice_MarshalBinaryForGob(t *testing.T) {
@@ -21,15 +23,14 @@ func TestPrice_MarshalBinaryForGob(t *testing.T) {
 	enc := gob.NewEncoder(&network) // Will write to network.
 	dec := gob.NewDecoder(&network) // Will read from network.
 	builder := cart.PaymentSplitByItemBuilder{}
-	builder.AddCartItem("id","method",domain.Charge{
-		Type:"type",
-		Price: domain.NewFromInt(100,1,"€"),
-		Value: domain.NewFromInt(100,1,"€"),
+	builder.AddCartItem("id", "method", domain.Charge{
+		Type:  "type",
+		Price: domain.NewFromInt(100, 1, "€"),
+		Value: domain.NewFromInt(100, 1, "€"),
 	})
 
-	forGob := SomeTypeWithPaymentSelection{Selection: cart.NewPaymentSelection("gateway",builder.Build())}
-	assert.Equal(t, domain.NewFromInt(100,1,"€"),forGob.Selection.ItemSplit().Sum().TotalValue())
-
+	forGob := SomeTypeWithPaymentSelection{Selection: cart.NewPaymentSelection("gateway", builder.Build())}
+	assert.Equal(t, domain.NewFromInt(100, 1, "€"), forGob.Selection.ItemSplit().Sum().TotalValue())
 
 	err := enc.Encode(&forGob)
 	if err != nil {
@@ -41,6 +42,106 @@ func TestPrice_MarshalBinaryForGob(t *testing.T) {
 		t.Fatal("decode error 1:", err)
 	}
 
-	assert.Equal(t, "gateway",received.Selection.Gateway())
-	assert.Equal(t, domain.NewFromInt(100,1,"€"),received.Selection.ItemSplit().Sum().TotalValue())
+	assert.Equal(t, "gateway", received.Selection.Gateway())
+	assert.Equal(t, domain.NewFromInt(100, 1, "€"), received.Selection.ItemSplit().Sum().TotalValue())
+}
+
+func TestPaymentSplit_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		split   cart.PaymentSplit
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name: "marshall payment split",
+			split: func() cart.PaymentSplit {
+				result := cart.PaymentSplit{}
+				charge := domain.Charge{
+					Type: "t1",
+				}
+				firstQualifier := cart.SplitQualifier{
+					Method:     "m1",
+					ChargeType: charge.Type,
+				}
+				secondQualifier := cart.SplitQualifier{
+					Method:     "m2",
+					ChargeType: charge.Type,
+				}
+				result[firstQualifier] = charge
+				result[secondQualifier] = charge
+				return result
+			}(),
+			want:    []byte("{\"m1___t1\":{\"Price\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Value\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Type\":\"t1\"},\"m2___t1\":{\"Price\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Value\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Type\":\"t1\"}}"),
+			wantErr: false,
+		},
+		{
+			name: "marshall payment split with empty values - error",
+			split: func() cart.PaymentSplit {
+				result := cart.PaymentSplit{}
+				charge := domain.Charge{
+					Type: "t1",
+				}
+				firstQualifier := cart.SplitQualifier{
+					Method:     "m1",
+					ChargeType: "",
+				}
+				secondQualifier := cart.SplitQualifier{
+					Method:     "",
+					ChargeType: charge.Type,
+				}
+				result[firstQualifier] = charge
+				result[secondQualifier] = charge
+				return result
+			}(),
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.split.MarshalJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PaymentSplit.MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("PaymentSplit.MarshalJSON() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPaymentSplit_UnmarshalJSON(t *testing.T) {
+	type args struct {
+		data []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "unmarshall payment split",
+			args: args{
+				data: []byte("{\"m1___t1\":{\"Price\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Value\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Type\":\"t1\"},\"m2___t1\":{\"Price\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Value\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Type\":\"t1\"}}"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "unmarshall payment split empty method or type - error",
+			args: args{
+				data: []byte("{\"m1_t1\":{\"Price\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Value\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Type\":\"t1\"},\"m2___t1\":{\"Price\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Value\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Type\":\"t1\"}}"),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			split := cart.PaymentSplit{}
+			if err := split.UnmarshalJSON(tt.args.data); (err != nil) != tt.wantErr {
+				t.Errorf("PaymentSplit.UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
 }

--- a/cart/domain/cart/paymentselection_test.go
+++ b/cart/domain/cart/paymentselection_test.go
@@ -72,7 +72,7 @@ func TestPaymentSplit_MarshalJSON(t *testing.T) {
 				result[secondQualifier] = charge
 				return result
 			}(),
-			want:    []byte("{\"m1___t1\":{\"Price\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Value\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Type\":\"t1\"},\"m2___t1\":{\"Price\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Value\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Type\":\"t1\"}}"),
+			want:    []byte("{\"m1-t1\":{\"Price\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Value\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Type\":\"t1\"},\"m2-t1\":{\"Price\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Value\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Type\":\"t1\"}}"),
 			wantErr: false,
 		},
 		{
@@ -125,7 +125,7 @@ func TestPaymentSplit_UnmarshalJSON(t *testing.T) {
 		{
 			name: "unmarshall payment split",
 			args: args{
-				data: []byte("{\"m1___t1\":{\"Price\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Value\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Type\":\"t1\"},\"m2___t1\":{\"Price\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Value\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Type\":\"t1\"}}"),
+				data: []byte("{\"m1-t1\":{\"Price\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Value\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Type\":\"t1\"},\"m2-t1\":{\"Price\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Value\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Type\":\"t1\"}}"),
 			},
 			want: func() cart.PaymentSplit {
 				result := cart.PaymentSplit{}
@@ -149,7 +149,7 @@ func TestPaymentSplit_UnmarshalJSON(t *testing.T) {
 		{
 			name: "unmarshall payment split empty method or type - error",
 			args: args{
-				data: []byte("{\"m1_t1\":{\"Price\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Value\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Type\":\"t1\"},\"m2___t1\":{\"Price\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Value\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Type\":\"t1\"}}"),
+				data: []byte("{\"m1?t1\":{\"Price\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Value\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Type\":\"t1\"},\"m2-t1\":{\"Price\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Value\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Type\":\"t1\"}}"),
 			},
 			want:    nil,
 			wantErr: true,


### PR DESCRIPTION
Currently the paymentsplit cannot be parsed to json as the key in the map is a complex object. I suggest to parse the information in this object to a string key to provide marshalling and unmarshalling behaviour.

In order to migitate overwrite of keys due to empty methods or chargetypes, I suggest to throw an error in case such a value is encountered.