### PR TITLE
cart: Fix typo 'BillingAdress' to 'BillingAddress'

### DIFF
--- a/cart/Changelog.md
+++ b/cart/Changelog.md
@@ -26,3 +26,6 @@
   * Changed visibility of `NewSimplePaymentSelection` to private, please use `NewDefaultPaymentSelection` instead
   * Update ChargeQualifier, add additional Reference string field
   * Add support for multiple charges of the same type (unique Reference needed)
+  
+# 8. August 2019
+* Renamed 'cart.BillingAdress' to 'cart.BillingAddress'

--- a/cart/domain/cart/cart.go
+++ b/cart/domain/cart/cart.go
@@ -23,8 +23,8 @@ type (
 		//EntityID is a second identifier that may be used by some backends
 		EntityID string
 
-		//BillingAdress - the main billing address (relevant for all payments/invoices)
-		BillingAdress *Address
+		//BillingAddress - the main billing address (relevant for all payments/invoices)
+		BillingAddress *Address
 
 		//Purchaser - additional infos for the legal contact person in this order
 		Purchaser *Person
@@ -590,10 +590,10 @@ func (b *Builder) SetReservedOrderID(id string) *Builder {
 	return b
 }
 
-// SetBillingAdress - optional
-func (b *Builder) SetBillingAdress(a Address) *Builder {
+// SetBillingAddress - optional
+func (b *Builder) SetBillingAddress(a Address) *Builder {
 	b.init()
-	b.cartInBuilding.BillingAdress = &a
+	b.cartInBuilding.BillingAddress = &a
 
 	return b
 }

--- a/cart/infrastructure/InMemoryBehaviour.go
+++ b/cart/infrastructure/InMemoryBehaviour.go
@@ -259,7 +259,7 @@ func (cob *InMemoryBehaviour) UpdatePurchaser(ctx context.Context, cart *domainc
 // UpdateBillingAddress - updates address
 func (cob *InMemoryBehaviour) UpdateBillingAddress(ctx context.Context, cart *domaincart.Cart, billingAddress domaincart.Address) (*domaincart.Cart, domaincart.DeferEvents, error) {
 
-	cart.BillingAdress = &billingAddress
+	cart.BillingAddress = &billingAddress
 
 	err := cob.cartStorage.StoreCart(cart)
 	if err != nil {

--- a/cart/interfaces/controller/forms/billingform.go
+++ b/cart/interfaces/controller/forms/billingform.go
@@ -61,8 +61,8 @@ func (p *BillingAddressFormService) GetFormData(ctx context.Context, req *web.Re
 	}
 	cart, err := p.applicationCartReceiverService.ViewCart(ctx, req.Session())
 	if err == nil {
-		if cart.BillingAdress != nil {
-			billingAddressForm.LoadFromCartAddress(*cart.BillingAdress)
+		if cart.BillingAddress != nil {
+			billingAddressForm.LoadFromCartAddress(*cart.BillingAddress)
 		}
 	}
 	return BillingAddressForm(billingAddressForm), nil

--- a/checkout/application/orderService.go
+++ b/checkout/application/orderService.go
@@ -222,7 +222,7 @@ func (os *OrderService) GetContactMail(cart cart.Cart) string {
 	//Get Email from either the cart
 	shippingEmail := cart.GetMainShippingEMail()
 	if shippingEmail == "" {
-		shippingEmail = cart.BillingAdress.Email
+		shippingEmail = cart.BillingAddress.Email
 	}
 	return shippingEmail
 }


### PR DESCRIPTION
Fix typo in accordance to bug:
https://targetprocess.aoe.com/restui/board.aspx?#page=bug/203974&appConfig=eyJhY2lkIjoiNDc3MUI4MzkxNjdDQkZERTVFRTI2REQzQTY4NUNEMEYifQ

This does break flamingo-om3 and KSO.
AKL is unaffected.
