### PR TITLE
Bugfix: Allow filters with multiple values

### DIFF
--- a/product/interfaces/templatefunctions/findProducts.go
+++ b/product/interfaces/templatefunctions/findProducts.go
@@ -37,16 +37,14 @@ func (tf *FindProducts) Func(ctx context.Context) interface{} {
 		config - map with certain keys - used to specify the searchRequest better
 	*/
 	return func(namespace string, configs ...pugjs.Map) *application.SearchResult {
-		var searchConfig, filterConstrains map[string]string
-		var keyValueFilters map[string][]string
+		var searchConfig = make(map[string]string)
+		var filterConstrains = make(map[string]string)
+		var keyValueFilters = make(map[string][]string)
 
 		if len(configs) > 0 {
 			searchConfig = configs[0].AsStringMap()
-		} else {
-			searchConfig = make(map[string]string)
 		}
 
-		keyValueFilters = make(map[string][]string)
 		if len(configs) > 1 {
 			for key, value := range configs[1].AsStringIfaceMap() {
 				if str, ok := value.(pugjs.String); ok { // allow string
@@ -59,8 +57,6 @@ func (tf *FindProducts) Func(ctx context.Context) interface{} {
 
 		if len(configs) > 2 {
 			filterConstrains = configs[2].AsStringMap()
-		} else {
-			filterConstrains = make(map[string]string)
 		}
 
 		filterProcessing := newFilterProcessing(web.RequestFromContext(ctx), namespace, searchConfig, keyValueFilters, filterConstrains)

--- a/product/interfaces/templatefunctions/findProducts.go
+++ b/product/interfaces/templatefunctions/findProducts.go
@@ -37,9 +37,9 @@ func (tf *FindProducts) Func(ctx context.Context) interface{} {
 		config - map with certain keys - used to specify the searchRequest better
 	*/
 	return func(namespace string, configs ...pugjs.Map) *application.SearchResult {
-		var searchConfig = make(map[string]string)
-		var filterConstrains = make(map[string]string)
-		var keyValueFilters = make(map[string][]string)
+		searchConfig := make(map[string]string)
+		filterConstrains := make(map[string]string)
+		keyValueFilters := make(map[string][]string)
 
 		if len(configs) > 0 {
 			searchConfig = configs[0].AsStringMap()

--- a/product/interfaces/templatefunctions/findProducts.go
+++ b/product/interfaces/templatefunctions/findProducts.go
@@ -2,6 +2,7 @@ package templatefunctions
 
 import (
 	"context"
+	"flamingo.me/pugtemplate/pugjs"
 	"log"
 	"strconv"
 	"strings"
@@ -33,25 +34,31 @@ func (tf *FindProducts) Func(ctx context.Context) interface{} {
 
 	/*
 		widgetName - used to namespace widget - in case we need pagination
-		config - map with certain keys - used to specifiy th searchRequest better
+		config - map with certain keys - used to specify the searchRequest better
 	*/
-	return func(namespace string, configs ...map[string]string) *application.SearchResult {
-		var searchConfig, keyValueFilters, filterConstrains map[string]string
+	return func(namespace string, configs ...pugjs.Map) *application.SearchResult {
+		var searchConfig, filterConstrains map[string]string
+		var keyValueFilters map[string][]string
 
 		if len(configs) > 0 {
-			searchConfig = configs[0]
+			searchConfig = configs[0].AsStringMap()
 		} else {
 			searchConfig = make(map[string]string)
 		}
 
+		keyValueFilters = make(map[string][]string)
 		if len(configs) > 1 {
-			keyValueFilters = configs[1]
-		} else {
-			keyValueFilters = make(map[string]string)
+			for key, value := range configs[1].AsStringIfaceMap() {
+				if str, ok := value.(pugjs.String); ok { // allow string
+					keyValueFilters[key] = []string{str.String()}
+				} else if arrStr, ok := value.([]string); ok { // and array of strings
+					keyValueFilters[key] = arrStr
+				}
+			}
 		}
 
 		if len(configs) > 2 {
-			filterConstrains = configs[2]
+			filterConstrains = configs[2].AsStringMap()
 		} else {
 			filterConstrains = make(map[string]string)
 		}
@@ -70,7 +77,7 @@ func (tf *FindProducts) Func(ctx context.Context) interface{} {
 	}
 }
 
-func newFilterProcessing(request *web.Request, namespace string, searchConfig, keyValueFilters, filterConstrains map[string]string) filterProcessing {
+func newFilterProcessing(request *web.Request, namespace string, searchConfig map[string]string, keyValueFilters map[string][]string, filterConstrains map[string]string) filterProcessing {
 	var filterProcessing filterProcessing
 	var searchRequest searchApplication.SearchRequest
 
@@ -85,9 +92,7 @@ func newFilterProcessing(request *web.Request, namespace string, searchConfig, k
 		searchRequest.PageSize = pageSize
 	}
 
-	for k, v := range keyValueFilters {
-		searchRequest.AddAdditionalFilter(domain.NewKeyValueFilter(k, []string{v}))
-	}
+	searchRequest.AddAdditionalFilters(domain.NewKeyValueFilters(keyValueFilters)...)
 
 	// Set blackList and whiteList, also trim spaces
 	filterProcessing.blackList = strings.Split(filterConstrains["blackList"], ",")

--- a/product/interfaces/templatefunctions/findProducts_test.go
+++ b/product/interfaces/templatefunctions/findProducts_test.go
@@ -104,7 +104,7 @@ func buildSearchResult() *application.SearchResult {
 }
 
 // helper function for test cases
-func buildFilterProcessing(keyValueFilter, filterConstrains map[string]string) filterProcessing {
+func buildFilterProcessing(keyValueFilter map[string][]string, filterConstrains map[string]string) filterProcessing {
 	requestURL := url.URL{}
 	webRequest := web.CreateRequest(&http.Request{
 		URL: &requestURL,


### PR DESCRIPTION
For example, selecting multiple delivery methods or brands was not possible.

With this fix it's allowed to either
- send an filter list with strings as values, like { 'brand': 'apple' } (the old way for backwards compatibility
- or send a list with an array of strings, like { 'brand': ['apple', 'samsung'] }