### PR TITLE
cart: add event that is dispatched before an order is placed

### DIFF
--- a/cart/application/cartReceiver_test.go
+++ b/cart/application/cartReceiver_test.go
@@ -8,7 +8,6 @@ import (
 	"flamingo.me/flamingo-commerce/v3/cart/domain/placeorder"
 	"flamingo.me/flamingo-commerce/v3/cart/domain/validation"
 
-
 	"reflect"
 	"testing"
 
@@ -148,6 +147,9 @@ func (m *MockEventPublisher) PublishChangedQtyInCartEvent(ctx context.Context, i
 }
 
 func (m *MockEventPublisher) PublishOrderPlacedEvent(ctx context.Context, cart *cartDomain.Cart, placedOrderInfos placeorder.PlacedOrderInfos) {
+}
+
+func (m *MockEventPublisher) PublishBeforeOrderPlaceEvent(ctx context.Context) {
 }
 
 // MockCartValidator

--- a/cart/application/cartService.go
+++ b/cart/application/cartService.go
@@ -764,6 +764,9 @@ func (cs *CartService) PlaceOrder(ctx context.Context, session *web.Session, pay
 	if cs.placeOrderService == nil {
 		return nil, errors.New("No placeOrderService registered")
 	}
+
+	cs.eventPublisher.PublishBeforeOrderPlaceEvent(ctx)
+
 	cart, _, err := cs.cartReceiverService.GetCart(ctx, session)
 	if err != nil {
 		return nil, err

--- a/cart/domain/events/eventPublishing.go
+++ b/cart/domain/events/eventPublishing.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"context"
+
 	"flamingo.me/flamingo-commerce/v3/cart/domain/placeorder"
 
 	cartDomain "flamingo.me/flamingo-commerce/v3/cart/domain/cart"
@@ -11,12 +12,12 @@ import (
 
 type (
 
-
 	//EventPublisher - technology free interface to publish events that might be interesting for outside (Publish)
 	EventPublisher interface {
 		PublishAddToCartEvent(ctx context.Context, marketPlaceCode string, variantMarketPlaceCode string, qty int)
 		PublishChangedQtyInCartEvent(ctx context.Context, item *cartDomain.Item, qtyBefore int, qtyAfter int, cartID string)
 		PublishOrderPlacedEvent(ctx context.Context, cart *cartDomain.Cart, placedOrderInfos placeorder.PlacedOrderInfos)
+		PublishBeforeOrderPlaceEvent(ctx context.Context)
 	}
 
 	//DefaultEventPublisher implements the event publisher of the domain and uses the framework event router
@@ -30,6 +31,7 @@ type (
 var (
 	_ EventPublisher = (*DefaultEventPublisher)(nil)
 	_ flamingo.Event = (*OrderPlacedEvent)(nil)
+	_ flamingo.Event = (*BeforeOrderPlaceEvent)(nil)
 	_ flamingo.Event = (*AddToCartEvent)(nil)
 	_ flamingo.Event = (*PaymentSelectionHasBeenResetEvent)(nil)
 	_ flamingo.Event = (*ChangedQtyInCartEvent)(nil)
@@ -89,5 +91,13 @@ func (d *DefaultEventPublisher) PublishOrderPlacedEvent(ctx context.Context, car
 	d.logger.WithContext(ctx).Info("Publish Event OrderPlacedEvent for Order: %#v", placedOrderInfos)
 
 	//For now we publish only to Flamingo default Event Router
+	d.eventRouter.Dispatch(ctx, &eventObject)
+}
+
+// PublishBeforeOrderPlaceEvent publishes an event before an order gets placed
+func (d *DefaultEventPublisher) PublishBeforeOrderPlaceEvent(ctx context.Context) {
+	eventObject := BeforeOrderPlaceEvent{}
+
+	d.logger.WithContext(ctx).Info("Publish Event BeforeOrderPlaceEvent")
 	d.eventRouter.Dispatch(ctx, &eventObject)
 }

--- a/cart/domain/events/events.go
+++ b/cart/domain/events/events.go
@@ -12,6 +12,9 @@ type (
 		PlacedOrderInfos placeorder.PlacedOrderInfos
 	}
 
+	// BeforeOrderPlaceEvent defines event properties
+	BeforeOrderPlaceEvent struct{}
+
 	// AddToCartEvent defines event properties
 	AddToCartEvent struct {
 		MarketplaceCode        string
@@ -32,7 +35,7 @@ type (
 
 	// PaymentSelectionHasBeenResetEvent defines event properties
 	PaymentSelectionHasBeenResetEvent struct {
-		Cart *cartDomain.Cart
+		Cart                     *cartDomain.Cart
 		ResettedPaymentSelection *cartDomain.PaymentSelection
 	}
 )


### PR DESCRIPTION
Currently we only have an event after the order is placed. Maybe I want to check / do stuff right before the order is placed.