### PR TITLE
product: allow to use provided urlslug from product data

### DIFF
--- a/product/Readme.md
+++ b/product/Readme.md
@@ -72,7 +72,7 @@ The view gets the following Data passed:
         VariantSelection variantSelection
         BackURL          string
     }
-``` 
+```
 
 ## Template functions
 
@@ -86,6 +86,11 @@ Returns the product or nil:
 
 Returns the correct url to the product:
 `getProductUrl(product)`
+
+The returned products urls slug will be
+
+* generated if the confuration `commerce.product.generateSlug` is set to true
+* use the configured attribute to fetch the utlSlug from the product data.
 
 ### findProducts
 

--- a/product/application/urlService_test.go
+++ b/product/application/urlService_test.go
@@ -1,0 +1,377 @@
+package application_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"flamingo.me/flamingo-commerce/v3/product/application"
+	"flamingo.me/flamingo-commerce/v3/product/domain"
+)
+
+func TestURLService_GetURLParams(t *testing.T) {
+
+	type fields struct {
+		config *struct {
+			GenerateSlug      bool   `inject:"config:commerce.product.generateSlug,optional"`
+			SlugAttributecode string `inject:"config:commerce.product.slugAttributeCode,optional"`
+		}
+	}
+	type args struct {
+		product     domain.BasicProduct
+		variantCode string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   map[string]string
+	}{
+		{
+			name: "nil product",
+			want: make(map[string]string),
+		},
+		{
+			name: "simple, generate slug",
+			fields: fields{
+				config: getConfig(true, "slug"),
+			},
+			args: args{
+				product: domain.SimpleProduct{
+					BasicProductData: domain.BasicProductData{
+						MarketPlaceCode: "test-code",
+						Title:           "Test Name",
+						Attributes: domain.Attributes{
+							"slug": domain.Attribute{
+								Code:     "slug",
+								RawValue: "test-slug",
+							},
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"marketplacecode": "test-code",
+				"name":            "test-name",
+			},
+		},
+		{
+			name: "simple, use slug, attribute missing",
+			fields: fields{
+				config: getConfig(false, "slug"),
+			},
+			args: args{
+				product: domain.SimpleProduct{
+					BasicProductData: domain.BasicProductData{
+						MarketPlaceCode: "test-code",
+						Title:           "Test Name",
+						Attributes: domain.Attributes{
+							"slug-invalid": domain.Attribute{
+								Code:     "slug",
+								RawValue: "test-slug",
+							},
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"marketplacecode": "test-code",
+				"name":            "test-name",
+			},
+		},
+		{
+			name: "simple, use slug, attribute empty",
+			fields: fields{
+				config: getConfig(false, "slug"),
+			},
+			args: args{
+				product: domain.SimpleProduct{
+					BasicProductData: domain.BasicProductData{
+						MarketPlaceCode: "test-code",
+						Title:           "Test Name",
+						Attributes: domain.Attributes{
+							"slug": domain.Attribute{
+								Code: "slug",
+							},
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"marketplacecode": "test-code",
+				"name":            "test-name",
+			},
+		},
+		{
+			name: "simple, use slug",
+			fields: fields{
+				config: getConfig(false, "slug"),
+			},
+			args: args{
+				product: domain.SimpleProduct{
+					BasicProductData: domain.BasicProductData{
+						MarketPlaceCode: "test-code",
+						Title:           "Test Name",
+						Attributes: domain.Attributes{
+							"slug": domain.Attribute{
+								Code:     "slug",
+								RawValue: "slug-test-name",
+							},
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"marketplacecode": "test-code",
+				"name":            "slug-test-name",
+			},
+		},
+		{
+			name: "configurable, use slug",
+			fields: fields{
+				config: getConfig(false, "slug"),
+			},
+			args: args{
+				product: domain.ConfigurableProduct{
+					BasicProductData: domain.BasicProductData{
+						MarketPlaceCode: "test-code",
+						Title:           "Test Name",
+						Attributes: domain.Attributes{
+							"slug": domain.Attribute{
+								Code:     "slug",
+								RawValue: "slug-test-name",
+							},
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"marketplacecode": "test-code",
+				"name":            "slug-test-name",
+			},
+		},
+		{
+			name: "configurable, active variant, use slug",
+			fields: fields{
+				config: getConfig(false, "slug"),
+			},
+			args: args{
+				product: domain.ConfigurableProductWithActiveVariant{
+					BasicProductData: domain.BasicProductData{
+						MarketPlaceCode: "test-code",
+						Title:           "Test Name",
+						Attributes: domain.Attributes{
+							"slug": domain.Attribute{
+								Code:     "slug",
+								RawValue: "slug-test-name",
+							},
+						},
+					},
+					ActiveVariant: domain.Variant{
+						BasicProductData: domain.BasicProductData{
+							MarketPlaceCode: "variant-test-code",
+							Title:           "Variant Name",
+							Attributes: domain.Attributes{
+								"slug": domain.Attribute{
+									Code:     "slug",
+									RawValue: "slug-variant-test-name",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"marketplacecode": "test-code",
+				"name":            "slug-variant-test-name",
+				"variantcode":     "variant-test-code",
+			},
+		},
+		{
+			name: "configurable, active variant, withvariant code, use slug",
+			fields: fields{
+				config: getConfig(false, "slug"),
+			},
+			args: args{
+				product: domain.ConfigurableProductWithActiveVariant{
+					BasicProductData: domain.BasicProductData{
+						MarketPlaceCode: "test-code",
+						Title:           "Test Name",
+						Attributes: domain.Attributes{
+							"slug": domain.Attribute{
+								Code:     "slug",
+								RawValue: "slug-test-name",
+							},
+						},
+					},
+					Variants: []domain.Variant{
+						{
+							BasicProductData: domain.BasicProductData{
+								MarketPlaceCode: "selected-variant",
+								Title:           "Select Variant Name",
+								Attributes: domain.Attributes{
+									"slug": domain.Attribute{
+										Code:     "slug",
+										RawValue: "slug-selected-variant-test-name",
+									},
+								},
+							},
+						},
+					},
+					ActiveVariant: domain.Variant{
+						BasicProductData: domain.BasicProductData{
+							MarketPlaceCode: "variant-test-code",
+							Title:           "Variant Name",
+							Attributes: domain.Attributes{
+								"slug": domain.Attribute{
+									Code:     "slug",
+									RawValue: "slug-variant-test-name",
+								},
+							},
+						},
+					},
+				},
+				variantCode: "selected-variant",
+			},
+			want: map[string]string{
+				"marketplacecode": "test-code",
+				"name":            "slug-selected-variant-test-name",
+				"variantcode":     "selected-variant",
+			},
+		},
+		{
+			name: "configurable, with teaser, use slug, no slug on teaser set",
+			fields: fields{
+				config: getConfig(false, "slug"),
+			},
+			args: args{
+				product: domain.ConfigurableProduct{
+					BasicProductData: domain.BasicProductData{
+						MarketPlaceCode: "test-code",
+						Title:           "Test Name",
+					},
+					Variants: []domain.Variant{
+						{
+							BasicProductData: domain.BasicProductData{
+								MarketPlaceCode: "selected-variant",
+								Title:           "Select Variant Name",
+								Attributes: domain.Attributes{
+									"slug": domain.Attribute{
+										Code:     "slug",
+										RawValue: "slug-selected-variant-test-name",
+									},
+								},
+							},
+						},
+					},
+					Teaser: domain.TeaserData{
+						PreSelectedVariantSku: "teaser-preselected-variant",
+						ShortTitle:            "teaser-short-title",
+					},
+				},
+			},
+			want: map[string]string{
+				"marketplacecode": "test-code",
+				"name":            "teaser-short-title",
+				"variantcode":     "teaser-preselected-variant",
+			},
+		},
+		{
+			name: "configurable, with teaser, use slug, no slug on teaser set",
+			fields: fields{
+				config: getConfig(false, "slug"),
+			},
+			args: args{
+				product: domain.ConfigurableProduct{
+					BasicProductData: domain.BasicProductData{
+						MarketPlaceCode: "test-code",
+						Title:           "Test Name",
+					},
+					Variants: []domain.Variant{
+						{
+							BasicProductData: domain.BasicProductData{
+								MarketPlaceCode: "selected-variant",
+								Title:           "Select Variant Name",
+								Attributes: domain.Attributes{
+									"slug": domain.Attribute{
+										Code:     "slug",
+										RawValue: "slug-selected-variant-test-name",
+									},
+								},
+							},
+						},
+					},
+					Teaser: domain.TeaserData{
+						PreSelectedVariantSku: "teaser-preselected-variant",
+						ShortTitle:            "teaser-short-title",
+						URLSlug:               "teaser-url-slug",
+					},
+				},
+			},
+			want: map[string]string{
+				"marketplacecode": "test-code",
+				"name":            "teaser-url-slug",
+				"variantcode":     "teaser-preselected-variant",
+			},
+		},
+		{
+			name: "configurable, variant set, use slug",
+			fields: fields{
+				config: getConfig(false, "slug"),
+			},
+			args: args{
+				product: domain.ConfigurableProduct{
+					BasicProductData: domain.BasicProductData{
+						MarketPlaceCode: "test-code",
+						Title:           "Test Name",
+					},
+					Variants: []domain.Variant{
+						{
+							BasicProductData: domain.BasicProductData{
+								MarketPlaceCode: "selected-variant",
+								Title:           "Select Variant Name",
+								Attributes: domain.Attributes{
+									"slug": domain.Attribute{
+										Code:     "slug",
+										RawValue: "slug-selected-variant-test-name",
+									},
+								},
+							},
+						},
+					},
+				},
+				variantCode: "selected-variant",
+			},
+			want: map[string]string{
+				"marketplacecode": "test-code",
+				"name":            "slug-selected-variant-test-name",
+				"variantcode":     "selected-variant",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &application.URLService{}
+			s.Inject(
+				nil,
+				tt.fields.config,
+			)
+			got := s.GetURLParams(tt.args.product, tt.args.variantCode)
+			assert.Equal(t, tt.want, got, "url params")
+		})
+	}
+}
+
+func getConfig(generate bool, code string) *struct {
+	GenerateSlug      bool   `inject:"config:commerce.product.generateSlug,optional"`
+	SlugAttributecode string `inject:"config:commerce.product.slugAttributeCode,optional"`
+} {
+
+	return &struct {
+		GenerateSlug      bool   `inject:"config:commerce.product.generateSlug,optional"`
+		SlugAttributecode string `inject:"config:commerce.product.slugAttributeCode,optional"`
+	}{
+		GenerateSlug:      generate,
+		SlugAttributecode: code,
+	}
+}

--- a/product/domain/productBasics.go
+++ b/product/domain/productBasics.go
@@ -122,6 +122,7 @@ type (
 	TeaserData struct {
 		ShortTitle       string
 		ShortDescription string
+		URLSlug          string
 		//TeaserPrice is the price that should be shown in teasers (listview)
 		TeaserPrice PriceInfo
 		//TeaserPriceIsFromPrice - is set to true in cases where a product might have different prices (e.g. configurable)

--- a/product/module.go
+++ b/product/module.go
@@ -24,8 +24,16 @@ func (m *Module) Configure(injector *dingo.Injector) {
 // DefaultConfig for this module
 func (m *Module) DefaultConfig() config.Map {
 	return config.Map{
-		"commerce.product.view.template": "product/product",
-		"commerce.product.priceIsGross":  true,
+		"commerce": config.Map{
+			"product": config.Map{
+				"view": config.Map{
+					"template": "product/product",
+				},
+				"priceIsGross":      true,
+				"generateSlug":      true,
+				"slugAttributeCode": "urlSlug",
+			},
+		},
 		"templating": config.Map{
 			"product": config.Map{
 				"attributeRenderer": config.Map{},


### PR DESCRIPTION
Allow to use an url slug provided by product data by
- adding a configuration with fallback to slug generation if not configured
- add a configuration for the target attribute within the product data

refs 202816