### PR TITLE
cart: Resctructure discounts

### DIFF
--- a/cart/domain/cart/delivery_test.go
+++ b/cart/domain/cart/delivery_test.go
@@ -41,9 +41,9 @@ func TestDeliveryInfo_TotalCalculations(t *testing.T) {
 	).SetQty(5).AddTaxInfo(
 		"gst", new(big.Float).SetInt64(7), nil,
 	).SetID("1")
-	itemf.AddDiscount(ItemDiscount{
-		Code:          "summercampaign",
-		Amount:        priceDomain.NewFromInt(-2500, 100, "$"),
+	itemf.AddDiscount(AppliedDiscount{
+		CampaignCode:  "summercampaign",
+		Applied:       priceDomain.NewFromInt(-2500, 100, "$"),
 		IsItemRelated: true,
 	})
 	item2, err := itemf.CalculatePricesAndTaxAmountsFromSinglePriceNet().Build()

--- a/cart/domain/cart/discount.go
+++ b/cart/domain/cart/discount.go
@@ -145,6 +145,7 @@ func (discounts AppliedDiscounts) ByCampaignCode(campaignCode string) AppliedDis
 		return discount.CampaignCode == campaignCode
 	}
 	return discounts.filter(f)
+
 }
 
 // ByType filter AppliedDiscounts based on type

--- a/cart/domain/cart/discount.go
+++ b/cart/domain/cart/discount.go
@@ -16,24 +16,27 @@ type (
 	// WithDiscount interface for a cart that is able to handle discounts
 	WithDiscount interface {
 		HasAppliedDiscounts() bool
-		AggregateDiscounts() []*AppliedDiscount
+		CollectDiscounts() []*AppliedDiscount
 	}
+
+	// ByCode implements sort.Interface for []AppliedDiscount based on code
+	ByCode []*AppliedDiscount
 )
 
-// AggregateDiscounts sums up discounts of cart based on its deliveries
+// CollectDiscounts sums up discounts of cart based on its deliveries
 // All discounts with the same type and title are aggregated and returned as one with a summed price
