### PR TITLE
cart: remove zero charges from payment selection

### DIFF
--- a/cart/domain/cart/paymentselection.go
+++ b/cart/domain/cart/paymentselection.go
@@ -94,13 +94,13 @@ func NewDefaultPaymentSelection(gateway string, chargeTypeToPaymentMethod map[st
 	}
 	result, err := newPaymentSelectionWithGiftCard(gateway, chargeTypeToPaymentMethod, pricedItems, giftCards)
 	// filter out zero charges from here on out
-	result = removeZeroCharges(result, chargeTypeToPaymentMethod)
+	result = RemoveZeroCharges(result, chargeTypeToPaymentMethod)
 	return result, err
 }
 
-// removeZeroCharges removes charges which have an amount of zero from selection as they are necessary
+// RemoveZeroCharges removes charges which have an value of zero from selection as they are necessary
 // for our internal calculations but not for external clients, we assume zero charges are ignored
-func removeZeroCharges(selection PaymentSelection, chargeTypeToPaymentMethod map[string]string) PaymentSelection {
+func RemoveZeroCharges(selection PaymentSelection, chargeTypeToPaymentMethod map[string]string) PaymentSelection {
 	result := DefaultPaymentSelection{
 		GatewayProp: selection.Gateway(),
 	}
@@ -121,7 +121,7 @@ func removeZeroChargesFromSplit(builder *PaymentSplitByItemBuilder, paymentSplit
 	for id, split := range paymentSplit {
 		for qualifier, charge := range split.ChargesByType().GetAllCharges() {
 			// skip charges with zero value
-			if charge.Price.IsZero() {
+			if charge.Value.IsZero() {
 				continue
 			}
 			// we assume that map of types and method matches

--- a/cart/domain/cart/paymentselection.go
+++ b/cart/domain/cart/paymentselection.go
@@ -57,13 +57,16 @@ type (
 	// PaymentSplitService enables the creation of a PaymentSplitByItem following different payment methods
 	PaymentSplitService struct{}
 
+	// builderAddFunc is a function used by builder to add items
+	// function which corresponds to builder adddX function (addCartItem, addShipping, addTotal)
+	builderAddFunc func(string, string, price.Charge) *PaymentSplitByItemBuilder
+
 	// itemsWithAdd is a helper struct which holds items with their corresponding add function
 	// from PaymentSplitByItemBuilder
 	itemsWithAdd struct {
 		// map of payable items corresponding to price.PricedItems
-		ItemsToPay map[string]price.Price
-		// function which corresponds to builder adddX function (addCartItem, addShipping, addTotal)
-		AddFunction func(string, string, price.Charge) *PaymentSplitByItemBuilder
+		ItemsToPay  map[string]price.Price
+		AddFunction builderAddFunc
 	}
 )
 
@@ -89,7 +92,43 @@ func NewDefaultPaymentSelection(gateway string, chargeTypeToPaymentMethod map[st
 	if _, ok := chargeTypeToPaymentMethod[price.ChargeTypeMain]; !ok {
 		return nil, fmt.Errorf("payment method for charge type %q not defined", price.ChargeTypeMain)
 	}
-	return newPaymentSelectionWithGiftCard(gateway, chargeTypeToPaymentMethod, pricedItems, giftCards)
+	result, err := newPaymentSelectionWithGiftCard(gateway, chargeTypeToPaymentMethod, pricedItems, giftCards)
+	// filter out zero charges from here on out
+	result = removeZeroCharges(result, chargeTypeToPaymentMethod)
+	return result, err
+}
+
+// removeZeroCharges removes charges which have an amount of zero from selection as they are necessary
+// for our internal calculations but not for external clients, we assume zero charges are ignored
+func removeZeroCharges(selection PaymentSelection, chargeTypeToPaymentMethod map[string]string) PaymentSelection {
+	result := DefaultPaymentSelection{
+		GatewayProp: selection.Gateway(),
+	}
+	builder := PaymentSplitByItemBuilder{}
+	// remove all zero charges from selection with helper function
+	removeZeroChargesFromSplit(&builder, selection.ItemSplit().CartItems, chargeTypeToPaymentMethod, builder.AddCartItem)
+	removeZeroChargesFromSplit(&builder, selection.ItemSplit().ShippingItems, chargeTypeToPaymentMethod, builder.AddShippingItem)
+	removeZeroChargesFromSplit(&builder, selection.ItemSplit().TotalItems, chargeTypeToPaymentMethod, builder.AddTotalItem)
+
+	result.ChargedItemsProp = builder.Build()
+	return result
+}
+
+// removeZeroChargesFromSplit remove charges from single item splits
+// helper which overwrites passed builder instance with adjusted charges
+func removeZeroChargesFromSplit(builder *PaymentSplitByItemBuilder, paymentSplit map[string]PaymentSplit,
+	chargeTypeToPaymentMethod map[string]string, add builderAddFunc) {
+	for id, split := range paymentSplit {
+		for qualifier, charge := range split.ChargesByType().GetAllCharges() {
+			// skip charges with zero value
+			if charge.Price.IsZero() {
+				continue
+			}
+			// we assume that map of types and method matches
+			method, _ := chargeTypeToPaymentMethod[qualifier.Type]
+			builder = add(id, method, charge)
+		}
+	}
 }
 
 // newSimplePaymentSelection returns a PaymentSelection that can be used to update the cart.

--- a/cart/domain/cart/paymentselection.go
+++ b/cart/domain/cart/paymentselection.go
@@ -58,7 +58,7 @@ type (
 	PaymentSplitService struct{}
 
 	// builderAddFunc is a function used by builder to add items
-	// function which corresponds to builder adddX function (addCartItem, addShipping, addTotal)
+	// function which corresponds to builder addX function (addCartItem, addShipping, addTotal)
 	builderAddFunc func(string, string, price.Charge) *PaymentSplitByItemBuilder
 
 	// itemsWithAdd is a helper struct which holds items with their corresponding add function

--- a/cart/domain/cart/paymentselection_wb_test.go
+++ b/cart/domain/cart/paymentselection_wb_test.go
@@ -397,3 +397,71 @@ func Test_CreateSimplePaymentWithoutGiftCards(t *testing.T) {
 	assert.Equal(t, domain.NewFromInt(0, 1, "€").FloatAmount(), selection.CartSplit().ChargesByType().GetByTypeForced(domain.ChargeTypeGiftCard).Value.FloatAmount())
 	assert.Equal(t, domain.NewFromInt(120, 100, "€").FloatAmount(), selection.CartSplit().ChargesByType().GetByTypeForced(domain.ChargeTypeMain).Value.FloatAmount())
 }
+
+func Test_CreatePaymentWithFilteredCharges(t *testing.T) {
+	cart := Cart{
+		Deliveries: []Delivery{
+			{
+				DeliveryInfo: DeliveryInfo{
+					Code: "1",
+				},
+				Cartitems: []Item{
+					{
+						ID:            "1",
+						RowPriceGross: domain.NewFromInt(50, 1, "€"),
+					},
+					{
+						ID:            "2",
+						RowPriceGross: domain.NewFromInt(20, 1, "€"),
+					},
+				},
+				ShippingItem: ShippingItem{
+					Title:    "1",
+					PriceNet: domain.NewFromInt(20, 1, "€"),
+				},
+			},
+		},
+		Totalitems: []Totalitem{
+			{
+				Code:  "1",
+				Title: "1",
+				Price: domain.NewFromInt(10, 1, "€"),
+			},
+		},
+		AppliedGiftCards: AppliedGiftCards{
+			{
+				Code:    "giftcard-1",
+				Applied: domain.NewFromInt(90, 1, "€"),
+			},
+			{
+				Code:    "giftcard-2",
+				Applied: domain.NewFromInt(5, 1, "€"),
+			},
+		},
+	}
+	selection, err := NewDefaultPaymentSelection("gateyway", getPaymentMethodMapping(t), cart)
+	assert.NoError(t, err)
+	// force type for zero charges
+	assert.Equal(t, domain.NewFromInt(95, 1, "€").FloatAmount(), selection.CartSplit().ChargesByType().GetByTypeForced(domain.ChargeTypeGiftCard).Value.FloatAmount())
+	assert.Equal(t, domain.NewFromInt(5, 1, "€").FloatAmount(), selection.CartSplit().ChargesByType().GetByTypeForced(domain.ChargeTypeMain).Value.FloatAmount())
+
+	// check item charges for items
+	assert.Equal(t, 2, len(selection.ItemSplit().CartItems))
+	for _, split := range selection.ItemSplit().CartItems {
+		_, found := split.ChargesByType().GetByType(domain.ChargeTypeMain)
+		assert.False(t, found)
+	}
+
+	// check item charges for shipping
+	assert.Equal(t, 1, len(selection.ItemSplit().ShippingItems))
+	for _, split := range selection.ItemSplit().ShippingItems {
+		_, found := split.ChargesByType().GetByType(domain.ChargeTypeMain)
+		assert.False(t, found)
+	}
+
+	// based on our strategy the only thing we pay with a main charge should be a total item
+	items := selection.ItemSplit().TotalItems
+	charge, found := items["1"].ChargesByType().GetByType(domain.ChargeTypeMain)
+	assert.True(t, found)
+	assert.Equal(t, domain.NewFromInt(5, 1, "€").GetPayable(), charge.Price)
+}

--- a/cart/domain/cart/paymentselection_wb_test.go
+++ b/cart/domain/cart/paymentselection_wb_test.go
@@ -128,7 +128,7 @@ func Test_CanBuildSimpleSelectionWithGiftCard(t *testing.T) {
 
 }
 
-func Test_CanBuildSimpleSelectionWithGiftCard2(t *testing.T) {
+func Test_CanBuildSimpleSelectionWithGiftCardFullPayment(t *testing.T) {
 	cart := Cart{
 		Deliveries: []Delivery{
 			{
@@ -160,7 +160,9 @@ func Test_CanBuildSimpleSelectionWithGiftCard2(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, domain.NewFromInt(1198, 100, "€").FloatAmount(), selection.TotalValue().FloatAmount())
 	assert.Equal(t, domain.NewFromInt(1198, 100, "€").FloatAmount(), selection.CartSplit().ChargesByType().GetByTypeForced(domain.ChargeTypeGiftCard).Value.FloatAmount())
-	assert.Equal(t, domain.NewFromInt(0, 100, "€").FloatAmount(), selection.CartSplit().ChargesByType().GetByTypeForced(domain.ChargeTypeMain).Value.FloatAmount())
+
+	_, found := selection.CartSplit().ChargesByType().GetByType(domain.ChargeTypeMain)
+	assert.False(t, found, "cart fully payed with gift card, there should be no main charge left")
 }
 
 func Test_CanCalculateGiftCardChargeWithRest(t *testing.T) {


### PR DESCRIPTION
Currently for the calculation of splitted charges we need zero charges. These charges do not make sense for a clients payment (0 charges cannot be payed). 
Therefore before the payment selection is generated for the client I suggest to filter out 
zero charges.