### PR TITLE
cart: always reserve an order id if requested

### DIFF
--- a/cart/application/cartService.go
+++ b/cart/application/cartService.go
@@ -729,6 +729,7 @@ func (cs *CartService) DeleteCartInCache(ctx context.Context, session *web.Sessi
 
 // ReserveOrderIDAndSave reserves order id by using the PlaceOrder behaviour, sets and saves it on the cart.
 // Each call of this method reserves a new order ID, even if it is already set on the cart.
+// You may want to use this before proceeding with payment to ensure having a useful reference in the payment processing
 func (cs *CartService) ReserveOrderIDAndSave(ctx context.Context, session *web.Session) (*cartDomain.Cart, error) {
 	if cs.placeOrderService == nil {
 		return nil, errors.New("No placeOrderService registered")

--- a/cart/application/cartService.go
+++ b/cart/application/cartService.go
@@ -728,8 +728,7 @@ func (cs *CartService) DeleteCartInCache(ctx context.Context, session *web.Sessi
 }
 
 // ReserveOrderIDAndSave reserves order id by using the PlaceOrder behaviour, sets and saves it on the cart.
-// If the cart already holds a reserved order id no set/save is performed and the existing cart is returned.
-// You may want to use this before proceeding with payment to ensure having a useful reference in the payment processing
+// Each call of this method reserves a new order ID, even if it is already set on the cart.
 func (cs *CartService) ReserveOrderIDAndSave(ctx context.Context, session *web.Session) (*cartDomain.Cart, error) {
 	if cs.placeOrderService == nil {
 		return nil, errors.New("No placeOrderService registered")
@@ -737,11 +736,6 @@ func (cs *CartService) ReserveOrderIDAndSave(ctx context.Context, session *web.S
 	cart, behaviour, err := cs.cartReceiverService.GetCart(ctx, session)
 	if err != nil {
 		return nil, err
-	}
-
-	// the cart already has a reserved order id - no need to generate and update data
-	if cart.AdditionalData.ReservedOrderID != "" {
-		return cart, nil
 	}
 
 	reservedOrderID, err := cs.placeOrderService.ReserveOrderID(ctx, cart)


### PR DESCRIPTION
The CartService must always reserve a (new) orderID fetched from the PlaceOrderService if requested.

The reciever ReserveOrderIDAndSave must not check if an order ID is already set on the cart.