-func (c *Cart) AggregateDiscounts() []*AppliedDiscount {
+func (c *Cart) CollectDiscounts() []*AppliedDiscount {
 	return nil
 }
 
 // HasAppliedDiscounts check whether there are any discounts currently applied to the cart
 func (c *Cart) HasAppliedDiscounts() bool {
-	return len(c.AggregateDiscounts()) > 0
+	return len(c.CollectDiscounts()) > 0
 }
 
-// AggregateDiscounts sums up discounts of a delivery based on its single item discounts
+// CollectDiscounts sums up discounts of a delivery based on its single item discounts
 // All discounts with the same type and title are aggregated and returned as one with a summed price
-func (d *Delivery) AggregateDiscounts() []*AppliedDiscount {
+func (d *Delivery) CollectDiscounts() []*AppliedDiscount {
 	result := make([]*AppliedDiscount, 0)
 	// guard if no items in delivery, no need to iterate
 	if len(d.Cartitems) <= 0 {
@@ -44,40 +47,44 @@ func (d *Delivery) AggregateDiscounts() []*AppliedDiscount {
 
 // HasAppliedDiscounts check whether there are any discounts currently applied to the delivery
 func (d *Delivery) HasAppliedDiscounts() bool {
-	return len(d.AggregateDiscounts()) > 0
+	return len(d.CollectDiscounts()) > 0
 }
 
-// AggregateDiscounts parses discounts of a single item
+// CollectDiscounts parses discounts of a single item
 // All discounts with the same type and title are aggregated and returned as one with a summed price
-func (i *Item) AggregateDiscounts() []*AppliedDiscount {
-	result := make([]*AppliedDiscount, 0)
+func (i *Item) CollectDiscounts() []*AppliedDiscount {
 	// guard if no items in delivery, no need to iterate
 	if len(i.AppliedDiscounts) <= 0 {
-		return result
+		return make([]*AppliedDiscount, 0)
 	}
-	// aggregate discounts by type + title
-	collection := make(map[string]*AppliedDiscount)
-	for _, discount := range i.AppliedDiscounts {
-		key := discount.Type + discount.Title
-		if collected, ok := collection[key]; ok {
-			collected.Applied.Add(discount.Amount)
-			break
+	// parse item discounts to applied discounts
+	result := make([]*AppliedDiscount, len(i.AppliedDiscounts))
+	for index, val := range i.AppliedDiscounts {
+		result[index] = &AppliedDiscount{
+			Code:    val.Code,
+			Title:   val.Title,
+			Applied: val.Amount,
+			Type:    val.Type,
 		}
-		collection[key] = &AppliedDiscount{
-			Code:    discount.Code,
-			Title:   discount.Title,
-			Applied: discount.Amount,
-			Type:    discount.Type,
-		}
-	}
-	// restructure map to slice
-	for _, val := range collection {
-		result = append(result, val)
 	}
 	return result
 }
 
 // HasAppliedDiscounts check whether there are any discounts currently applied to the cart
 func (i *Item) HasAppliedDiscounts() bool {
-	return len(i.AggregateDiscounts()) > 0
+	return len(i.CollectDiscounts()) > 0
+}
+
+// implementations for sort interface
+
+func (a ByCode) Len() int {
+	return len(a)
+}
+
+func (a ByCode) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+func (a ByCode) Less(i, j int) bool {
+	return a[i].Code < a[j].Code
 }

--- a/cart/domain/cart/discount.go
+++ b/cart/domain/cart/discount.go
@@ -7,12 +7,12 @@ import (
 type (
 	// AppliedDiscount value object - generic reference for a discount
 	AppliedDiscount struct {
-		CampaignCode  string       // unique code of the underlying campaign e.g. "summersale-2018"
-		CouponCode    string       // unique code of discount e.g. from input field
+		CampaignCode  string       // unique code of the underlying campaign or rule e.g. "summer-campaign-2018"
+		CouponCode    string       // code of discount e.g. provided by user "summer2018"
 		Label         string       // readable name of discount "Super Summer Sale 2018"
 		Applied       domain.Price // how much of the discount has been subtracted from cart price, IMPORTANT: always negative
 		Type          string       // to distinguish between discounts
-		IsItemRelated bool         // flag indicating if the discount is applied due to item
+		IsItemRelated bool         // flag indicating if the discount is applied due to item in cart
 	}
 
 	// WithDiscount interface for a cart that is able to handle discounts

--- a/cart/domain/cart/discount.go
+++ b/cart/domain/cart/discount.go
@@ -1,0 +1,83 @@
+package cart
+
+import (
+	"flamingo.me/flamingo-commerce/v3/price/domain"
+)
+
+type (
+	// AppliedDiscount value object - generic reference for a discount
+	AppliedDiscount struct {
+		Code    string       // unique code of discount
+		Title   string       // readable name of discount
+		Applied domain.Price // how much of the discount has been subtracted from cart price
+		Type    string       // to distinguish between discounts
+	}
+
+	// WithDiscount interface for a cart that is able to handle discounts
+	WithDiscount interface {
+		HasAppliedDiscounts() bool
+		AggregateDiscounts() []*AppliedDiscount
+	}
+)
+
+// AggregateDiscounts sums up discounts of cart based on its deliveries
+// All discounts with the same type and title are aggregated and returned as one with a summed price
+func (c *Cart) AggregateDiscounts() []*AppliedDiscount {
+	return nil
+}
+
+// HasAppliedDiscounts check whether there are any discounts currently applied to the cart
+func (c *Cart) HasAppliedDiscounts() bool {
+	return len(c.AggregateDiscounts()) > 0
+}
+
+// AggregateDiscounts sums up discounts of a delivery based on its single item discounts
+// All discounts with the same type and title are aggregated and returned as one with a summed price
+func (d *Delivery) AggregateDiscounts() []*AppliedDiscount {
+	result := make([]*AppliedDiscount, 0)
+	// guard if no items in delivery, no need to iterate
+	if len(d.Cartitems) <= 0 {
+		return result
+	}
+	return result
+}
+
+// HasAppliedDiscounts check whether there are any discounts currently applied to the delivery
+func (d *Delivery) HasAppliedDiscounts() bool {
+	return len(d.AggregateDiscounts()) > 0
+}
+
+// AggregateDiscounts parses discounts of a single item
+// All discounts with the same type and title are aggregated and returned as one with a summed price
+func (i *Item) AggregateDiscounts() []*AppliedDiscount {
+	result := make([]*AppliedDiscount, 0)
+	// guard if no items in delivery, no need to iterate
+	if len(i.AppliedDiscounts) <= 0 {
+		return result
+	}
+	// aggregate discounts by type + title
+	collection := make(map[string]*AppliedDiscount)
+	for _, discount := range i.AppliedDiscounts {
+		key := discount.Type + discount.Title
+		if collected, ok := collection[key]; ok {
+			collected.Applied.Add(discount.Amount)
+			break
+		}
+		collection[key] = &AppliedDiscount{
+			Code:    discount.Code,
+			Title:   discount.Title,
+			Applied: discount.Amount,
+			Type:    discount.Type,
+		}
+	}
+	// restructure map to slice
+	for _, val := range collection {
+		result = append(result, val)
+	}
+	return result
+}
+
+// HasAppliedDiscounts check whether there are any discounts currently applied to the cart
+func (i *Item) HasAppliedDiscounts() bool {
+	return len(i.AggregateDiscounts()) > 0
+}

--- a/cart/domain/cart/discount.go
+++ b/cart/domain/cart/discount.go
@@ -15,8 +15,8 @@ type (
 
 	// WithDiscount interface for a cart that is able to handle discounts
 	WithDiscount interface {
-		HasAppliedDiscounts() bool
-		CollectDiscounts() []*AppliedDiscount
+		HasAppliedDiscounts() (bool, error)
+		CollectDiscounts() ([]*AppliedDiscount, error)
 	}
 
 	// ByCode implements sort.Interface for []AppliedDiscount based on code
@@ -25,37 +25,68 @@ type (
 
 // CollectDiscounts sums up discounts of cart based on its deliveries
 // All discounts with the same type and title are aggregated and returned as one with a summed price
-func (c *Cart) CollectDiscounts() []*AppliedDiscount {
-	return nil
+func (c *Cart) CollectDiscounts() ([]*AppliedDiscount, error) {
+	// guard if no items in delivery, no need to iterate
+	if len(c.Deliveries) <= 0 {
+		return make([]*AppliedDiscount, 0), nil
+	}
+	// collect different discounts on item level
+	var err error
+	collection := make(map[string]*AppliedDiscount)
+	for _, delivery := range c.Deliveries {
+		collection, err = mapDiscounts(collection, &delivery)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// transform map to flat slice
+	return mapToSlice(collection), nil
 }
 
 // HasAppliedDiscounts check whether there are any discounts currently applied to the cart
-func (c *Cart) HasAppliedDiscounts() bool {
-	return len(c.CollectDiscounts()) > 0
+func (c *Cart) HasAppliedDiscounts() (bool, error) {
+	discounts, err := c.CollectDiscounts()
+	if err != nil {
+		return false, err
+	}
+	return len(discounts) > 0, nil
 }
 
 // CollectDiscounts sums up discounts of a delivery based on its single item discounts
 // All discounts with the same type and title are aggregated and returned as one with a summed price
-func (d *Delivery) CollectDiscounts() []*AppliedDiscount {
-	result := make([]*AppliedDiscount, 0)
+func (d *Delivery) CollectDiscounts() ([]*AppliedDiscount, error) {
 	// guard if no items in delivery, no need to iterate
 	if len(d.Cartitems) <= 0 {
-		return result
+		return make([]*AppliedDiscount, 0), nil
 	}
-	return result
+	// collect different discounts on item level
+	var err error
+	collection := make(map[string]*AppliedDiscount)
+	for _, item := range d.Cartitems {
+		collection, err = mapDiscounts(collection, &item)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// transform map to flat slice
+	return mapToSlice(collection), nil
 }
 
 // HasAppliedDiscounts check whether there are any discounts currently applied to the delivery
-func (d *Delivery) HasAppliedDiscounts() bool {
-	return len(d.CollectDiscounts()) > 0
+func (d *Delivery) HasAppliedDiscounts() (bool, error) {
+	discounts, err := d.CollectDiscounts()
+	if err != nil {
+		return false, err
+	}
+	return len(discounts) > 0, nil
 }
 
 // CollectDiscounts parses discounts of a single item
 // All discounts with the same type and title are aggregated and returned as one with a summed price
-func (i *Item) CollectDiscounts() []*AppliedDiscount {
+func (i *Item) CollectDiscounts() ([]*AppliedDiscount, error) {
 	// guard if no items in delivery, no need to iterate
 	if len(i.AppliedDiscounts) <= 0 {
-		return make([]*AppliedDiscount, 0)
+		return make([]*AppliedDiscount, 0), nil
 	}
 	// parse item discounts to applied discounts
 	result := make([]*AppliedDiscount, len(i.AppliedDiscounts))
@@ -67,12 +98,56 @@ func (i *Item) CollectDiscounts() []*AppliedDiscount {
 			Type:    val.Type,
 		}
 	}
-	return result
+	return result, nil
 }
 
 // HasAppliedDiscounts check whether there are any discounts currently applied to the cart
-func (i *Item) HasAppliedDiscounts() bool {
-	return len(i.CollectDiscounts()) > 0
+func (i *Item) HasAppliedDiscounts() (bool, error) {
+	discounts, err := i.CollectDiscounts()
+	if err != nil {
+		return false, err
+	}
+	return len(discounts) > 0, nil
+}
+
+// private helper functions
+
+// mapToSlice transform map of discounts to flat slice
+func mapToSlice(collection map[string]*AppliedDiscount) []*AppliedDiscount {
+	result := make([]*AppliedDiscount, 0, len(collection))
+	for _, val := range collection {
+		result = append(result, val)
+	}
+	return result
+}
+
+// mapDiscounts map type + title of discount to corresponding discount
+func mapDiscounts(result map[string]*AppliedDiscount, discountable WithDiscount) (map[string]*AppliedDiscount, error) {
+	discounts, err := discountable.CollectDiscounts()
+	// in case discounts cannot be collected, stop execution
+	if err != nil {
+		return nil, err
+	}
+	for _, discount := range discounts {
+		key := discount.Type + discount.Title
+		// discount has been collected before, increase amount
+		if collected, ok := result[key]; ok {
+			update, err := collected.Applied.Add(discount.Applied)
+			if err != nil {
+				return nil, err
+			}
+			collected.Applied = update
+			continue
+		}
+		// discount is new, add to collection
+		result[key] = &AppliedDiscount{
+			Code:    discount.Code,
+			Title:   discount.Title,
+			Applied: discount.Applied,
+			Type:    discount.Type,
+		}
+	}
+	return result, nil
 }
 
 // implementations for sort interface

--- a/cart/domain/cart/discount.go
+++ b/cart/domain/cart/discount.go
@@ -18,7 +18,7 @@ type (
 	// WithDiscount interface for a cart that is able to handle discounts
 	WithDiscount interface {
 		HasAppliedDiscounts() (bool, error)
-		CollectDiscounts() (AppliedDiscounts, error)
+		MergeDiscounts() (AppliedDiscounts, error)
 	}
 
 	// AppliedDiscounts represents multiple discounts that are subtracted from total price of cart
@@ -32,9 +32,9 @@ var (
 	_ WithDiscount = new(Cart)
 )
 
-// CollectDiscounts sums up discounts of cart based on its deliveries
+// MergeDiscounts sums up discounts of cart based on its deliveries
 // All discounts with the same type and title are aggregated and returned as one with a summed price
-func (c *Cart) CollectDiscounts() (AppliedDiscounts, error) {
+func (c *Cart) MergeDiscounts() (AppliedDiscounts, error) {
 	// guard if no items in delivery, no need to iterate
 	if len(c.Deliveries) <= 0 {
 		return make([]AppliedDiscount, 0), nil
@@ -54,16 +54,16 @@ func (c *Cart) CollectDiscounts() (AppliedDiscounts, error) {
 
 // HasAppliedDiscounts check whether there are any discounts currently applied to the cart
 func (c *Cart) HasAppliedDiscounts() (bool, error) {
-	discounts, err := c.CollectDiscounts()
+	discounts, err := c.MergeDiscounts()
 	if err != nil {
 		return false, err
 	}
 	return len(discounts) > 0, nil
 }
 
-// CollectDiscounts sums up discounts of a delivery based on its single item discounts
+// MergeDiscounts sums up discounts of a delivery based on its single item discounts
 // All discounts with the same type and title are aggregated and returned as one with a summed price
-func (d *Delivery) CollectDiscounts() (AppliedDiscounts, error) {
+func (d *Delivery) MergeDiscounts() (AppliedDiscounts, error) {
 	// guard if no items in delivery, no need to iterate
 	if len(d.Cartitems) <= 0 {
 		return make([]AppliedDiscount, 0), nil
@@ -83,22 +83,22 @@ func (d *Delivery) CollectDiscounts() (AppliedDiscounts, error) {
 
 // HasAppliedDiscounts check whether there are any discounts currently applied to the delivery
 func (d *Delivery) HasAppliedDiscounts() (bool, error) {
-	discounts, err := d.CollectDiscounts()
+	discounts, err := d.MergeDiscounts()
 	if err != nil {
 		return false, err
 	}
 	return len(discounts) > 0, nil
 }
 
-// CollectDiscounts parses discounts of a single item
+// MergeDiscounts parses discounts of a single item
 // All discounts with the same type and title are aggregated and returned as one with a summed price
-func (i *Item) CollectDiscounts() (AppliedDiscounts, error) {
+func (i *Item) MergeDiscounts() (AppliedDiscounts, error) {
 	return i.AppliedDiscounts, nil
 }
 
 // HasAppliedDiscounts check whether there are any discounts currently applied to the cart
 func (i *Item) HasAppliedDiscounts() (bool, error) {
-	discounts, err := i.CollectDiscounts()
+	discounts, err := i.MergeDiscounts()
 	if err != nil {
 		return false, err
 	}
@@ -118,7 +118,7 @@ func mapToSlice(collection map[string]*AppliedDiscount) []AppliedDiscount {
 
 // mapDiscounts map type + title of discount to corresponding discount
 func mapDiscounts(result map[string]*AppliedDiscount, discountable WithDiscount) (map[string]*AppliedDiscount, error) {
-	discounts, err := discountable.CollectDiscounts()
+	discounts, err := discountable.MergeDiscounts()
 	// in case discounts cannot be collected, stop execution
 	if err != nil {
 		return nil, err

--- a/cart/domain/cart/discount.go
+++ b/cart/domain/cart/discount.go
@@ -25,6 +25,13 @@ type (
 	AppliedDiscounts []AppliedDiscount
 )
 
+var (
+	// interface assertions
+	_ WithDiscount = new(Item)
+	_ WithDiscount = new(Delivery)
+	_ WithDiscount = new(Cart)
+)
+
 // CollectDiscounts sums up discounts of cart based on its deliveries
 // All discounts with the same type and title are aggregated and returned as one with a summed price
 func (c *Cart) CollectDiscounts() (AppliedDiscounts, error) {

--- a/cart/domain/cart/discount.go
+++ b/cart/domain/cart/discount.go
@@ -124,8 +124,6 @@ func mapDiscounts(result map[string]*AppliedDiscount, discountable WithDiscount)
 				return nil, err
 			}
 			collected.Applied = update
-			floaty := collected.Applied.FloatAmount()
-			floaty *= 1
 			continue
 		}
 		// discount is new, add to collection

--- a/cart/domain/cart/discount_test.go
+++ b/cart/domain/cart/discount_test.go
@@ -10,7 +10,7 @@ import (
 	"flamingo.me/flamingo-commerce/v3/price/domain"
 )
 
-func TestCart_CollectDiscounts(t *testing.T) {
+func TestCart_MergeDiscounts(t *testing.T) {
 	tests := []struct {
 		name string
 		cart *cart.Cart
@@ -93,12 +93,12 @@ func TestCart_CollectDiscounts(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _ := tt.cart.CollectDiscounts()
+			got, _ := tt.cart.MergeDiscounts()
 			// we need to sort result to circumvent implementation changes in order
 			sort.Sort(testutils.ByCode(got))
 			sort.Sort(testutils.ByCode(tt.want))
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Cart.CollectDiscounts() = %v, want %v", got, tt.want)
+				t.Errorf("Cart.MergeDiscounts() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -175,7 +175,7 @@ func TestCart_HasDiscounts(t *testing.T) {
 	}
 }
 
-func TestDelivery_CollectDiscounts(t *testing.T) {
+func TestDelivery_MergeDiscounts(t *testing.T) {
 	tests := []struct {
 		name     string
 		delivery *cart.Delivery
@@ -218,12 +218,12 @@ func TestDelivery_CollectDiscounts(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _ := tt.delivery.CollectDiscounts()
+			got, _ := tt.delivery.MergeDiscounts()
 			// we need to sort result to circumvent implementation changes in order
 			sort.Sort(testutils.ByCode(got))
 			sort.Sort(testutils.ByCode(tt.want))
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Delivery.CollectDiscounts() = %v, want %v", got, tt.want)
+				t.Errorf("Delivery.MergeDiscounts() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -260,7 +260,7 @@ func TestDelivery_HasDiscounts(t *testing.T) {
 	}
 }
 
-func TestItem_CollectDiscounts(t *testing.T) {
+func TestItem_MergeDiscounts(t *testing.T) {
 	tests := []struct {
 		name string
 		item *cart.Item
@@ -300,12 +300,12 @@ func TestItem_CollectDiscounts(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _ := tt.item.CollectDiscounts()
+			got, _ := tt.item.MergeDiscounts()
 			// we need to sort result to circumvent implementation changes in order
 			sort.Sort(testutils.ByCode(got))
 			sort.Sort(testutils.ByCode(tt.want))
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Item.CollectDiscounts() = %v, want %v", got, tt.want)
+				t.Errorf("Item.MergeDiscounts() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/cart/domain/cart/discount_test.go
+++ b/cart/domain/cart/discount_test.go
@@ -67,7 +67,42 @@ func TestItem_CollectDiscounts(t *testing.T) {
 			sort.Sort(cart.ByCode(got))
 			sort.Sort(cart.ByCode(tt.want))
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Cart.CollectDiscounts() = %v, want %v", got, tt.want)
+				t.Errorf("Item.CollectDiscounts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestItem_HasDiscounts(t *testing.T) {
+	tests := []struct {
+		name string
+		item *cart.Item
+		want bool
+	}{
+		{
+			name: "no discounts on item",
+			item: &cart.Item{},
+			want: false,
+		},
+		{
+			name: "multiple discounts on item",
+			item: func() *cart.Item {
+				builder := cart.ItemBuilder{}
+				builder.AddDiscount(cart.ItemDiscount{
+					Code:  "code-1",
+					Title: "title-1",
+					Type:  "type-1",
+				})
+				item, _ := builder.Build()
+				return item
+			}(),
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.item.HasAppliedDiscounts(); got != tt.want {
+				t.Errorf("Item.HasDiscounts() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/cart/domain/cart/discount_test.go
+++ b/cart/domain/cart/discount_test.go
@@ -416,3 +416,129 @@ func TestItem_HasDiscounts(t *testing.T) {
 		})
 	}
 }
+
+func TestAppliedDiscounts_ByCampaignCode(t *testing.T) {
+	type args struct {
+		campaignCode string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		discounts cart.AppliedDiscounts
+		want      cart.AppliedDiscounts
+	}{
+		{
+			name: "no match for filter",
+			args: args{
+				campaignCode: "code-3",
+			},
+			discounts: cart.AppliedDiscounts{
+				{
+					CampaignCode: "code-1",
+				},
+				{
+					CampaignCode: "code-1",
+				},
+				{
+					CampaignCode: "code-2",
+				},
+			},
+			want: cart.AppliedDiscounts{},
+		},
+		{
+			name: "match for filter",
+			args: args{
+				campaignCode: "code-1",
+			},
+			discounts: cart.AppliedDiscounts{
+				{
+					CampaignCode: "code-1",
+				},
+				{
+					CampaignCode: "code-1",
+				},
+				{
+					CampaignCode: "code-2",
+				},
+			},
+			want: cart.AppliedDiscounts{
+				{
+					CampaignCode: "code-1",
+				},
+				{
+					CampaignCode: "code-1",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.discounts.ByCampaignCode(tt.args.campaignCode); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AppliedDiscounts.ByCampaignCode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAppliedDiscounts_ByType(t *testing.T) {
+	type args struct {
+		filterType string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		discounts cart.AppliedDiscounts
+		want      cart.AppliedDiscounts
+	}{
+		{
+			name: "no match for filter",
+			args: args{
+				filterType: "type-3",
+			},
+			discounts: cart.AppliedDiscounts{
+				{
+					Type: "type-1",
+				},
+				{
+					Type: "type-2",
+				},
+				{
+					Type: "type-1",
+				},
+			},
+			want: cart.AppliedDiscounts{},
+		},
+		{
+			name: "match for filter",
+			args: args{
+				filterType: "type-1",
+			},
+			discounts: cart.AppliedDiscounts{
+				{
+					Type: "type-1",
+				},
+				{
+					Type: "type-2",
+				},
+				{
+					Type: "type-1",
+				},
+			},
+			want: cart.AppliedDiscounts{
+				{
+					Type: "type-1",
+				},
+				{
+					Type: "type-1",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.discounts.ByType(tt.args.filterType); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AppliedDiscounts.ByType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cart/domain/cart/discount_test.go
+++ b/cart/domain/cart/discount_test.go
@@ -287,10 +287,6 @@ func TestDelivery_CollectDiscounts(t *testing.T) {
 			sort.Sort(ByCode(got))
 			sort.Sort(ByCode(tt.want))
 			if !reflect.DeepEqual(got, tt.want) {
-				for _, val := range got {
-					floaty := val.Applied.FloatAmount()
-					floaty = floaty * 1
-				}
 				t.Errorf("Delivery.CollectDiscounts() = %v, want %v", got, tt.want)
 			}
 		})

--- a/cart/domain/cart/discount_test.go
+++ b/cart/domain/cart/discount_test.go
@@ -1,0 +1,74 @@
+package cart_test
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"flamingo.me/flamingo-commerce/v3/cart/domain/cart"
+)
+
+func TestItem_CollectDiscounts(t *testing.T) {
+	tests := []struct {
+		name string
+		item *cart.Item
+		want []*cart.AppliedDiscount
+	}{
+		{
+			name: "no discounts on item",
+			item: &cart.Item{},
+			want: []*cart.AppliedDiscount{},
+		},
+		{
+			name: "multiple different discounts on item",
+			item: func() *cart.Item {
+				builder := cart.ItemBuilder{}
+				builder.AddDiscount(cart.ItemDiscount{
+					Code:  "code-1",
+					Title: "title-1",
+					Type:  "type-1",
+				})
+				builder.AddDiscount(cart.ItemDiscount{
+					Code:  "code-1",
+					Title: "title-2",
+					Type:  "type-1",
+				})
+				builder.AddDiscount(cart.ItemDiscount{
+					Code:  "code-1",
+					Title: "title-1",
+					Type:  "type-2",
+				})
+				item, _ := builder.Build()
+				return item
+			}(),
+			want: []*cart.AppliedDiscount{
+				{
+					Code:  "code-1",
+					Title: "title-1",
+					Type:  "type-1",
+				},
+				{
+					Code:  "code-1",
+					Title: "title-2",
+					Type:  "type-1",
+				},
+				{
+					Code:  "code-1",
+					Title: "title-1",
+					Type:  "type-2",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.item.CollectDiscounts()
+			// we need to sort result to circumvent implementation changes in order
+			sort.Sort(cart.ByCode(got))
+			sort.Sort(cart.ByCode(tt.want))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Cart.CollectDiscounts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cart/domain/cart/discount_test.go
+++ b/cart/domain/cart/discount_test.go
@@ -6,7 +6,311 @@ import (
 	"testing"
 
 	"flamingo.me/flamingo-commerce/v3/cart/domain/cart"
+	"flamingo.me/flamingo-commerce/v3/price/domain"
 )
+
+// buildItemWithDiscounts helper for item building
+func buildItemWithDiscounts() *cart.Item {
+	builder := cart.ItemBuilder{}
+	builder.AddDiscount(cart.ItemDiscount{
+		Code:   "code-1",
+		Title:  "title-1",
+		Type:   "type-1",
+		Amount: domain.NewFromFloat(10.0, "$"),
+	})
+	builder.AddDiscount(cart.ItemDiscount{
+		Code:   "code-2",
+		Title:  "title-2",
+		Type:   "type-1",
+		Amount: domain.NewFromFloat(15.0, "$"),
+	})
+	builder.AddDiscount(cart.ItemDiscount{
+		Code:   "code-3",
+		Title:  "title-1",
+		Type:   "type-2",
+		Amount: domain.NewFromFloat(5.0, "$"),
+	})
+	item, _ := builder.Build()
+	return item
+}
+
+// buildDeliverxWithDiscounts helper for delivery building
+// Adds an item with discount twice
+// This means when discounts are summed up (based on type + delivery)
+// The amount should be added to the previous discount
+func buildDeliveryWithDiscounts() *cart.Delivery {
+	builder := cart.DeliveryBuilder{}
+	builder.SetDeliveryCode("code")
+	builder.AddItem(*buildItemWithDiscounts())
+	builder.AddItem(*buildItemWithDiscounts())
+	// add items with discounts
+	delivery, _ := builder.Build()
+	return delivery
+}
+
+func TestCart_CollectDiscounts(t *testing.T) {
+	tests := []struct {
+		name string
+		cart *cart.Cart
+		want []*cart.AppliedDiscount
+	}{
+		{
+			name: "empty cart",
+			cart: &cart.Cart{},
+			want: []*cart.AppliedDiscount{},
+		},
+		{
+			name: "cart with deliveries but without items",
+			cart: &cart.Cart{
+				Deliveries: func() []cart.Delivery {
+					result := make([]cart.Delivery, 0)
+					builder := cart.DeliveryBuilder{}
+					builder.SetDeliveryCode("code-1")
+					delivery, _ := builder.Build()
+					result = append(result, *delivery)
+					builder = cart.DeliveryBuilder{}
+					builder.SetDeliveryCode("code-2")
+					result = append(result, *delivery)
+					return result
+				}(),
+			},
+			want: []*cart.AppliedDiscount{},
+		},
+		{
+			name: "cart with deliveries with items but without discounts",
+			cart: &cart.Cart{
+				Deliveries: func() []cart.Delivery {
+					result := make([]cart.Delivery, 0)
+					builder := cart.DeliveryBuilder{}
+					builder.SetDeliveryCode("code-1")
+					builder.AddItem(cart.Item{})
+					builder.AddItem(cart.Item{})
+					delivery, _ := builder.Build()
+					result = append(result, *delivery)
+					builder = cart.DeliveryBuilder{}
+					builder.SetDeliveryCode("code-2")
+					result = append(result, *delivery)
+					return result
+				}(),
+			},
+			want: []*cart.AppliedDiscount{},
+		},
+		{
+			name: "cart with deliveries with items with discounts",
+			cart: &cart.Cart{
+				Deliveries: func() []cart.Delivery {
+					result := make([]cart.Delivery, 0)
+					delivery := buildDeliveryWithDiscounts()
+					result = append(result, *delivery)
+					delivery = buildDeliveryWithDiscounts()
+					result = append(result, *delivery)
+					return result
+				}(),
+			},
+			want: []*cart.AppliedDiscount{
+				{
+					Code:    "code-1",
+					Title:   "title-1",
+					Type:    "type-1",
+					Applied: domain.NewFromFloat(40.0, "$"),
+				},
+				{
+					Code:    "code-2",
+					Title:   "title-2",
+					Type:    "type-1",
+					Applied: domain.NewFromFloat(60.0, "$"),
+				},
+				{
+					Code:    "code-3",
+					Title:   "title-1",
+					Type:    "type-2",
+					Applied: domain.NewFromFloat(20.0, "$"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := tt.cart.CollectDiscounts()
+			// we need to sort result to circumvent implementation changes in order
+			sort.Sort(cart.ByCode(got))
+			sort.Sort(cart.ByCode(tt.want))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Cart.CollectDiscounts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCart_HasDiscounts(t *testing.T) {
+	tests := []struct {
+		name string
+		cart *cart.Cart
+		want bool
+	}{
+		{
+			name: "empty cart",
+			cart: &cart.Cart{},
+			want: false,
+		},
+		{
+			name: "cart with deliveries but without items",
+			cart: &cart.Cart{
+				Deliveries: func() []cart.Delivery {
+					result := make([]cart.Delivery, 0)
+					builder := cart.DeliveryBuilder{}
+					builder.SetDeliveryCode("code-1")
+					delivery, _ := builder.Build()
+					result = append(result, *delivery)
+					builder = cart.DeliveryBuilder{}
+					builder.SetDeliveryCode("code-2")
+					result = append(result, *delivery)
+					return result
+				}(),
+			},
+			want: false,
+		},
+		{
+			name: "cart with deliveries with items but without discounts",
+			cart: &cart.Cart{
+				Deliveries: func() []cart.Delivery {
+					result := make([]cart.Delivery, 0)
+					builder := cart.DeliveryBuilder{}
+					builder.SetDeliveryCode("code-1")
+					builder.AddItem(cart.Item{})
+					builder.AddItem(cart.Item{})
+					delivery, _ := builder.Build()
+					result = append(result, *delivery)
+					builder = cart.DeliveryBuilder{}
+					builder.SetDeliveryCode("code-2")
+					result = append(result, *delivery)
+					return result
+				}(),
+			},
+			want: false,
+		},
+		{
+			name: "cart with deliveries with items with discounts",
+			cart: &cart.Cart{
+				Deliveries: func() []cart.Delivery {
+					result := make([]cart.Delivery, 0)
+					delivery := buildDeliveryWithDiscounts()
+					result = append(result, *delivery)
+					delivery = buildDeliveryWithDiscounts()
+					result = append(result, *delivery)
+					return result
+				}(),
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, _ := tt.cart.HasAppliedDiscounts(); got != tt.want {
+				t.Errorf("Cart.HasDiscounts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDelivery_CollectDiscounts(t *testing.T) {
+	tests := []struct {
+		name     string
+		delivery *cart.Delivery
+		want     []*cart.AppliedDiscount
+	}{
+		{
+			name:     "empty delivery",
+			delivery: &cart.Delivery{},
+			want:     []*cart.AppliedDiscount{},
+		},
+		{
+			name: "delivery with items but without discounts",
+			delivery: func() *cart.Delivery {
+				builder := cart.DeliveryBuilder{}
+				builder.AddItem(cart.Item{})
+				builder.AddItem(cart.Item{})
+				builder.SetDeliveryCode("code")
+				delivery, _ := builder.Build()
+				return delivery
+			}(),
+			want: []*cart.AppliedDiscount{},
+		},
+		{
+			name:     "delivery with items with discounts",
+			delivery: buildDeliveryWithDiscounts(),
+			want: []*cart.AppliedDiscount{
+				{
+					Code:    "code-1",
+					Title:   "title-1",
+					Type:    "type-1",
+					Applied: domain.NewFromFloat(20.0, "$"),
+				},
+				{
+					Code:    "code-2",
+					Title:   "title-2",
+					Type:    "type-1",
+					Applied: domain.NewFromFloat(30.0, "$"),
+				},
+				{
+					Code:    "code-3",
+					Title:   "title-1",
+					Type:    "type-2",
+					Applied: domain.NewFromFloat(10.0, "$"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := tt.delivery.CollectDiscounts()
+			// we need to sort result to circumvent implementation changes in order
+			sort.Sort(cart.ByCode(got))
+			sort.Sort(cart.ByCode(tt.want))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Delivery.CollectDiscounts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDelivery_HasDiscounts(t *testing.T) {
+	tests := []struct {
+		name     string
+		delivery *cart.Delivery
+		want     bool
+	}{
+		{
+			name:     "empty delivery",
+			delivery: &cart.Delivery{},
+			want:     false,
+		},
+		{
+			name: "delivery with items but without discounts",
+			delivery: func() *cart.Delivery {
+				builder := cart.DeliveryBuilder{}
+				builder.AddItem(cart.Item{})
+				builder.AddItem(cart.Item{})
+				builder.SetDeliveryCode("code")
+				delivery, _ := builder.Build()
+				return delivery
+			}(),
+			want: false,
+		},
+		{
+			name:     "delivery with items with discounts",
+			delivery: buildDeliveryWithDiscounts(),
+			want:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, _ := tt.delivery.HasAppliedDiscounts(); got != tt.want {
+				t.Errorf("Delivery.HasDiscounts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestItem_CollectDiscounts(t *testing.T) {
 	tests := []struct {
@@ -21,48 +325,32 @@ func TestItem_CollectDiscounts(t *testing.T) {
 		},
 		{
 			name: "multiple different discounts on item",
-			item: func() *cart.Item {
-				builder := cart.ItemBuilder{}
-				builder.AddDiscount(cart.ItemDiscount{
-					Code:  "code-1",
-					Title: "title-1",
-					Type:  "type-1",
-				})
-				builder.AddDiscount(cart.ItemDiscount{
-					Code:  "code-1",
-					Title: "title-2",
-					Type:  "type-1",
-				})
-				builder.AddDiscount(cart.ItemDiscount{
-					Code:  "code-1",
-					Title: "title-1",
-					Type:  "type-2",
-				})
-				item, _ := builder.Build()
-				return item
-			}(),
+			item: buildItemWithDiscounts(),
 			want: []*cart.AppliedDiscount{
 				{
-					Code:  "code-1",
-					Title: "title-1",
-					Type:  "type-1",
+					Code:    "code-1",
+					Title:   "title-1",
+					Type:    "type-1",
+					Applied: domain.NewFromFloat(10.0, "$"),
 				},
 				{
-					Code:  "code-1",
-					Title: "title-2",
-					Type:  "type-1",
+					Code:    "code-2",
+					Title:   "title-2",
+					Type:    "type-1",
+					Applied: domain.NewFromFloat(15.0, "$"),
 				},
 				{
-					Code:  "code-1",
-					Title: "title-1",
-					Type:  "type-2",
+					Code:    "code-3",
+					Title:   "title-1",
+					Type:    "type-2",
+					Applied: domain.NewFromFloat(5.0, "$"),
 				},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.item.CollectDiscounts()
+			got, _ := tt.item.CollectDiscounts()
 			// we need to sort result to circumvent implementation changes in order
 			sort.Sort(cart.ByCode(got))
 			sort.Sort(cart.ByCode(tt.want))
@@ -101,7 +389,7 @@ func TestItem_HasDiscounts(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.item.HasAppliedDiscounts(); got != tt.want {
+			if got, _ := tt.item.HasAppliedDiscounts(); got != tt.want {
 				t.Errorf("Item.HasDiscounts() = %v, want %v", got, tt.want)
 			}
 		})

--- a/cart/domain/cart/item.go
+++ b/cart/domain/cart/item.go
@@ -45,17 +45,7 @@ type (
 		RowTaxes Taxes
 
 		// AppliedDiscounts contains the details about the discounts applied to this item - they can be "itemrelated" or not
-		AppliedDiscounts []ItemDiscount
-	}
-
-	// ItemDiscount value object
-	ItemDiscount struct {
-		Code   string
-		Title  string
-		Amount priceDomain.Price
-		// IsItemRelated is a flag indicating if the discount should be displayed in the item or if it the result of a cart discount
-		IsItemRelated bool
-		Type          string
+		AppliedDiscounts AppliedDiscounts
 	}
 
 	// ItemBuilder can be used to construct an item with a fluent interface
@@ -90,7 +80,7 @@ func (i Item) ItemRelatedDiscountAmount() priceDomain.Price {
 		if !discount.IsItemRelated {
 			continue
 		}
-		prices = append(prices, discount.Amount)
+		prices = append(prices, discount.Applied)
 	}
 
 	result, _ := priceDomain.SumAll(prices...)
@@ -106,7 +96,7 @@ func (i Item) NonItemRelatedDiscountAmount() priceDomain.Price {
 		if discount.IsItemRelated {
 			continue
 		}
-		prices = append(prices, discount.Amount)
+		prices = append(prices, discount.Applied)
 	}
 
 	result, _ := priceDomain.SumAll(prices...)
@@ -251,21 +241,21 @@ func (f *ItemBuilder) AddTaxInfo(taxType string, taxRate *big.Float, taxAmount *
 }
 
 // AddDiscount - adds a discount
-func (f *ItemBuilder) AddDiscount(discount ItemDiscount) *ItemBuilder {
+func (f *ItemBuilder) AddDiscount(discount AppliedDiscount) *ItemBuilder {
 	f.init()
-	if !discount.Amount.IsPayable() {
+	if !discount.Applied.IsPayable() {
 		f.invariantError = errors.New("AddDiscount need to have payable price")
 	}
-	if !discount.Amount.IsNegative() {
-		f.invariantError = fmt.Errorf("AddDiscount need to have negative price - given %f", discount.Amount.FloatAmount())
+	if !discount.Applied.IsNegative() {
+		f.invariantError = fmt.Errorf("AddDiscount need to have negative price - given %f", discount.Applied.FloatAmount())
 	}
-	f.checkCurrency(&discount.Amount)
+	f.checkCurrency(&discount.Applied)
 	f.itemInBuilding.AppliedDiscounts = append(f.itemInBuilding.AppliedDiscounts, discount)
 	return f
 }
 
 // AddDiscounts - adds a discount
-func (f *ItemBuilder) AddDiscounts(discounts ...ItemDiscount) *ItemBuilder {
+func (f *ItemBuilder) AddDiscounts(discounts ...AppliedDiscount) *ItemBuilder {
 	for _, discount := range discounts {
 		f.AddDiscount(discount)
 	}

--- a/cart/domain/cart/item.go
+++ b/cart/domain/cart/item.go
@@ -55,6 +55,7 @@ type (
 		Amount priceDomain.Price
 		// IsItemRelated is a flag indicating if the discount should be displayed in the item or if it the result of a cart discount
 		IsItemRelated bool
+		Type          string
 	}
 
 	// ItemBuilder can be used to construct an item with a fluent interface

--- a/cart/domain/cart/item_test.go
+++ b/cart/domain/cart/item_test.go
@@ -16,13 +16,13 @@ func TestItem_PriceCalculation(t *testing.T) {
 	item := cartDomain.Item{
 		SinglePriceNet:   priceDomain.NewFromInt(1234, 100, "EUR"),
 		SinglePriceGross: priceDomain.NewFromInt(1247, 100, "EUR"),
-		AppliedDiscounts: []cartDomain.ItemDiscount{
+		AppliedDiscounts: []cartDomain.AppliedDiscount{
 			{
-				Amount:        priceDomain.NewFromInt(-100, 100, "EUR"),
+				Applied:       priceDomain.NewFromInt(-100, 100, "EUR"),
 				IsItemRelated: true,
 			},
 			{
-				Amount:        priceDomain.NewFromInt(-200, 100, "EUR"),
+				Applied:       priceDomain.NewFromInt(-200, 100, "EUR"),
 				IsItemRelated: false,
 			},
 		},

--- a/cart/domain/decorator/cartDecorator.go
+++ b/cart/domain/decorator/cartDecorator.go
@@ -30,12 +30,14 @@ type (
 	DecoratedDelivery struct {
 		Delivery       cart.Delivery
 		DecoratedItems []DecoratedCartItem
+		Logger         flamingo.Logger
 	}
 
 	// DecoratedCartItem Decorates a CartItem with its Product
 	DecoratedCartItem struct {
 		Item    cart.Item
 		Product domain.BasicProduct
+		Logger  flamingo.Logger
 	}
 
 	// GroupedDecoratedCartItem - value object used for grouping (generated on the fly)
@@ -52,6 +54,20 @@ func (df *DecoratedCartFactory) Inject(
 ) {
 	df.productService = productService
 	df.logger = logger
+}
+
+// Inject dependencies
+func (dci *DecoratedCartItem) Inject(
+	logger flamingo.Logger,
+) {
+	dci.Logger = logger.WithField("category", "cart").WithField("subcategory", "DecoratedCartItem")
+}
+
+// Inject dependencies
+func (dc *DecoratedDelivery) Inject(
+	logger flamingo.Logger,
+) {
+	dc.Logger = logger.WithField("category", "cart").WithField("subcategory", "DecoratedDelivery")
 }
 
 // Create Factory method to get Decorated Cart

--- a/cart/domain/decorator/discount.go
+++ b/cart/domain/decorator/discount.go
@@ -15,7 +15,7 @@ type (
 	// with an error, errors are just logged
 	DecoratedWithDiscount interface {
 		HasAppliedDiscounts() bool
-		CollectDiscounts() cart.AppliedDiscounts
+		MergeDiscounts() cart.AppliedDiscounts
 	}
 )
 
@@ -31,8 +31,8 @@ func (dci *DecoratedCartItem) HasAppliedDiscounts() bool {
 	return hasAppliedDiscounts(dci)
 }
 
-// CollectDiscounts sum up discounts applied to item
-func (dci DecoratedCartItem) CollectDiscounts() cart.AppliedDiscounts {
+// MergeDiscounts sum up discounts applied to item
+func (dci DecoratedCartItem) MergeDiscounts() cart.AppliedDiscounts {
 	return collectDiscounts(&dci.Item, dci.Logger)
 }
 
@@ -41,8 +41,8 @@ func (dc DecoratedDelivery) HasAppliedDiscounts() bool {
 	return hasAppliedDiscounts(dc)
 }
 
-// CollectDiscounts sum up discounts applied to delivery
-func (dc DecoratedDelivery) CollectDiscounts() cart.AppliedDiscounts {
+// MergeDiscounts sum up discounts applied to delivery
+func (dc DecoratedDelivery) MergeDiscounts() cart.AppliedDiscounts {
 	return collectDiscounts(&dc.Delivery, dc.Logger)
 }
 
@@ -51,8 +51,8 @@ func (dc DecoratedCart) HasAppliedDiscounts() bool {
 	return hasAppliedDiscounts(dc)
 }
 
-// CollectDiscounts sum up discounts applied to cart
-func (dc DecoratedCart) CollectDiscounts() cart.AppliedDiscounts {
+// MergeDiscounts sum up discounts applied to cart
+func (dc DecoratedCart) MergeDiscounts() cart.AppliedDiscounts {
 	return collectDiscounts(&dc.Cart, dc.Logger)
 }
 
@@ -60,11 +60,11 @@ func (dc DecoratedCart) CollectDiscounts() cart.AppliedDiscounts {
 // interface cart.WithDiscount and can therefore be abstracted
 
 func hasAppliedDiscounts(discountable DecoratedWithDiscount) bool {
-	return len(discountable.CollectDiscounts()) > 0
+	return len(discountable.MergeDiscounts()) > 0
 }
 
 func collectDiscounts(discountable cart.WithDiscount, logger flamingo.Logger) cart.AppliedDiscounts {
-	discounts, err := discountable.CollectDiscounts()
+	discounts, err := discountable.MergeDiscounts()
 	if err != nil {
 		logger.Error(errorLog)
 		return make(cart.AppliedDiscounts, 0)

--- a/cart/domain/decorator/discount.go
+++ b/cart/domain/decorator/discount.go
@@ -33,7 +33,7 @@ func (dci *DecoratedCartItem) HasAppliedDiscounts() bool {
 
 // MergeDiscounts sum up discounts applied to item
 func (dci DecoratedCartItem) MergeDiscounts() cart.AppliedDiscounts {
-	return collectDiscounts(&dci.Item, dci.Logger)
+	return collectDiscounts(&dci.Item, dci.logger)
 }
 
 // HasAppliedDiscounts checks whether decorated delivery has discounts
@@ -43,7 +43,7 @@ func (dc DecoratedDelivery) HasAppliedDiscounts() bool {
 
 // MergeDiscounts sum up discounts applied to delivery
 func (dc DecoratedDelivery) MergeDiscounts() cart.AppliedDiscounts {
-	return collectDiscounts(&dc.Delivery, dc.Logger)
+	return collectDiscounts(&dc.Delivery, dc.logger)
 }
 
 // HasAppliedDiscounts checks whether decorated cart has discounts

--- a/cart/domain/decorator/discount_test.go
+++ b/cart/domain/decorator/discount_test.go
@@ -11,7 +11,7 @@ import (
 	"flamingo.me/flamingo-commerce/v3/price/domain"
 )
 
-func TestDecoratedItem_CollectDiscounts(t *testing.T) {
+func TestDecoratedItem_MergeDiscounts(t *testing.T) {
 	tests := []struct {
 		name string
 		item *decorator.DecoratedCartItem
@@ -53,12 +53,12 @@ func TestDecoratedItem_CollectDiscounts(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.item.CollectDiscounts()
+			got := tt.item.MergeDiscounts()
 			// we need to sort result to circumvent implementation changes in order
 			sort.Sort(testutils.ByCode(got))
 			sort.Sort(testutils.ByCode(tt.want))
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("DecoratedItem.CollectDiscounts() = %v, want %v", got, tt.want)
+				t.Errorf("DecoratedItem.MergeDiscounts() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -104,7 +104,7 @@ func TestDecoratedItem_HasDiscounts(t *testing.T) {
 	}
 }
 
-func TestDecoratedDelivery_CollectDiscounts(t *testing.T) {
+func TestDecoratedDelivery_MergeDiscounts(t *testing.T) {
 	tests := []struct {
 		name     string
 		delivery *decorator.DecoratedDelivery
@@ -161,12 +161,12 @@ func TestDecoratedDelivery_CollectDiscounts(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.delivery.CollectDiscounts()
+			got := tt.delivery.MergeDiscounts()
 			// we need to sort result to circumvent implementation changes in order
 			sort.Sort(testutils.ByCode(got))
 			sort.Sort(testutils.ByCode(tt.want))
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("DecoratedDelivery.CollectDiscounts() = %v, want %v", got, tt.want)
+				t.Errorf("DecoratedDelivery.MergeDiscounts() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -209,7 +209,7 @@ func TestDecoratedDelivery_HasDiscounts(t *testing.T) {
 	}
 }
 
-func TestDecoratedCart_CollectDiscounts(t *testing.T) {
+func TestDecoratedCart_MergeDiscounts(t *testing.T) {
 	tests := []struct {
 		name string
 		cart *decorator.DecoratedCart
@@ -300,12 +300,12 @@ func TestDecoratedCart_CollectDiscounts(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.cart.CollectDiscounts()
+			got := tt.cart.MergeDiscounts()
 			// we need to sort result to circumvent implementation changes in order
 			sort.Sort(testutils.ByCode(got))
 			sort.Sort(testutils.ByCode(tt.want))
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("DecoratedCart.CollectDiscounts() = %v, want %v", got, tt.want)
+				t.Errorf("DecoratedCart.MergeDiscounts() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/cart/domain/decorator/discount_test.go
+++ b/cart/domain/decorator/discount_test.go
@@ -1,0 +1,391 @@
+package decorator_test
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"flamingo.me/flamingo-commerce/v3/cart/domain/cart"
+	"flamingo.me/flamingo-commerce/v3/cart/domain/decorator"
+	"flamingo.me/flamingo-commerce/v3/cart/domain/testutils"
+	"flamingo.me/flamingo-commerce/v3/price/domain"
+)
+
+func TestDecoratedItem_CollectDiscounts(t *testing.T) {
+	tests := []struct {
+		name string
+		item *decorator.DecoratedCartItem
+		want cart.AppliedDiscounts
+	}{
+		{
+			name: "no discounts on item",
+			item: &decorator.DecoratedCartItem{
+				Item: cart.Item{},
+			},
+			want: nil,
+		},
+		{
+			name: "multiple discounts on item",
+			item: &decorator.DecoratedCartItem{
+				Item: *testutils.BuildItemWithDiscounts(t),
+			},
+			want: cart.AppliedDiscounts{
+				{
+					CampaignCode: "code-1",
+					Label:        "title-1",
+					Type:         "type-1",
+					Applied:      domain.NewFromFloat(-10.0, "$"),
+				},
+				{
+					CampaignCode: "code-2",
+					Label:        "title-2",
+					Type:         "type-1",
+					Applied:      domain.NewFromFloat(-15.0, "$"),
+				},
+				{
+					CampaignCode: "code-3",
+					Label:        "title-1",
+					Type:         "type-2",
+					Applied:      domain.NewFromFloat(-5.0, "$"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.item.CollectDiscounts()
+			// we need to sort result to circumvent implementation changes in order
+			sort.Sort(testutils.ByCode(got))
+			sort.Sort(testutils.ByCode(tt.want))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DecoratedItem.CollectDiscounts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecoratedItem_HasDiscounts(t *testing.T) {
+	tests := []struct {
+		name string
+		item *decorator.DecoratedCartItem
+		want bool
+	}{
+		{
+			name: "no discounts on item",
+			item: &decorator.DecoratedCartItem{
+				Item: cart.Item{},
+			},
+			want: false,
+		},
+		{
+			name: "multiple discounts on item",
+			item: func() *decorator.DecoratedCartItem {
+				builder := cart.ItemBuilder{}
+				builder.AddDiscount(cart.AppliedDiscount{
+					CampaignCode: "code-1",
+					Label:        "title-1",
+					Type:         "type-1",
+				})
+				item, _ := builder.Build()
+				decorated := decorator.DecoratedCartItem{
+					Item: *item,
+				}
+				return &decorated
+			}(),
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.item.HasAppliedDiscounts(); got != tt.want {
+				t.Errorf("DecoratedItem.HasDiscounts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecoratedDelivery_CollectDiscounts(t *testing.T) {
+	tests := []struct {
+		name     string
+		delivery *decorator.DecoratedDelivery
+		want     cart.AppliedDiscounts
+	}{
+		{
+			name: "empty delivery",
+			delivery: &decorator.DecoratedDelivery{
+				Delivery: cart.Delivery{},
+			},
+			want: cart.AppliedDiscounts{},
+		},
+		{
+			name: "delivery with items but without discounts",
+			delivery: func() *decorator.DecoratedDelivery {
+				builder := cart.DeliveryBuilder{}
+				builder.AddItem(cart.Item{})
+				builder.AddItem(cart.Item{})
+				builder.SetDeliveryCode("code")
+				delivery, _ := builder.Build()
+				decorated := decorator.DecoratedDelivery{
+					Delivery: *delivery,
+				}
+				return &decorated
+			}(),
+			want: cart.AppliedDiscounts{},
+		},
+		{
+			name: "delivery with items with discounts",
+			delivery: &decorator.DecoratedDelivery{
+				Delivery: *testutils.BuildDeliveryWithDiscounts(t),
+			},
+			want: cart.AppliedDiscounts{
+				{
+					CampaignCode: "code-1",
+					Label:        "title-1",
+					Type:         "type-1",
+					Applied:      domain.NewFromFloat(-20.0, "$"),
+				},
+				{
+					CampaignCode: "code-2",
+					Label:        "title-2",
+					Type:         "type-1",
+					Applied:      domain.NewFromFloat(-30.0, "$"),
+				},
+				{
+					CampaignCode: "code-3",
+					Label:        "title-1",
+					Type:         "type-2",
+					Applied:      domain.NewFromFloat(-10.0, "$"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.delivery.CollectDiscounts()
+			// we need to sort result to circumvent implementation changes in order
+			sort.Sort(testutils.ByCode(got))
+			sort.Sort(testutils.ByCode(tt.want))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DecoratedDelivery.CollectDiscounts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecoratedDelivery_HasDiscounts(t *testing.T) {
+	tests := []struct {
+		name     string
+		delivery *decorator.DecoratedDelivery
+		want     bool
+	}{
+		{
+			name: "empty delivery",
+			delivery: &decorator.DecoratedDelivery{
+				Delivery: cart.Delivery{},
+			},
+			want: false,
+		},
+		{
+			name: "delivery with items but without discounts",
+			delivery: &decorator.DecoratedDelivery{
+				Delivery: *testutils.BuildDeliveryWithoutDiscounts(t),
+			},
+			want: false,
+		},
+		{
+			name: "delivery with items with discounts",
+			delivery: &decorator.DecoratedDelivery{
+				Delivery: *testutils.BuildDeliveryWithDiscounts(t),
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.delivery.HasAppliedDiscounts(); got != tt.want {
+				t.Errorf("DecoratedDelivery.HasDiscounts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecoratedCart_CollectDiscounts(t *testing.T) {
+	tests := []struct {
+		name string
+		cart *decorator.DecoratedCart
+		want cart.AppliedDiscounts
+	}{
+		{
+			name: "empty cart",
+			cart: &decorator.DecoratedCart{
+				Cart: cart.Cart{},
+			},
+			want: cart.AppliedDiscounts{},
+		},
+		{
+			name: "cart with deliveries but without items",
+			cart: &decorator.DecoratedCart{
+				Cart: cart.Cart{
+					Deliveries: func() []cart.Delivery {
+						result := make([]cart.Delivery, 0)
+						builder := cart.DeliveryBuilder{}
+						builder.SetDeliveryCode("code-1")
+						delivery, _ := builder.Build()
+						result = append(result, *delivery)
+						builder = cart.DeliveryBuilder{}
+						builder.SetDeliveryCode("code-2")
+						result = append(result, *delivery)
+						return result
+					}(),
+				},
+			},
+			want: cart.AppliedDiscounts{},
+		},
+		{
+			name: "cart with deliveries with items but without discounts",
+			cart: &decorator.DecoratedCart{
+				Cart: cart.Cart{
+					Deliveries: func() []cart.Delivery {
+						result := make([]cart.Delivery, 0)
+						builder := cart.DeliveryBuilder{}
+						builder.SetDeliveryCode("code-1")
+						builder.AddItem(cart.Item{})
+						builder.AddItem(cart.Item{})
+						delivery, _ := builder.Build()
+						result = append(result, *delivery)
+						builder = cart.DeliveryBuilder{}
+						builder.SetDeliveryCode("code-2")
+						result = append(result, *delivery)
+						return result
+					}(),
+				},
+			},
+			want: cart.AppliedDiscounts{},
+		},
+		{
+			name: "cart with deliveries with items with discounts",
+			cart: &decorator.DecoratedCart{
+				Cart: cart.Cart{
+					Deliveries: func() []cart.Delivery {
+						result := make([]cart.Delivery, 0)
+						delivery := testutils.BuildDeliveryWithDiscounts(t)
+						result = append(result, *delivery)
+						delivery = testutils.BuildDeliveryWithDiscounts(t)
+						result = append(result, *delivery)
+						return result
+					}(),
+				},
+			},
+			want: cart.AppliedDiscounts{
+				{
+					CampaignCode: "code-1",
+					Label:        "title-1",
+					Type:         "type-1",
+					Applied:      domain.NewFromFloat(-40.0, "$"),
+				},
+				{
+					CampaignCode: "code-2",
+					Label:        "title-2",
+					Type:         "type-1",
+					Applied:      domain.NewFromFloat(-60.0, "$"),
+				},
+				{
+					CampaignCode: "code-3",
+					Label:        "title-1",
+					Type:         "type-2",
+					Applied:      domain.NewFromFloat(-20.0, "$"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cart.CollectDiscounts()
+			// we need to sort result to circumvent implementation changes in order
+			sort.Sort(testutils.ByCode(got))
+			sort.Sort(testutils.ByCode(tt.want))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DecoratedCart.CollectDiscounts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecoratedCart_HasDiscounts(t *testing.T) {
+	tests := []struct {
+		name string
+		cart *decorator.DecoratedCart
+		want bool
+	}{
+		{
+			name: "empty cart",
+			cart: &decorator.DecoratedCart{
+				Cart: cart.Cart{},
+			},
+			want: false,
+		},
+		{
+			name: "cart with deliveries but without items",
+			cart: &decorator.DecoratedCart{
+				Cart: cart.Cart{
+					Deliveries: func() []cart.Delivery {
+						result := make([]cart.Delivery, 0)
+						builder := cart.DeliveryBuilder{}
+						builder.SetDeliveryCode("code-1")
+						delivery, _ := builder.Build()
+						result = append(result, *delivery)
+						builder = cart.DeliveryBuilder{}
+						builder.SetDeliveryCode("code-2")
+						result = append(result, *delivery)
+						return result
+					}(),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "cart with deliveries with items but without discounts",
+			cart: &decorator.DecoratedCart{
+				Cart: cart.Cart{
+					Deliveries: func() []cart.Delivery {
+						result := make([]cart.Delivery, 0)
+						builder := cart.DeliveryBuilder{}
+						builder.SetDeliveryCode("code-1")
+						builder.AddItem(cart.Item{})
+						builder.AddItem(cart.Item{})
+						delivery, _ := builder.Build()
+						result = append(result, *delivery)
+						builder = cart.DeliveryBuilder{}
+						builder.SetDeliveryCode("code-2")
+						result = append(result, *delivery)
+						return result
+					}(),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "cart with deliveries with items with discounts",
+			cart: &decorator.DecoratedCart{
+				Cart: cart.Cart{
+					Deliveries: func() []cart.Delivery {
+						result := make([]cart.Delivery, 0)
+						delivery := testutils.BuildDeliveryWithDiscounts(t)
+						result = append(result, *delivery)
+						delivery = testutils.BuildDeliveryWithDiscounts(t)
+						result = append(result, *delivery)
+						return result
+					}(),
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cart.HasAppliedDiscounts(); got != tt.want {
+				t.Errorf("DecoratedCart.HasDiscounts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cart/domain/testutils/utils.go
+++ b/cart/domain/testutils/utils.go
@@ -1,0 +1,89 @@
+package testutils
+
+import (
+	"testing"
+
+	"flamingo.me/flamingo-commerce/v3/cart/domain/cart"
+	"flamingo.me/flamingo-commerce/v3/price/domain"
+)
+
+type (
+	// ByCode implements sort.Interface for []AppliedDiscount based on code
+	ByCode cart.AppliedDiscounts
+)
+
+// implementations for sort interface
+
+func (a ByCode) Len() int {
+	return len(a)
+}
+
+func (a ByCode) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+func (a ByCode) Less(i, j int) bool {
+	return a[i].CampaignCode < a[j].CampaignCode
+}
+
+// BuildItemWithDiscounts helper for item building
+func BuildItemWithDiscounts(t *testing.T) *cart.Item {
+	t.Helper()
+	builder := cart.ItemBuilder{}
+	builder.AddDiscount(cart.AppliedDiscount{
+		CampaignCode: "code-1",
+		Label:        "title-1",
+		Type:         "type-1",
+		Applied:      domain.NewFromFloat(-10.0, "$"),
+	})
+	builder.AddDiscount(cart.AppliedDiscount{
+		CampaignCode: "code-2",
+		Label:        "title-2",
+		Type:         "type-1",
+		Applied:      domain.NewFromFloat(-15.0, "$"),
+	})
+	builder.AddDiscount(cart.AppliedDiscount{
+		CampaignCode: "code-3",
+		Label:        "title-1",
+		Type:         "type-2",
+		Applied:      domain.NewFromFloat(-5.0, "$"),
+	})
+	builder.SetID("id-1")
+	item, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Could not build item %s", err.Error())
+	}
+	return item
+}
+
+// BuildDeliveryWithDiscounts helper for delivery building
+// Adds an item with discount twice
+// This means when discounts are summed up (based on type + delivery)
+// The amount should be added to the previous discount
+func BuildDeliveryWithDiscounts(t *testing.T) *cart.Delivery {
+	t.Helper()
+	builder := cart.DeliveryBuilder{}
+	builder.SetDeliveryCode("code")
+	builder.AddItem(*BuildItemWithDiscounts(t))
+	builder.AddItem(*BuildItemWithDiscounts(t))
+	// add items with discounts
+	delivery, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Could not build delivery %s", err.Error())
+	}
+	return delivery
+}
+
+// BuildDeliveryWithoutDiscounts helper for delivery building
+func BuildDeliveryWithoutDiscounts(t *testing.T) *cart.Delivery {
+	t.Helper()
+	builder := cart.DeliveryBuilder{}
+	builder.AddItem(cart.Item{})
+	builder.AddItem(cart.Item{})
+	builder.SetDeliveryCode("code")
+	delivery, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Could not build delivery %s", err.Error())
+	}
+	return delivery
+}


### PR DESCRIPTION
Currently Discounts are available on Item level (ItemDiscounts) but not on a delivery or a cart level. These information may be useful for the client, therefore I suggest a new generic structure of Discounts that are available on Item, Delivery and Cart level. ~~The discounts are merged by their title and a newly introduced type~~. 

The discounts are merged by their campaign code, which is defined as a code that is a underlying identifier.

