### PR TITLE
payment/checkout: Enable payment / checkout to early place order  and show a robust payment page

### DIFF
--- a/cart/application/cartReceiver.go
+++ b/cart/application/cartReceiver.go
@@ -63,6 +63,33 @@ func (cs *CartReceiverService) Inject(
 	}
 }
 
+// RestoreCart restores a previously used guest / customer cart
+func (cs *CartReceiverService) RestoreCart(ctx context.Context, session *web.Session, cartToRestore *cart.Cart) (*cartDomain.Cart, error) {
+	if cs.userService.IsLoggedIn(ctx, session) {
+		auth, err := cs.authManager.Auth(ctx, session)
+		if err != nil {
+			return nil, err
+		}
+
+		restoredCart, err := cs.customerCartService.RestoreCart(ctx, auth, cartToRestore)
+		if err != nil {
+			return nil, err
+		}
+
+		cs.storeCartInCacheIfCacheIsEnabled(ctx, session, restoredCart)
+		return restoredCart, nil
+	}
+
+	restoredCart, err := cs.guestCartService.RestoreCart(ctx, cartToRestore)
+	if err != nil {
+		return nil, err
+	}
+
+	session.Store(GuestCartSessionKey, restoredCart.ID)
+	cs.storeCartInCacheIfCacheIsEnabled(ctx, session, restoredCart)
+	return restoredCart, nil
+}
+
 // IsLoggedIn returns the logged in state
 func (cs *CartReceiverService) IsLoggedIn(ctx context.Context, session *web.Session) bool {
 	return cs.userService.IsLoggedIn(ctx, session)
@@ -208,7 +235,7 @@ func (cs *CartReceiverService) getExistingGuestCart(ctx context.Context, session
 			cs.logger.WithContext(ctx).Error(err)
 		}
 	}
-	
+
 	if err != nil || !found {
 		cart, err = cs.getSessionGuestCart(ctx, session)
 

--- a/cart/application/cartReceiver.go
+++ b/cart/application/cartReceiver.go
@@ -64,7 +64,7 @@ func (cs *CartReceiverService) Inject(
 }
 
 // RestoreCart restores a previously used guest / customer cart
-func (cs *CartReceiverService) RestoreCart(ctx context.Context, session *web.Session, cartToRestore *cart.Cart) (*cartDomain.Cart, error) {
+func (cs *CartReceiverService) RestoreCart(ctx context.Context, session *web.Session, cartToRestore cart.Cart) (*cartDomain.Cart, error) {
 	if cs.userService.IsLoggedIn(ctx, session) {
 		auth, err := cs.authManager.Auth(ctx, session)
 		if err != nil {

--- a/cart/application/cartReceiver_test.go
+++ b/cart/application/cartReceiver_test.go
@@ -48,7 +48,7 @@ func (m *MockGuestCartServiceAdapter) GetModifyBehaviour(context.Context) (cartD
 	return new(cartInfrastructure.InMemoryBehaviour), nil
 }
 
-func (m *MockGuestCartServiceAdapter) RestoreCart(ctx context.Context, cart *cartDomain.Cart) (*cartDomain.Cart, error) {
+func (m *MockGuestCartServiceAdapter) RestoreCart(ctx context.Context, cart cartDomain.Cart) (*cartDomain.Cart, error) {
 	panic("implement me")
 }
 
@@ -74,7 +74,7 @@ func (m *MockGuestCartServiceAdapterError) GetModifyBehaviour(context.Context) (
 	return new(cartInfrastructure.InMemoryBehaviour), nil
 }
 
-func (m *MockGuestCartServiceAdapterError) RestoreCart(ctx context.Context, cart *cartDomain.Cart) (*cartDomain.Cart, error) {
+func (m *MockGuestCartServiceAdapterError) RestoreCart(ctx context.Context, cart cartDomain.Cart) (*cartDomain.Cart, error) {
 	panic("implement me")
 }
 
@@ -99,7 +99,7 @@ func (m *MockCustomerCartService) GetCart(ctx context.Context, auth domain.Auth,
 	}, nil
 }
 
-func (m *MockCustomerCartService) RestoreCart(ctx context.Context, auth domain.Auth, cart *cartDomain.Cart) (*cartDomain.Cart, error) {
+func (m *MockCustomerCartService) RestoreCart(ctx context.Context, auth domain.Auth, cart cartDomain.Cart) (*cartDomain.Cart, error) {
 	panic("implement me")
 }
 

--- a/cart/application/cartReceiver_test.go
+++ b/cart/application/cartReceiver_test.go
@@ -8,7 +8,6 @@ import (
 	"flamingo.me/flamingo-commerce/v3/cart/domain/placeorder"
 	"flamingo.me/flamingo-commerce/v3/cart/domain/validation"
 
-
 	"reflect"
 	"testing"
 
@@ -49,6 +48,15 @@ func (m *MockGuestCartServiceAdapter) GetModifyBehaviour(context.Context) (cartD
 	return new(cartInfrastructure.InMemoryBehaviour), nil
 }
 
+func (m *MockGuestCartServiceAdapter) RestoreCart(ctx context.Context, cart *cartDomain.Cart) (*cartDomain.Cart, error) {
+	panic("implement me")
+}
+
+var (
+	// test interface implementation
+	_ cartDomain.GuestCartService = (*MockGuestCartServiceAdapterError)(nil)
+)
+
 type (
 	// MockGuestCartServiceAdapter with error on GetCart
 	MockGuestCartServiceAdapterError struct{}
@@ -64,6 +72,10 @@ func (m *MockGuestCartServiceAdapterError) GetNewCart(ctx context.Context) (*car
 
 func (m *MockGuestCartServiceAdapterError) GetModifyBehaviour(context.Context) (cartDomain.ModifyBehaviour, error) {
 	return new(cartInfrastructure.InMemoryBehaviour), nil
+}
+
+func (m *MockGuestCartServiceAdapterError) RestoreCart(ctx context.Context, cart *cartDomain.Cart) (*cartDomain.Cart, error) {
+	panic("implement me")
 }
 
 // MockCustomerCartService
@@ -85,6 +97,10 @@ func (m *MockCustomerCartService) GetCart(ctx context.Context, auth domain.Auth,
 	return &cartDomain.Cart{
 		ID: "mock_customer_cart",
 	}, nil
+}
+
+func (m *MockCustomerCartService) RestoreCart(ctx context.Context, auth domain.Auth, cart *cartDomain.Cart) (*cartDomain.Cart, error) {
+	panic("implement me")
 }
 
 // MockProductService

--- a/cart/application/cartReceiver_test.go
+++ b/cart/application/cartReceiver_test.go
@@ -2,17 +2,15 @@ package application_test
 
 import (
 	"context"
-
-	"flamingo.me/flamingo-commerce/v3/cart/domain/decorator"
-	"flamingo.me/flamingo-commerce/v3/cart/domain/events"
-	"flamingo.me/flamingo-commerce/v3/cart/domain/placeorder"
-	"flamingo.me/flamingo-commerce/v3/cart/domain/validation"
-
 	"reflect"
 	"testing"
 
 	cartApplication "flamingo.me/flamingo-commerce/v3/cart/application"
 	cartDomain "flamingo.me/flamingo-commerce/v3/cart/domain/cart"
+	"flamingo.me/flamingo-commerce/v3/cart/domain/decorator"
+	"flamingo.me/flamingo-commerce/v3/cart/domain/events"
+	"flamingo.me/flamingo-commerce/v3/cart/domain/placeorder"
+	"flamingo.me/flamingo-commerce/v3/cart/domain/validation"
 	cartInfrastructure "flamingo.me/flamingo-commerce/v3/cart/infrastructure"
 	productDomain "flamingo.me/flamingo-commerce/v3/product/domain"
 	authApplication "flamingo.me/flamingo/v3/core/oauth/application"
@@ -49,7 +47,9 @@ func (m *MockGuestCartServiceAdapter) GetModifyBehaviour(context.Context) (cartD
 }
 
 func (m *MockGuestCartServiceAdapter) RestoreCart(ctx context.Context, cart cartDomain.Cart) (*cartDomain.Cart, error) {
-	panic("implement me")
+	restoredCart := cart
+	restoredCart.ID = "1111"
+	return &restoredCart, nil
 }
 
 var (
@@ -75,7 +75,7 @@ func (m *MockGuestCartServiceAdapterError) GetModifyBehaviour(context.Context) (
 }
 
 func (m *MockGuestCartServiceAdapterError) RestoreCart(ctx context.Context, cart cartDomain.Cart) (*cartDomain.Cart, error) {
-	panic("implement me")
+	return nil, errors.New("defective")
 }
 
 // MockCustomerCartService
@@ -120,14 +120,17 @@ func (m *MockProductService) Get(ctx context.Context, marketplaceCode string) (p
 // MockCartCache
 
 type (
-	MockCartCache struct{}
+	MockCartCache struct {
+		CachedCart *cartDomain.Cart
+	}
 )
 
 func (m *MockCartCache) GetCart(context.Context, *web.Session, cartApplication.CartCacheIdentifier) (*cartDomain.Cart, error) {
-	return &cartDomain.Cart{}, nil
+	return m.CachedCart, nil
 }
 
-func (m *MockCartCache) CacheCart(context.Context, *web.Session, cartApplication.CartCacheIdentifier, *cartDomain.Cart) error {
+func (m *MockCartCache) CacheCart(ctx context.Context, s *web.Session, cci cartApplication.CartCacheIdentifier, cart *cartDomain.Cart) error {
+	m.CachedCart = cart
 	return nil
 }
 
@@ -193,6 +196,22 @@ type (
 
 func (m *MockDeliveryInfoBuilder) BuildByDeliveryCode(deliveryCode string) (*cartDomain.DeliveryInfo, error) {
 	return &cartDomain.DeliveryInfo{}, nil
+}
+
+type (
+	MockUserService struct{}
+)
+
+var _ authApplication.UserServiceInterface = (*MockUserService)(nil)
+
+func (m *MockUserService) GetUser(ctx context.Context, session *web.Session) *domain.User {
+	return &domain.User{
+		Name: "Test",
+	}
+}
+
+func (m *MockUserService) IsLoggedIn(ctx context.Context, session *web.Session) bool {
+	return true
 }
 
 func TestCartReceiverService_ShouldHaveGuestCart(t *testing.T) {
@@ -707,6 +726,196 @@ func TestCartReceiverService_GetDecoratedCart(t *testing.T) {
 				t.Errorf("CartReceiverService.GetDecoratedCart() got1 = %v, wantType0 %v", got1, tt.wantType1)
 
 				return
+			}
+		})
+	}
+}
+
+func TestCartReceiverService_RestoreCart(t *testing.T) {
+	type fields struct {
+		guestCartService     cartDomain.GuestCartService
+		customerCartService  cartDomain.CustomerCartService
+		cartDecoratorFactory *decorator.DecoratedCartFactory
+		authManager          *authApplication.AuthManager
+		userService          authApplication.UserServiceInterface
+		eventRouter          flamingo.EventRouter
+		logger               flamingo.Logger
+		cartCache            cartApplication.CartCache
+	}
+	type args struct {
+		ctx           context.Context
+		session       *web.Session
+		cartToRestore cartDomain.Cart
+	}
+	tests := []struct {
+		name                   string
+		fields                 fields
+		args                   args
+		want                   *cartDomain.Cart
+		wantErr                bool
+		wantGuestCartSessionID bool
+		wantCartStoredInCache  bool
+	}{
+		{
+			name: "restore guest cart without error",
+			fields: fields{
+				guestCartService: &MockGuestCartServiceAdapter{},
+				userService:      &authApplication.UserService{},
+				logger:           &flamingo.NullLogger{},
+				cartCache:        &MockCartCache{},
+			},
+			args: args{
+				ctx:     web.ContextWithSession(context.Background(), web.EmptySession()),
+				session: web.EmptySession(),
+				cartToRestore: cartDomain.Cart{
+					ID: "1234",
+					BillingAddress: &cartDomain.Address{
+						Firstname: "Test",
+						Lastname:  "Test",
+						Email:     "test@test.xy",
+					},
+					Deliveries: []cartDomain.Delivery{
+						{
+							DeliveryInfo: cartDomain.DeliveryInfo{
+								Code:     "pickup",
+								Workflow: "pickup",
+							},
+							Cartitems: []cartDomain.Item{
+								{
+									ID:                     "1",
+									ExternalReference:      "sku-1",
+									MarketplaceCode:        "sku-1",
+									VariantMarketPlaceCode: "",
+									ProductName:            "Product #1",
+									SourceID:               "",
+									Qty:                    2,
+								},
+							},
+							ShippingItem: cartDomain.ShippingItem{},
+						},
+					},
+				},
+			},
+			want: &cartDomain.Cart{
+				ID: "1111",
+				BillingAddress: &cartDomain.Address{
+					Firstname: "Test",
+					Lastname:  "Test",
+					Email:     "test@test.xy",
+				},
+				Deliveries: []cartDomain.Delivery{
+					{
+						DeliveryInfo: cartDomain.DeliveryInfo{
+							Code:     "pickup",
+							Workflow: "pickup",
+						},
+						Cartitems: []cartDomain.Item{
+							{
+								ID:                     "1",
+								ExternalReference:      "sku-1",
+								MarketplaceCode:        "sku-1",
+								VariantMarketPlaceCode: "",
+								ProductName:            "Product #1",
+								SourceID:               "",
+								Qty:                    2,
+							},
+						},
+						ShippingItem: cartDomain.ShippingItem{},
+					},
+				},
+			},
+			wantErr:                false,
+			wantGuestCartSessionID: true,
+			wantCartStoredInCache:  true,
+		},
+		{
+			name: "restore guest cart with error",
+			fields: fields{
+				guestCartService: &MockGuestCartServiceAdapterError{},
+				userService:      &authApplication.UserService{},
+				logger:           &flamingo.NullLogger{},
+				cartCache:        &MockCartCache{},
+			},
+			args: args{
+				ctx:     web.ContextWithSession(context.Background(), web.EmptySession()),
+				session: web.EmptySession(),
+				cartToRestore: cartDomain.Cart{
+					ID: "1234",
+					BillingAddress: &cartDomain.Address{
+						Firstname: "Test",
+						Lastname:  "Test",
+						Email:     "test@test.xy",
+					},
+					Deliveries: []cartDomain.Delivery{
+						{
+							DeliveryInfo: cartDomain.DeliveryInfo{
+								Code:     "pickup",
+								Workflow: "pickup",
+							},
+							Cartitems: []cartDomain.Item{
+								{
+									ID:                     "1",
+									ExternalReference:      "sku-1",
+									MarketplaceCode:        "sku-1",
+									VariantMarketPlaceCode: "",
+									ProductName:            "Product #1",
+									SourceID:               "",
+									Qty:                    2,
+								},
+							},
+							ShippingItem: cartDomain.ShippingItem{},
+						},
+					},
+				},
+			},
+			want:                   nil,
+			wantErr:                true,
+			wantGuestCartSessionID: false,
+			wantCartStoredInCache:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := &cartApplication.CartReceiverService{}
+			cs.Inject(
+				tt.fields.guestCartService,
+				tt.fields.customerCartService,
+				tt.fields.cartDecoratorFactory,
+				tt.fields.authManager,
+				tt.fields.userService,
+				tt.fields.logger,
+				nil,
+				&struct {
+					CartCache cartApplication.CartCache `inject:",optional"`
+				}{
+					CartCache: tt.fields.cartCache,
+				},
+			)
+			got, err := cs.RestoreCart(tt.args.ctx, tt.args.session, tt.args.cartToRestore)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RestoreCart() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("RestoreCart() got = %v, want %v", got, tt.want)
+			}
+
+			sessionGot, found := tt.args.session.Load(cartApplication.GuestCartSessionKey)
+			if found != tt.wantGuestCartSessionID {
+				t.Error("GuestCartID not found in session")
+			}
+
+			if found == true && tt.want != nil {
+				if !reflect.DeepEqual(tt.want.ID, sessionGot) {
+					t.Errorf("GuestCartID in session does not match restored cart got = %v, want %v", got, tt.wantGuestCartSessionID)
+				}
+			}
+
+			if tt.wantCartStoredInCache && tt.fields.cartCache != nil {
+				cart, _ := tt.fields.cartCache.GetCart(nil, nil, cartApplication.CartCacheIdentifier{})
+				if cart == nil {
+					t.Error("Cart not found in cart cache")
+				}
 			}
 		})
 	}

--- a/cart/application/cartService.go
+++ b/cart/application/cartService.go
@@ -793,6 +793,23 @@ func (cs *CartService) PlaceOrder(ctx context.Context, session *web.Session, pay
 	return placeOrderInfos, err
 }
 
+// CancelOrder cancels a previously placed order and restores the cart content
+func (cs *CartService) CancelOrder(ctx context.Context, session *web.Session, orderInfos placeorder.PlacedOrderInfos, cart *cartDomain.Cart) (*cartDomain.Cart, error) {
+	err := cs.placeOrderService.CancelOrder(ctx, orderInfos)
+	if err != nil {
+		cs.logger.Error(fmt.Sprintf("couldn't cancel order %q, err: %v", orderInfos, err))
+		return nil, err
+	}
+
+	restoredCart, err := cs.cartReceiverService.RestoreCart(ctx, session, cart)
+	if err != nil {
+		cs.logger.Error(fmt.Sprintf("couldn't restore cart err: %v", err))
+		return nil, err
+	}
+
+	return restoredCart, nil
+}
+
 // GetDefaultDeliveryCode returns the configured default deliverycode
 func (cs *CartService) GetDefaultDeliveryCode() string {
 	return cs.defaultDeliveryCode

--- a/cart/application/cartService.go
+++ b/cart/application/cartService.go
@@ -794,7 +794,7 @@ func (cs *CartService) PlaceOrder(ctx context.Context, session *web.Session, pay
 }
 
 // CancelOrder cancels a previously placed order and restores the cart content
-func (cs *CartService) CancelOrder(ctx context.Context, session *web.Session, orderInfos placeorder.PlacedOrderInfos, cart *cartDomain.Cart) (*cartDomain.Cart, error) {
+func (cs *CartService) CancelOrder(ctx context.Context, session *web.Session, orderInfos placeorder.PlacedOrderInfos, cart cartDomain.Cart) (*cartDomain.Cart, error) {
 	err := cs.placeOrderService.CancelOrder(ctx, orderInfos)
 	if err != nil {
 		cs.logger.Error(fmt.Sprintf("couldn't cancel order %q, err: %v", orderInfos, err))

--- a/cart/domain/cart/cartServicePorts.go
+++ b/cart/domain/cart/cartServicePorts.go
@@ -16,16 +16,21 @@ type (
 		// GetModifyBehaviour gets the behaviour for the guest cart service
 		GetModifyBehaviour(context.Context) (ModifyBehaviour, error)
 		GetCart(ctx context.Context, cartID string) (*Cart, error)
-
-		//GetNewCart - should return a new guest cart (including the id of the cart)
+		// GetNewCart - should return a new guest cart (including the id of the cart)
 		GetNewCart(ctx context.Context) (*Cart, error)
+		// RestoreCart restores a previously used guest cart with all its content.
+		// Depending on the used adapter this can lead to a new Cart.ID
+		RestoreCart(ctx context.Context, cart *Cart) (*Cart, error)
 	}
 
-	// CustomerCartService  interface - Secondary PORT
+	// CustomerCartService interface - Secondary PORT
 	CustomerCartService interface {
 		// GetModifyBehaviour gets the behaviour for the customer cart service
 		GetModifyBehaviour(context.Context, domain.Auth) (ModifyBehaviour, error)
 		GetCart(ctx context.Context, auth domain.Auth, cartID string) (*Cart, error)
+		// RestoreCart restores a previously used customer cart with all its content.
+		// Depending on the used adapter this can lead to a new Cart.ID
+		RestoreCart(ctx context.Context, auth domain.Auth, cart *Cart) (*Cart, error)
 	}
 
 	// DeferEvents represents events that should be dispatched after a cart modify call

--- a/cart/domain/cart/cartServicePorts.go
+++ b/cart/domain/cart/cartServicePorts.go
@@ -20,7 +20,7 @@ type (
 		GetNewCart(ctx context.Context) (*Cart, error)
 		// RestoreCart restores a previously used guest cart with all its content.
 		// Depending on the used adapter this can lead to a new Cart.ID
-		RestoreCart(ctx context.Context, cart *Cart) (*Cart, error)
+		RestoreCart(ctx context.Context, cart Cart) (*Cart, error)
 	}
 
 	// CustomerCartService interface - Secondary PORT
@@ -30,7 +30,7 @@ type (
 		GetCart(ctx context.Context, auth domain.Auth, cartID string) (*Cart, error)
 		// RestoreCart restores a previously used customer cart with all its content.
 		// Depending on the used adapter this can lead to a new Cart.ID
-		RestoreCart(ctx context.Context, auth domain.Auth, cart *Cart) (*Cart, error)
+		RestoreCart(ctx context.Context, auth domain.Auth, cart Cart) (*Cart, error)
 	}
 
 	// DeferEvents represents events that should be dispatched after a cart modify call

--- a/cart/domain/placeorder/placeorder.go
+++ b/cart/domain/placeorder/placeorder.go
@@ -2,6 +2,7 @@ package placeorder
 
 import (
 	"context"
+
 	"flamingo.me/flamingo-commerce/v3/cart/domain/cart"
 	price "flamingo.me/flamingo-commerce/v3/price/domain"
 	oauth "flamingo.me/flamingo/v3/core/oauth/domain"
@@ -13,6 +14,8 @@ type (
 		PlaceGuestCart(ctx context.Context, cart *cart.Cart, payment *Payment) (PlacedOrderInfos, error)
 		PlaceCustomerCart(ctx context.Context, auth oauth.Auth, cart *cart.Cart, payment *Payment) (PlacedOrderInfos, error)
 		ReserveOrderID(ctx context.Context, cart *cart.Cart) (string, error)
+		// CancelOrder cancels an previously placed order and returns the used cart
+		CancelOrder(ctx context.Context, orderInfos PlacedOrderInfos) error
 	}
 	// Payment represents all payments done for the cart and which items have been purchased by what method
 	Payment struct {
@@ -146,11 +149,11 @@ func (c ChargeByItem) ChargeForTotal(itemid string) (*price.Charge, bool) {
 func (c ChargeByItem) TotalItems() map[string]price.Charge {
 	return c.totalItems
 }
+
 //ShippingItems - returns ShippingItems
 func (c ChargeByItem) ShippingItems() map[string]price.Charge {
 	return c.shippingItems
 }
-
 
 //AddCartItem - modifies the current instance and adds a charge for an item
 func (c ChargeByItem) AddCartItem(id string, charge price.Charge) ChargeByItem {
@@ -160,7 +163,6 @@ func (c ChargeByItem) AddCartItem(id string, charge price.Charge) ChargeByItem {
 	c.cartItems[id] = charge
 	return c
 }
-
 
 //AddTotalItem - modifies the current instance and adds a charge for an item
 func (c ChargeByItem) AddTotalItem(id string, charge price.Charge) ChargeByItem {

--- a/cart/infrastructure/email/emailplaceorder.go
+++ b/cart/infrastructure/email/emailplaceorder.go
@@ -11,7 +11,7 @@ import (
 )
 
 type (
-	// PlaceOrderServiceAdapter provides an implementation of the Service as email adpater
+	// PlaceOrderServiceAdapter provides an implementation of the Service as email adapter
 	//  TODO - this example adapter need to be implemented
 	PlaceOrderServiceAdapter struct {
 		emailAddress string
@@ -64,7 +64,13 @@ func (e *PlaceOrderServiceAdapter) PlaceCustomerCart(ctx context.Context, auth a
 	return placedOrders, nil
 }
 
-//ReserveOrderID - returns the reserved order id
-func (e *PlaceOrderServiceAdapter) ReserveOrderID(ctx context.Context, cart *cartDomain.Cart) (string,error) {
+// ReserveOrderID returns the reserved order id
+func (e *PlaceOrderServiceAdapter) ReserveOrderID(ctx context.Context, cart *cartDomain.Cart) (string, error) {
 	return cart.ID, nil
+}
+
+// CancelOrder cancels a placed order
+func (e *PlaceOrderServiceAdapter) CancelOrder(ctx context.Context, orderInfos placeorder.PlacedOrderInfos) error {
+	// since we don't actual place orders we just return nil here
+	return nil
 }

--- a/cart/infrastructure/inMemoryCustomerCartserviceAdapter.go
+++ b/cart/infrastructure/inMemoryCustomerCartserviceAdapter.go
@@ -35,3 +35,11 @@ func (gcs *InMemoryCustomerCartService) GetCart(ctx context.Context, auth domain
 func (gcs *InMemoryCustomerCartService) GetModifyBehaviour(context.Context, domain.Auth) (cart.ModifyBehaviour, error) {
 	return gcs.inMemoryBehaviour, nil
 }
+
+// RestoreCart restores a previously used cart
+func (gcs *InMemoryCustomerCartService) RestoreCart(ctx context.Context, auth domain.Auth, cart *cart.Cart) (*cart.Cart, error) {
+	customerCart := cart
+
+	err := gcs.inMemoryBehaviour.StoreCart(customerCart)
+	return customerCart, err
+}

--- a/cart/infrastructure/inMemoryCustomerCartserviceAdapter.go
+++ b/cart/infrastructure/inMemoryCustomerCartserviceAdapter.go
@@ -37,9 +37,9 @@ func (gcs *InMemoryCustomerCartService) GetModifyBehaviour(context.Context, doma
 }
 
 // RestoreCart restores a previously used cart
-func (gcs *InMemoryCustomerCartService) RestoreCart(ctx context.Context, auth domain.Auth, cart *cart.Cart) (*cart.Cart, error) {
+func (gcs *InMemoryCustomerCartService) RestoreCart(ctx context.Context, auth domain.Auth, cart cart.Cart) (*cart.Cart, error) {
 	customerCart := cart
 
-	err := gcs.inMemoryBehaviour.StoreCart(customerCart)
-	return customerCart, err
+	err := gcs.inMemoryBehaviour.StoreCart(&customerCart)
+	return &customerCart, err
 }

--- a/cart/infrastructure/inMemoryGuestCartserviceAdapter.go
+++ b/cart/infrastructure/inMemoryGuestCartserviceAdapter.go
@@ -11,7 +11,7 @@ import (
 type (
 	// InMemoryGuestCartService defines the in memory guest cart service
 	InMemoryGuestCartService struct {
-		inMemoryCartOrderBehaviour *InMemoryBehaviour
+		inMemoryBehaviour *InMemoryBehaviour
 	}
 )
 
@@ -23,12 +23,12 @@ var (
 func (gcs *InMemoryGuestCartService) Inject(
 	InMemoryCartOrderBehaviour *InMemoryBehaviour,
 ) {
-	gcs.inMemoryCartOrderBehaviour = InMemoryCartOrderBehaviour
+	gcs.inMemoryBehaviour = InMemoryCartOrderBehaviour
 }
 
 // GetCart fetches a cart from the in memory guest cart service
 func (gcs *InMemoryGuestCartService) GetCart(ctx context.Context, cartID string) (*cart.Cart, error) {
-	cart, err := gcs.inMemoryCartOrderBehaviour.GetCart(ctx, cartID)
+	cart, err := gcs.inMemoryBehaviour.GetCart(ctx, cartID)
 	return cart, err
 }
 
@@ -38,11 +38,20 @@ func (gcs *InMemoryGuestCartService) GetNewCart(ctx context.Context) (*cart.Cart
 		ID: strconv.Itoa(rand.Int()),
 	}
 
-	error := gcs.inMemoryCartOrderBehaviour.StoreCart(guestCart)
-	return guestCart, error
+	err := gcs.inMemoryBehaviour.StoreCart(guestCart)
+	return guestCart, err
 }
 
 // GetModifyBehaviour returns the cart order behaviour of the service
 func (gcs *InMemoryGuestCartService) GetModifyBehaviour(context.Context) (cart.ModifyBehaviour, error) {
-	return gcs.inMemoryCartOrderBehaviour, nil
+	return gcs.inMemoryBehaviour, nil
+}
+
+// RestoreCart restores a previously used guest cart
+func (gcs *InMemoryGuestCartService) RestoreCart(ctx context.Context, cart *cart.Cart) (*cart.Cart, error) {
+	guestCart := cart
+	guestCart.ID = strconv.Itoa(rand.Int())
+
+	err := gcs.inMemoryBehaviour.StoreCart(guestCart)
+	return guestCart, err
 }

--- a/cart/infrastructure/inMemoryGuestCartserviceAdapter.go
+++ b/cart/infrastructure/inMemoryGuestCartserviceAdapter.go
@@ -48,10 +48,10 @@ func (gcs *InMemoryGuestCartService) GetModifyBehaviour(context.Context) (cart.M
 }
 
 // RestoreCart restores a previously used guest cart
-func (gcs *InMemoryGuestCartService) RestoreCart(ctx context.Context, cart *cart.Cart) (*cart.Cart, error) {
+func (gcs *InMemoryGuestCartService) RestoreCart(ctx context.Context, cart cart.Cart) (*cart.Cart, error) {
 	guestCart := cart
 	guestCart.ID = strconv.Itoa(rand.Int())
 
-	err := gcs.inMemoryBehaviour.StoreCart(guestCart)
-	return guestCart, err
+	err := gcs.inMemoryBehaviour.StoreCart(&guestCart)
+	return &guestCart, err
 }

--- a/checkout/Changelog.md
+++ b/checkout/Changelog.md
@@ -1,0 +1,3 @@
+# 20. August 2019
+* Add new PaymentAction which processes the payment flow status
+* Add option to place an order as early as the payment is started

--- a/checkout/Readme.md
+++ b/checkout/Readme.md
@@ -16,20 +16,30 @@ This module implements controller and services for the following checkout flow (
 1. Checkout Action
     * this is the main step, and the template should render the big checkout form (or at least the parts that are interesting). 
     * on submit and if everything was valid:
-        * Action will update the cart - specifically the following informations:
+        * Action will update the cart - specifically the following information:
             * Update billing (on cart level)
             * Update deliveryinfos on (each) delivery in the cart (e.g. used to set shipping address)
-            * Select Payment Gateway and prefered Payment Method
+            * Select Payment Gateway and preferred Payment Method
             * Optional Save the wished payment split for each item in the cart
-            * Optional add Vouchers (may already happend before)            
-        * Forward to next Action
+            * Optional add Vouchers/GiftCards (may already happened before)            
+        * If Review Action is skipped:
+            * Start payment and place order if needed (EarlyPlaceOrder)
+            * Redirect to Payment Action
+        * If Review Step is not skipped:
+            * Redirect to Review Action
 1. Review Action (Optional)
-    * Renderes "review" template that can be used to review the cart
-    * After confirming:
-        * Action will give control to the selected PaymentFlow (see payment module)
+    * Renders "review" template that can be used to review the cart
+    * After confirming start the payment and place order if needed (EarlyPlaceOrder)
+1. Payment Action
+    * Ask Payment Gateway about FlowStatus and handle it
+    * FlowStatus:
+        * Error / Abort by customer: Redirect to checkout and reopen cart if needed
+        * Success / Approved: Redirect to PalceOrderAction
+        * Unapproved: Render payment template and let frontend decide how to continue in flow (e.g. redirect to payment provider)
 1. Place Order Action
-    * Get PaymentFlow Result
-    * Place Order and forward to success
+    * Check if order already placed (EarlyPlaceOrder)
+    * If order not already placed check FlowStatus and place order
+    * Put order infos in flash message and redirect to Success Action
 1. Success Action:
     * Renders order success template
 

--- a/checkout/application/orderService.go
+++ b/checkout/application/orderService.go
@@ -337,6 +337,7 @@ func (os *OrderService) preparePlaceOrderInfo(ctx context.Context, currentCart c
 	placeOrderInfo := &PlaceOrderInfo{
 		ContactEmail: email,
 		PlacedOrders: placedOrderInfos,
+		Cart:         currentCart,
 	}
 
 	for _, transaction := range cartPayment.Transactions {

--- a/checkout/application/orderService.go
+++ b/checkout/application/orderService.go
@@ -38,7 +38,9 @@ type (
 		PaymentInfos []PlaceOrderPaymentInfo
 		PlacedOrders placeorder.PlacedOrderInfos
 		ContactEmail string
+		Cart         cart.Cart
 	}
+
 	//PlaceOrderPaymentInfo holding payment infos
 	PlaceOrderPaymentInfo struct {
 		Gateway         string
@@ -51,8 +53,11 @@ type (
 )
 
 const (
-	//PaymentFlowStandardCorrelationID - used as correlationid for the start of the payment (session scoped)
+	// PaymentFlowStandardCorrelationID used as correlationid for the start of the payment (session scoped)
 	PaymentFlowStandardCorrelationID = "checkout"
+
+	// LastPlacedOrderSessionKey is the session key for storing the last placed order
+	LastPlacedOrderSessionKey = "orderservice_last_placed"
 )
 
 var orderFailedStat = stats.Int64("flamingo-commerce/orderfailed", "my stat records 1 occurences per error", stats.UnitDimensionless)
@@ -103,20 +108,21 @@ func (os *OrderService) CurrentCartSaveInfos(ctx context.Context, session *web.S
 		os.logger.WithContext(ctx).Warn("CurrentCartSaveInfos called without billing address")
 		return errors.New("Billing Address is missing")
 	}
+
 	decoratedCart, err := os.cartReceiverService.ViewDecoratedCart(ctx, session)
 	if err != nil {
 		os.logger.WithContext(ctx).Error("CurrentCartSaveInfos GetDecoratedCart Error %v", err)
 		return err
 	}
 
-	//update Billing
+	// update Billing
 	err = os.cartService.UpdateBillingAddress(ctx, session, billingAddress)
 	if err != nil {
 		os.logger.WithContext(ctx).Error("OnStepCurrentCartPlaceOrder UpdateBillingAddress Error %v", err)
 		return err
 	}
 
-	//Update ShippingAddress on ALL Deliveries in the Cart if given
+	// Update ShippingAddress on ALL Deliveries in the Cart if given
 	// Maybe later we need to support different shipping addresses in the Checkout
 	if shippingAddress != nil {
 		for _, d := range decoratedCart.Cart.Deliveries {
@@ -131,14 +137,14 @@ func (os *OrderService) CurrentCartSaveInfos(ctx context.Context, session *web.S
 
 	}
 
-	//Update Purchaser
+	// Update Purchaser
 	err = os.cartService.UpdatePurchaser(ctx, session, purchaser, additionalData)
 	if err != nil {
 		os.logger.WithContext(ctx).Error("OnStepCurrentCartPlaceOrder UpdatePurchaser Error %v", err)
 		return err
 	}
 
-	//After setting DeliveryInfos - call SourcingEnginge (this will reload the cart and update all items!)
+	// After setting DeliveryInfos - call SourcingEnginge (this will reload the cart and update all items!)
 	err = os.SetSources(ctx, session)
 	if err != nil {
 		os.logger.WithContext(ctx).Error("OnStepCurrentCartPlaceOrder SetSources Error %v", err)
@@ -147,48 +153,8 @@ func (os *OrderService) CurrentCartSaveInfos(ctx context.Context, session *web.S
 	return nil
 }
 
-//CurrentCartPlaceOrder - use to place the current cart
-func (os *OrderService) CurrentCartPlaceOrder(ctx context.Context, session *web.Session, payment placeorder.Payment) (placeorder.PlacedOrderInfos, error) {
-	// use a background context from here on to prevent the place order canceled by context cancel
-	placeOrderContext := web.ContextWithRequest(
-		web.ContextWithSession(
-			context.Background(),
-			web.SessionFromContext(ctx),
-		),
-		web.RequestFromContext(ctx),
-	)
-
-	decoratedCart, err := os.cartReceiverService.ViewDecoratedCart(placeOrderContext, session)
-
-	if err != nil {
-		// record failcount metric
-		stats.Record(placeOrderContext, orderFailedStat.M(1))
-		os.logger.WithContext(placeOrderContext).Error("OnStepCurrentCartPlaceOrder GetDecoratedCart Error %v", err)
-		return nil, err
-	}
-
-	validationResult := os.cartService.ValidateCart(placeOrderContext, session, decoratedCart)
-	if !validationResult.IsValid() {
-		// record failcount metric
-		stats.Record(placeOrderContext, orderFailedStat.M(1))
-		os.logger.WithContext(placeOrderContext).Warn("Try to place an invalid cart")
-		return nil, errors.New("cart is invalid")
-	}
-
-	placedOrderInfos, err := os.cartService.PlaceOrder(placeOrderContext, session, &payment)
-
-	if err != nil {
-		// record failcount metric
-		stats.Record(placeOrderContext, orderFailedStat.M(1))
-		os.logger.WithContext(placeOrderContext).Error("Error during place Order:" + err.Error())
-		return nil, errors.New("error while placing the order. please contact customer support")
-	}
-	return placedOrderInfos, nil
-}
-
-// GetPaymentGateway helper
+// GetPaymentGateway tries to get the supplied payment gateway by code from the registered payment gateways
 func (os *OrderService) GetPaymentGateway(ctx context.Context, paymentGatewayCode string) (interfaces.WebCartPaymentGateway, error) {
-
 	gateway, ok := os.webCartPaymentGateways[paymentGatewayCode]
 	if !ok {
 		return nil, errors.New("Payment gateway " + paymentGatewayCode + " not found")
@@ -197,15 +163,51 @@ func (os *OrderService) GetPaymentGateway(ctx context.Context, paymentGatewayCod
 	return gateway, nil
 }
 
-//GetAvailablePaymentGateways - returns the list of registered WebCartPaymentGateway
+// GetAvailablePaymentGateways returns the list of registered WebCartPaymentGateway
 func (os *OrderService) GetAvailablePaymentGateways(ctx context.Context) map[string]interfaces.WebCartPaymentGateway {
 	return os.webCartPaymentGateways
 }
 
-//CurrentCartPlaceOrderWithPaymentProcessing - use to place the current cart
+// CurrentCartPlaceOrder places the current cart without additional payment processing
+func (os *OrderService) CurrentCartPlaceOrder(ctx context.Context, session *web.Session, cartPayment placeorder.Payment) (*PlaceOrderInfo, error) {
+	// use a background context from here on to prevent the place order canceled by context cancel
+	placeOrderContext := os.createNewBackgroundContext(ctx)
+
+	decoratedCart, err := os.cartReceiverService.ViewDecoratedCart(placeOrderContext, session)
+	if err != nil {
+		// record fail count metric
+		stats.Record(placeOrderContext, orderFailedStat.M(1))
+		os.logger.WithContext(placeOrderContext).Error("OnStepCurrentCartPlaceOrder GetDecoratedCart Error %v", err)
+		return nil, err
+	}
+
+	validationResult := os.cartService.ValidateCart(placeOrderContext, session, decoratedCart)
+	if !validationResult.IsValid() {
+		// record fail count metric
+		stats.Record(placeOrderContext, orderFailedStat.M(1))
+		os.logger.WithContext(placeOrderContext).Warn("Try to place an invalid cart")
+		return nil, errors.New("cart is invalid")
+	}
+
+	placedOrderInfos, err := os.cartService.PlaceOrder(placeOrderContext, session, &cartPayment)
+	if err != nil {
+		// record fail count metric
+		stats.Record(placeOrderContext, orderFailedStat.M(1))
+		os.logger.WithContext(placeOrderContext).Error("Error during place Order:" + err.Error())
+		return nil, errors.New("error while placing the order. please contact customer support")
+	}
+
+	placeOrderInfo := os.preparePlaceOrderInfo(ctx, decoratedCart.Cart, placedOrderInfos, cartPayment)
+	os.storeLastPlacedOrder(ctx, placeOrderInfo)
+
+	return placeOrderInfo, nil
+}
+
+// CurrentCartPlaceOrderWithPaymentProcessing places the current cart which is fetched from the context
 func (os *OrderService) CurrentCartPlaceOrderWithPaymentProcessing(ctx context.Context, session *web.Session) (*PlaceOrderInfo, error) {
 	// use a background context from here on to prevent the place order canceled by context cancel
 	placeOrderContext := os.createNewBackgroundContext(ctx)
+
 	// fetch decorated cart either via cache or freshly from cart receiver service
 	decoratedCart, err := os.cartReceiverService.ViewDecoratedCart(placeOrderContext, session)
 	if err != nil {
@@ -214,10 +216,21 @@ func (os *OrderService) CurrentCartPlaceOrderWithPaymentProcessing(ctx context.C
 		os.logger.WithContext(placeOrderContext).Warn("Cannot create decorated cart from cart")
 		return nil, errors.New("cart is invalid")
 	}
+
 	return os.placeOrderWithPaymentProcessing(placeOrderContext, decoratedCart, session)
 }
 
-// GetContactMail helper with fallback
+// CartPlaceOrderWithPaymentProcessing places the cart passed to the function
+// this function enables clients to pass a cart as is, without the usage of the cartReceiverService
+func (os *OrderService) CartPlaceOrderWithPaymentProcessing(ctx context.Context, decoratedCart *decorator.DecoratedCart,
+	session *web.Session) (*PlaceOrderInfo, error) {
+	// use a background context from here on to prevent the place order canceled by context cancel
+	placeOrderContext := os.createNewBackgroundContext(ctx)
+
+	return os.placeOrderWithPaymentProcessing(placeOrderContext, decoratedCart, session)
+}
+
+// GetContactMail returns the contact mail from the shipping address with fall back to the billing address
 func (os *OrderService) GetContactMail(cart cart.Cart) string {
 	//Get Email from either the cart
 	shippingEmail := cart.GetMainShippingEMail()
@@ -227,13 +240,34 @@ func (os *OrderService) GetContactMail(cart cart.Cart) string {
 	return shippingEmail
 }
 
-// CartPlaceOrderWithPaymentProcessing - use to place the cart passed to the function
-// this function enables clients to pass a cart as is, without the usage of the cartReceiverService
-func (os *OrderService) CartPlaceOrderWithPaymentProcessing(ctx context.Context, decoratedCart *decorator.DecoratedCart,
-	session *web.Session) (*PlaceOrderInfo, error) {
-	// use a background context from here on to prevent the place order canceled by context cancel
-	placeOrderContext := os.createNewBackgroundContext(ctx)
-	return os.placeOrderWithPaymentProcessing(placeOrderContext, decoratedCart, session)
+// storeLastPlacedOrder stores the last placed order/cart in the session
+func (os *OrderService) storeLastPlacedOrder(ctx context.Context, info *PlaceOrderInfo) {
+	session := web.SessionFromContext(ctx)
+
+	_ = session.Store(LastPlacedOrderSessionKey, info)
+}
+
+// LastPlacedOrder returns the last placed order/cart if available
+func (os *OrderService) LastPlacedOrder(ctx context.Context) (*PlaceOrderInfo, error) {
+	session := web.SessionFromContext(ctx)
+
+	lastPlacedOrder, found := session.Load(LastPlacedOrderSessionKey)
+	if found == false {
+		return nil, nil
+	}
+
+	placeOrderInfo, ok := lastPlacedOrder.(*PlaceOrderInfo)
+	if ok == false {
+		return nil, errors.New("placeOrderInfo couldn't be received from session")
+	}
+
+	return placeOrderInfo, nil
+}
+
+// ClearLastPlacedOrder clears the last placed cart, this can be useful if an cart / order is finished
+func (os *OrderService) ClearLastPlacedOrder(ctx context.Context) {
+	session := web.SessionFromContext(ctx)
+	session.Delete(LastPlacedOrderSessionKey)
 }
 
 // placeOrderWithPaymentProcessing after generating the decorated cart, the place order flow
@@ -248,7 +282,7 @@ func (os *OrderService) placeOrderWithPaymentProcessing(ctx context.Context, dec
 
 	validationResult := os.cartService.ValidateCart(ctx, session, decoratedCart)
 	if !validationResult.IsValid() {
-		// record failcount metric
+		// record fail count metric
 		stats.Record(ctx, orderFailedStat.M(1))
 		os.logger.WithContext(ctx).Warn("Try to place an invalid cart")
 		return nil, errors.New("cart is invalid")
@@ -256,6 +290,7 @@ func (os *OrderService) placeOrderWithPaymentProcessing(ctx context.Context, dec
 
 	gateway, err := os.GetPaymentGateway(ctx, decoratedCart.Cart.PaymentSelection.Gateway())
 	if err != nil {
+		// record fail count metric
 		stats.Record(ctx, orderFailedStat.M(1))
 		os.logger.WithContext(ctx).Error(fmt.Sprintf("cart.checkoutcontroller.submitaction: Error %v  Gateway: %v", err, decoratedCart.Cart.PaymentSelection.Gateway()))
 		return nil, errors.New("selected gateway not available")
@@ -265,6 +300,7 @@ func (os *OrderService) placeOrderWithPaymentProcessing(ctx context.Context, dec
 	if err != nil {
 		return nil, err
 	}
+
 	err = gateway.ConfirmResult(ctx, &decoratedCart.Cart, cartPayment)
 	if err != nil {
 		return nil, err
@@ -272,15 +308,33 @@ func (os *OrderService) placeOrderWithPaymentProcessing(ctx context.Context, dec
 
 	placedOrderInfos, err := os.cartService.PlaceOrder(ctx, session, cartPayment)
 	if err != nil {
-		// record failcount metric
+		// record fail count metric
 		stats.Record(ctx, orderFailedStat.M(1))
 		os.logger.WithContext(ctx).Error("Error during place Order:" + err.Error())
 		return nil, errors.New("error while placing the order. please contact customer support")
 	}
 
-	email := os.GetContactMail(decoratedCart.Cart)
+	placeOrderInfo := os.preparePlaceOrderInfo(ctx, decoratedCart.Cart, placedOrderInfos, *cartPayment)
+	os.storeLastPlacedOrder(ctx, placeOrderInfo)
 
-	placeOrderInfo := PlaceOrderInfo{
+	return placeOrderInfo, nil
+}
+
+// createNewBackgroundContext creates a new background context to avoid cancellation by parent context
+func (os *OrderService) createNewBackgroundContext(ctx context.Context) context.Context {
+	return web.ContextWithRequest(
+		web.ContextWithSession(
+			context.Background(),
+			web.SessionFromContext(ctx),
+		),
+		web.RequestFromContext(ctx),
+	)
+}
+
+func (os *OrderService) preparePlaceOrderInfo(ctx context.Context, currentCart cart.Cart, placedOrderInfos placeorder.PlacedOrderInfos, cartPayment placeorder.Payment) *PlaceOrderInfo {
+	email := os.GetContactMail(currentCart)
+
+	placeOrderInfo := &PlaceOrderInfo{
 		ContactEmail: email,
 		PlacedOrders: placedOrderInfos,
 	}
@@ -295,16 +349,6 @@ func (os *OrderService) placeOrderWithPaymentProcessing(ctx context.Context, dec
 			CreditCardInfo:  transaction.CreditCardInfo,
 		})
 	}
-	return &placeOrderInfo, nil
-}
 
-// createNewBackgroundContext creates a new background context to avoid cancellation by parent context
-func (os *OrderService) createNewBackgroundContext(ctx context.Context) context.Context {
-	return web.ContextWithRequest(
-		web.ContextWithSession(
-			context.Background(),
-			web.SessionFromContext(ctx),
-		),
-		web.RequestFromContext(ctx),
-	)
+	return placeOrderInfo
 }

--- a/checkout/application/orderService.go
+++ b/checkout/application/orderService.go
@@ -205,6 +205,11 @@ func (os *OrderService) CurrentCartPlaceOrder(ctx context.Context, session *web.
 	return placeOrderInfo, nil
 }
 
+// CancelOrder cancels an previously placed order and returns the cart with the order content
+func (os *OrderService) CancelOrder(ctx context.Context, session *web.Session, order *PlaceOrderInfo) (*cart.Cart, error) {
+	return os.cartService.CancelOrder(ctx, session, order.PlacedOrders, &order.Cart)
+}
+
 // CurrentCartPlaceOrderWithPaymentProcessing places the current cart which is fetched from the context
 func (os *OrderService) CurrentCartPlaceOrderWithPaymentProcessing(ctx context.Context, session *web.Session) (*PlaceOrderInfo, error) {
 	// use a background context from here on to prevent the place order canceled by context cancel

--- a/checkout/application/orderService.go
+++ b/checkout/application/orderService.go
@@ -266,6 +266,7 @@ func (os *OrderService) LastPlacedOrder(ctx context.Context) (*PlaceOrderInfo, e
 	return &placeOrderInfo, nil
 }
 
+// HasLastPlacedOrder returns if a order has been previously placed
 func (os *OrderService) HasLastPlacedOrder(ctx context.Context) bool {
 	lastPlaced, err := os.LastPlacedOrder(ctx)
 	return lastPlaced != nil && err == nil

--- a/checkout/application/orderService.go
+++ b/checkout/application/orderService.go
@@ -261,7 +261,7 @@ func (os *OrderService) placeOrderWithPaymentProcessing(ctx context.Context, dec
 		return nil, errors.New("selected gateway not available")
 	}
 
-	cartPayment, err := gateway.GetFlowResult(ctx, &decoratedCart.Cart, PaymentFlowStandardCorrelationID)
+	cartPayment, err := gateway.FlowResult(ctx, &decoratedCart.Cart, PaymentFlowStandardCorrelationID)
 	if err != nil {
 		return nil, err
 	}

--- a/checkout/application/orderService.go
+++ b/checkout/application/orderService.go
@@ -261,7 +261,7 @@ func (os *OrderService) placeOrderWithPaymentProcessing(ctx context.Context, dec
 		return nil, errors.New("selected gateway not available")
 	}
 
-	cartPayment, err := gateway.FlowResult(ctx, &decoratedCart.Cart, PaymentFlowStandardCorrelationID)
+	cartPayment, err := gateway.OrderPaymentFromFlow(ctx, &decoratedCart.Cart, PaymentFlowStandardCorrelationID)
 	if err != nil {
 		return nil, err
 	}

--- a/checkout/application/orderService_test.go
+++ b/checkout/application/orderService_test.go
@@ -1,0 +1,108 @@
+package application_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"flamingo.me/flamingo-commerce/v3/checkout/application"
+	"flamingo.me/flamingo-commerce/v3/payment/interfaces"
+	"flamingo.me/flamingo/v3/framework/flamingo"
+	"flamingo.me/flamingo/v3/framework/web"
+)
+
+func TestOrderService_LastPlacedOrder(t *testing.T) {
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *application.PlaceOrderInfo
+		wantErr bool
+	}{
+		{
+			name: "",
+			args: args{
+				ctx: contextWithPlaceOrderInfoInSession(&application.PlaceOrderInfo{
+					PaymentInfos: nil,
+					PlacedOrders: nil,
+					ContactEmail: "test@test.de",
+				}),
+			},
+			want: &application.PlaceOrderInfo{
+				PaymentInfos: nil,
+				PlacedOrders: nil,
+				ContactEmail: "test@test.de",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeGatewayProvider := func() map[string]interfaces.WebCartPaymentGateway {
+				return map[string]interfaces.WebCartPaymentGateway{}
+			}
+
+			os := &application.OrderService{}
+			os.Inject(nil, flamingo.NullLogger{}, nil, nil, nil, fakeGatewayProvider, nil)
+			got, err := os.LastPlacedOrder(tt.args.ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LastPlacedOrder() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("LastPlacedOrder() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOrderService_ClearLastPlacedOrder(t *testing.T) {
+	fakeGatewayProvider := func() map[string]interfaces.WebCartPaymentGateway {
+		return map[string]interfaces.WebCartPaymentGateway{}
+	}
+
+	os := &application.OrderService{}
+	os.Inject(nil, flamingo.NullLogger{}, nil, nil, nil, fakeGatewayProvider, nil)
+
+	want := &application.PlaceOrderInfo{
+		PaymentInfos: nil,
+		PlacedOrders: nil,
+		ContactEmail: "test@test.de",
+	}
+
+	ctx := contextWithPlaceOrderInfoInSession(&application.PlaceOrderInfo{
+		PaymentInfos: nil,
+		PlacedOrders: nil,
+		ContactEmail: "test@test.de",
+	})
+
+	got, err := os.LastPlacedOrder(ctx)
+	if err != nil {
+		t.Errorf("LastPlacedOrder() shouldn't return an error: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("LastPlacedOrder() got = %v, want %v", got, want)
+	}
+
+	os.ClearLastPlacedOrder(ctx)
+
+	got, err = os.LastPlacedOrder(ctx)
+	if err != nil {
+		t.Errorf("LastPlacedOrder() shouldn't return an error: %v", err)
+	}
+
+	if got != nil {
+		t.Errorf("LastPlacedOrder() shouldn't return an order")
+	}
+
+}
+
+func contextWithPlaceOrderInfoInSession(info *application.PlaceOrderInfo) context.Context {
+	session := web.EmptySession()
+	session.Store(application.LastPlacedOrderSessionKey, info)
+	return web.ContextWithSession(context.Background(), session)
+}

--- a/checkout/application/orderService_test.go
+++ b/checkout/application/orderService_test.go
@@ -24,7 +24,7 @@ func TestOrderService_LastPlacedOrder(t *testing.T) {
 		{
 			name: "",
 			args: args{
-				ctx: contextWithPlaceOrderInfoInSession(&application.PlaceOrderInfo{
+				ctx: contextWithPlaceOrderInfoInSession(application.PlaceOrderInfo{
 					PaymentInfos: nil,
 					PlacedOrders: nil,
 					ContactEmail: "test@test.de",
@@ -73,7 +73,7 @@ func TestOrderService_ClearLastPlacedOrder(t *testing.T) {
 		ContactEmail: "test@test.de",
 	}
 
-	ctx := contextWithPlaceOrderInfoInSession(&application.PlaceOrderInfo{
+	ctx := contextWithPlaceOrderInfoInSession(application.PlaceOrderInfo{
 		PaymentInfos: nil,
 		PlacedOrders: nil,
 		ContactEmail: "test@test.de",
@@ -101,7 +101,7 @@ func TestOrderService_ClearLastPlacedOrder(t *testing.T) {
 
 }
 
-func contextWithPlaceOrderInfoInSession(info *application.PlaceOrderInfo) context.Context {
+func contextWithPlaceOrderInfoInSession(info application.PlaceOrderInfo) context.Context {
 	session := web.EmptySession()
 	session.Store(application.LastPlacedOrderSessionKey, info)
 	return web.ContextWithSession(context.Background(), session)

--- a/checkout/interfaces/controller/checkoutcontroller.go
+++ b/checkout/interfaces/controller/checkoutcontroller.go
@@ -473,7 +473,7 @@ func (cc *CheckoutController) processPayment(ctx context.Context, r *web.Request
 
 	// payment flow requires an early place order
 	if flowResult.EarlyPlaceOrder {
-		payment, err := gateway.OrderPaymentFromFlow(ctx, &decoratedCart.Cart, flowResult)
+		payment, err := gateway.OrderPaymentFromFlow(ctx, &decoratedCart.Cart, application.PaymentFlowStandardCorrelationID)
 		if err != nil {
 			return cc.showCheckoutFormWithErrors(ctx, r, *decoratedCart, nil, err)
 		}

--- a/checkout/interfaces/controller/checkoutcontroller.go
+++ b/checkout/interfaces/controller/checkoutcontroller.go
@@ -483,6 +483,11 @@ func (cc *CheckoutController) processPayment(ctx context.Context, r *web.Request
 			return cc.showCheckoutFormWithErrors(ctx, r, *decoratedCart, nil, err)
 		}
 
+		err = cc.orderService.SetSources(ctx, session)
+		if err != nil {
+			return cc.showCheckoutFormWithErrors(ctx, r, *decoratedCart, nil, err)
+		}
+
 		_, err = cc.orderService.CurrentCartPlaceOrder(ctx, session, *payment)
 		if err != nil {
 			return cc.showCheckoutFormWithErrors(ctx, r, *decoratedCart, nil, err)

--- a/checkout/interfaces/controller/checkoutcontroller.go
+++ b/checkout/interfaces/controller/checkoutcontroller.go
@@ -589,6 +589,9 @@ func (cc *CheckoutController) PaymentAction(ctx context.Context, r *web.Request)
 		// TODO: reopen cart via cart service
 		cc.orderService.ClearLastPlacedOrder(ctx)
 		return cc.responder.RouteRedirect("checkout", nil)
+	case paymentDomain.PaymentFlowWaitingForCustomer:
+		// payment pending, waiting for customer
+		return cc.responder.Render("checkout/payment", viewData).SetNoCache()
 	default:
 		// show payment page which can react to unknown payment status
 		return cc.responder.Render("checkout/payment", viewData).SetNoCache()

--- a/checkout/module.go
+++ b/checkout/module.go
@@ -60,6 +60,9 @@ func (r *routes) Routes(registry *web.RouterRegistry) {
 	registry.HandleAny("checkout", r.controller.SubmitCheckoutAction)
 	registry.Route("/checkout", "checkout")
 
+	registry.HandleAny("checkout.payment", r.controller.PaymentAction)
+	registry.Route("/checkout/payment", "checkout.payment")
+
 	registry.HandleAny("checkout.success", r.controller.SuccessAction)
 	registry.Route("/checkout/success", "checkout.success")
 
@@ -69,8 +72,6 @@ func (r *routes) Routes(registry *web.RouterRegistry) {
 	registry.HandleAny("checkout.placeorder", r.controller.PlaceOrderAction)
 	registry.Route("/checkout/placeorder", "checkout.placeorder")
 }
-
-
 
 // Depends on other modules
 func (m *Module) Depends() []dingo.Module {

--- a/payment/Changelog.md
+++ b/payment/Changelog.md
@@ -1,0 +1,10 @@
+# 20. August 2019
+* Reworked WebCartPaymentGateway Interface
+    * Removed StartWebFlow func
+    * Renamed GetFlowResult to OrderPaymentFromFlow
+    * Add function to get newly introduced FlowStatus
+* Add new generic API endpoint to fetch the current FlowStatus of a payment
+* Enhanced / updated domain model
+    * Changed FlowResult to contain FlowStatus and allow flag to represent and early place order
+    * Add FlowStatus which contains current status of the payment flow
+    

--- a/payment/Readme.md
+++ b/payment/Readme.md
@@ -1,8 +1,8 @@
 # Payment Package
 
-Uff Payment is a taff topic and this package offers a generic concept to implement payment processing.
+Uff Payment is a tough topic and this package offers a generic concept to implement payment processing.
 
-Before we start we should clearify some namings:
+Before we start we should clarify some namings:
 * PaymentGateway: Is a digital tool that allows for online (credit card) payment request processing. It accepts PaymentRequest
 * PaymentMethod: Represents the used Payment -Typical payment methods include cash, checks, credit or debit cards, money orders, bank transfers and online payment services such as PayPal.
 
@@ -12,21 +12,48 @@ The main thing this package offers is a *WebCartPaymentGateway* interface.
 This is an interface that supports the processing of cart payments in any possible flow.
 
 The checkout will use this to start a payment of a cart. 
-Since a payment may involve redirects to one or more external hosted payment pages - or the requirement to show some iframes this interface uses a very genric abstraction.
+Since a payment may involve redirects to one or more external hosted payment pages - or the requirement to show some iframe this interface uses a very generic abstraction.
 
 Basically the checkout will at some point call
 ```go
- result, err := theSelectedWebCartPaymentGateway.StartFlow(ctx, cart, selectedMethod, sessionid, returnUrl) 
+ result, err := theSelectedWebCartPaymentGateway.StartFlow(ctx, cart, selectedMethod, correlationID, returnURL) 
  if err != nil {
    return result
  }
 ```
 This basically forwards the control of what should happen in the browser of the user 100% to the Payment Flow.
-The only thing it need to make sure is, that at the end the user should be returned to the given "returnUrl". Which will be normally the placeOrder Action of the checkout.
+The only thing it need to make sure is, that at the end the user should be returned to the given "returnUL". Which will be normally the payment processing page of the checkout.
 
-There the checkout will ask the Gateway implementation again to get the result (or an error if payment failed):
+There the checkout will ask the Gateway implementation again to get the current status of the payment flow and can decide if the payment if successful / failed or if further actions need to take place to proceed in the payment status (e.g. rendering an iframe of the payment provider)
 ```go
- cartPayment, err := theSelectedWebCartPaymentGateway.GetFlowResult(ctx, cart, sessionid)
+    flowStatus, err := gateway.FlowStatus(ctx, &decoratedCart.Cart, application.PaymentFlowStandardCorrelationID)
+ 	if err != nil {
+ 		return err
+ 	}
+ 
+ 	switch flowStatus.Status {
+ 	case paymentDomain.PaymentFlowStatusUnapproved:
+ 		// payment just started render payment page which handles actions
+ 		return cc.responder.Render("checkout/payment", viewData).SetNoCache()
+ 	case paymentDomain.PaymentFlowStatusApproved:
+ 		// payment is done but not confirmed by customer, confirm it and place order 
+ 		return cc.responder.RouteRedirect("checkout.placeorder", nil)
+ 	case paymentDomain.PaymentFlowStatusCompleted:
+ 		// payment is done and confirmed, place order
+ 		return cc.responder.RouteRedirect("checkout.placeorder", nil)
+ 	case paymentDomain.PaymentFlowStatusAborted:
+ 		// payment was aborted by user, redirect to checkout so a new payment can be started
+ 		return cc.responder.RouteRedirect("checkout", nil)
+ 	case paymentDomain.PaymentFlowStatusFailed:
+ 		// payment failed, redirect back to checkout
+ 		return cc.responder.RouteRedirect("checkout", nil)
+ 	case paymentDomain.PaymentFlowWaitingForCustomer:
+ 		// payment pending, waiting for customer
+ 		return cc.responder.Render("checkout/payment", viewData).SetNoCache()
+ 	default:
+ 		// show payment page which can react to unknown payment status
+ 		return cc.responder.Render("checkout/payment", viewData).SetNoCache()
+ 	}
  ..
 ```
 

--- a/payment/domain/payment.go
+++ b/payment/domain/payment.go
@@ -11,14 +11,10 @@ type (
 
 	// FlowResult contains information about a newly started flow
 	FlowResult struct {
-		// Status of the payment flow
-		Status string
 		// EarlyPlaceOrder indicates if the order should be placed with the beginning of the payment flow
 		EarlyPlaceOrder bool
-		// Action to perform to proceed in the payment flow
-		Action string
-		// Data contains additional information related to the action / flow
-		Data interface{}
+		// Status contains the current payment status
+		Status FlowStatus
 	}
 
 	// FlowStatus contains information about the current payment status

--- a/payment/domain/payment.go
+++ b/payment/domain/payment.go
@@ -47,6 +47,17 @@ const (
 	PaymentErrorCodeCaptureFailed = "capture_failed"
 	// ErrorPaymentAbortedByCustomer error
 	ErrorPaymentAbortedByCustomer = "payment-aborted-by-customer"
+
+	// PaymentFlowStatusUnapproved payment started
+	PaymentFlowStatusUnapproved = "payment_unapproved"
+	// PaymentFlowStatusFailed payment failed
+	PaymentFlowStatusFailed = "payment_failed"
+	// PaymentFlowStatusAborted payment aborted by user
+	PaymentFlowStatusAborted = "payment_aborted"
+	// PaymentFlowStatusApproved payment approved by payment adapter
+	PaymentFlowStatusApproved = "payment_approved"
+	// PaymentFlowStatusCompleted payment approved and confirmed by customer
+	PaymentFlowStatusCompleted = "payment_completed"
 )
 
 // Error getter

--- a/payment/domain/payment.go
+++ b/payment/domain/payment.go
@@ -25,6 +25,8 @@ type (
 		Action string
 		// Data contains additional information related to the action / flow
 		Data interface{}
+		// Error contains additional information in case of an error (e.g. payment failed)
+		Error *Error
 	}
 
 	// Error should be used by PaymentGateway to indicate that payment failed (so that the customer can see a speaking message)
@@ -35,14 +37,14 @@ type (
 )
 
 const (
-	// PaymentErrorCodeCancelled cancelled
-	PaymentErrorCodeCancelled = "payment_cancelled"
+	// PaymentErrorCodeFailed error
+	PaymentErrorCodeFailed = "failed"
 	// PaymentErrorCodeAuthorizeFailed error
 	PaymentErrorCodeAuthorizeFailed = "authorization_failed"
 	// PaymentErrorCodeCaptureFailed error
 	PaymentErrorCodeCaptureFailed = "capture_failed"
-	// ErrorPaymentAbortedByCustomer error
-	ErrorPaymentAbortedByCustomer = "payment-aborted-by-customer"
+	// PaymentErrorAbortedByCustomer error
+	PaymentErrorAbortedByCustomer = "aborted_by_customer"
 
 	// PaymentFlowStatusUnapproved payment started
 	PaymentFlowStatusUnapproved = "payment_unapproved"

--- a/payment/domain/payment.go
+++ b/payment/domain/payment.go
@@ -13,8 +13,8 @@ type (
 	FlowResult struct {
 		// Status of the payment flow
 		Status string
-		// PlaceOrder indicates if the order should be placed with the beginning of the payment flow
-		PlaceOrder bool
+		// EarlyPlaceOrder indicates if the order should be placed with the beginning of the payment flow
+		EarlyPlaceOrder bool
 		// Action to perform to proceed in the payment flow
 		Action string
 		// Data contains additional information related to the action / flow

--- a/payment/domain/payment.go
+++ b/payment/domain/payment.go
@@ -54,6 +54,8 @@ const (
 	PaymentFlowStatusApproved = "payment_approved"
 	// PaymentFlowStatusCompleted payment approved and confirmed by customer
 	PaymentFlowStatusCompleted = "payment_completed"
+	// PaymentFlowWaitingForCustomer payment waiting for customer
+	PaymentFlowWaitingForCustomer = "payment_waiting_for_customer"
 )
 
 // Error getter

--- a/payment/domain/payment.go
+++ b/payment/domain/payment.go
@@ -1,7 +1,5 @@
 package domain
 
-import "net/url"
-
 type (
 	// Method contains information about a general payment method
 	Method struct {
@@ -11,10 +9,25 @@ type (
 		Code string
 	}
 
-	// FlowResult contains an url and a type to use to start a flow
+	// FlowResult contains information about a newly started flow
 	FlowResult struct {
-		URL  *url.URL
-		Type string
+		// Status of the payment flow
+		Status string
+		// PlaceOrder indicates if the order should be placed with the beginning of the payment flow
+		PlaceOrder bool
+		// Action to perform to proceed in the payment flow
+		Action string
+		// Data contains additional information related to the action / flow
+		Data interface{}
+	}
+
+	// FlowStatus contains information about the current payment status
+	FlowStatus struct {
+		// Status of the payment flow
+		Status string
+		// Action to perform to proceed in the payment flow
+		Action string
+		// Data contains additional information related to the action / flow
 		Data interface{}
 	}
 

--- a/payment/interfaces/controller/paymentapicontroller.go
+++ b/payment/interfaces/controller/paymentapicontroller.go
@@ -1,0 +1,122 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"flamingo.me/flamingo-commerce/v3/cart/domain/decorator"
+
+	cartApplication "flamingo.me/flamingo-commerce/v3/cart/application"
+	"flamingo.me/flamingo-commerce/v3/checkout/application"
+
+	"flamingo.me/flamingo/v3/framework/flamingo"
+	"flamingo.me/flamingo/v3/framework/web"
+)
+
+type (
+	// PaymentAPIController for payment api
+	PaymentAPIController struct {
+		responder                      *web.Responder
+		cartReceiverService            *cartApplication.CartReceiverService
+		orderService                   *application.OrderService
+		logger                         flamingo.Logger
+		decoratedCartFactory           *decorator.DecoratedCartFactory
+		applicationCartReceiverService *cartApplication.CartReceiverService
+	}
+
+	resultError struct {
+		Message string
+		Code    string
+	}
+)
+
+// Inject dependencies
+func (pc *PaymentAPIController) Inject(
+	responder *web.Responder,
+	Logger flamingo.Logger,
+	cartReceiver *cartApplication.CartReceiverService,
+	orderService *application.OrderService,
+	decoratedCartFactory *decorator.DecoratedCartFactory,
+	applicationCartReceiverService *cartApplication.CartReceiverService,
+) {
+	pc.responder = responder
+	pc.logger = Logger.WithField("category", "PaymentApiController")
+	pc.cartReceiverService = cartReceiver
+	pc.orderService = orderService
+	pc.decoratedCartFactory = decoratedCartFactory
+	pc.applicationCartReceiverService = applicationCartReceiverService
+}
+
+// Status Get Payment Status
+func (pc *PaymentAPIController) Status(ctx context.Context, r *web.Request) web.Result {
+	decoratedCart, err := pc.lastPlacedOrCurrentCart(ctx)
+
+	if err != nil {
+		pc.logger.Warn("Error when getting last used cart", err)
+		return pc.responder.Data(resultError{
+			Message: fmt.Sprintf("Cart not found: %v", err),
+			Code:    "status.polling.cart.error",
+		})
+	}
+
+	if decoratedCart.Cart.PaymentSelection == nil {
+		pc.logger.Warn("Error because payment selection is empty")
+		return pc.responder.Data(resultError{
+			Message: "Payment selection is empty",
+			Code:    "status.polling.paymentselection.error",
+		})
+	}
+
+	gateway, err := pc.orderService.GetPaymentGateway(ctx, decoratedCart.Cart.PaymentSelection.Gateway())
+	if err != nil {
+		pc.logger.Warn("Error because payment gateway is not set", err)
+		return pc.responder.Data(resultError{
+			Message: fmt.Sprintf("Payment Gateway is not set: %v", err),
+			Code:    "status.polling.paymentgateway.error",
+		})
+	}
+
+	flowStatus, err := gateway.FlowStatus(ctx, &decoratedCart.Cart, application.PaymentFlowStandardCorrelationID)
+	if err != nil {
+		pc.logger.Warn("Error because flow status is unknown", err)
+		return pc.responder.Data(resultError{
+			Message: fmt.Sprintf("Flow status unknown: %v", err),
+			Code:    "status.polling.flowstatus.error",
+		})
+	}
+
+	return pc.responder.Data(flowStatus)
+}
+
+func (pc *PaymentAPIController) lastPlaceOrderInfo(ctx context.Context) (*application.PlaceOrderInfo, error) {
+	lastPlacedOrder, err := pc.orderService.LastPlacedOrder(ctx)
+	if err != nil {
+		pc.logger.Warn("couldn't get last placed order from orderService:", err)
+		return nil, err
+	}
+
+	return lastPlacedOrder, nil
+}
+
+// lastPlacedOrCurrentCart returns the decorated cart of the last placed order if there is one if not return the current cart
+func (pc *PaymentAPIController) lastPlacedOrCurrentCart(ctx context.Context) (*decorator.DecoratedCart, error) {
+	lastPlacedOrder, err := pc.lastPlaceOrderInfo(ctx)
+	if err != nil {
+		pc.logger.Warn("couldn't get last placed order from orderService:", err)
+		return nil, err
+	}
+
+	if lastPlacedOrder != nil {
+		// cart has been placed early use it
+		return pc.decoratedCartFactory.Create(ctx, lastPlacedOrder.Cart), nil
+	}
+
+	// cart wasn't placed early, fetch it from service
+	decoratedCart, err := pc.applicationCartReceiverService.ViewDecoratedCart(ctx, web.SessionFromContext(ctx))
+	if err != nil {
+		pc.logger.WithContext(ctx).Error("lastPlacedOrCurrentCart -> ViewDecoratedCart Error:", err)
+		return nil, err
+	}
+
+	return decoratedCart, nil
+}

--- a/payment/interfaces/offlinePaymentGateway.go
+++ b/payment/interfaces/offlinePaymentGateway.go
@@ -18,7 +18,7 @@ type OfflineWebCartPaymentGateway struct {
 }
 
 const (
-	//OfflineWebCartPaymentGatewayCode - the gateway code
+	// OfflineWebCartPaymentGatewayCode - the gateway code
 	OfflineWebCartPaymentGatewayCode = "offline"
 )
 
@@ -36,14 +36,16 @@ func (o *OfflineWebCartPaymentGateway) Inject(responder *web.Responder, config *
 
 // Methods returns the Payment Providers available Payment Methods
 func (o *OfflineWebCartPaymentGateway) Methods() []domain.Method {
-	return []domain.Method{{
-		Title: "cash on delivery",
-		Code:  "offlinepayment_cashondelivery",
-	},
+	return []domain.Method{
+		{
+			Title: "cash on delivery",
+			Code:  "offlinepayment_cashondelivery",
+		},
 		{
 			Title: "cash in advance",
 			Code:  "offlinepayment_cashinadvance",
-		}}
+		},
+	}
 }
 
 func (o *OfflineWebCartPaymentGateway) isSupportedMethod(method string) bool {
@@ -56,41 +58,44 @@ func (o *OfflineWebCartPaymentGateway) isSupportedMethod(method string) bool {
 }
 
 func (o *OfflineWebCartPaymentGateway) checkCart(currentCart *cartDomain.Cart) error {
-	//Read the infos in the cart and check precondition
+	// Read the infos in the cart and check precondition
 	if currentCart.PaymentSelection.Gateway() != OfflineWebCartPaymentGatewayCode {
-		return errors.New("Cart is not supposed to be payed by this gateway")
+		return errors.New("cart is not supposed to be payed by this gateway")
 	}
 	for qualifier := range currentCart.PaymentSelection.CartSplit() {
 		if !o.isSupportedMethod(qualifier.Method) {
-			return errors.New("Cart payment method not supported by gateway")
+			return errors.New("cart payment method not supported by gateway")
 		}
 	}
 	return nil
 }
 
-// StartFlow for offline payment
+// StartFlow for offline payment and directly mark it as completed, since there is no online payment process
 func (o *OfflineWebCartPaymentGateway) StartFlow(ctx context.Context, currentCart *cartDomain.Cart, correlationID string, returnURL *url.URL) (*domain.FlowResult, error) {
 	err := o.checkCart(currentCart)
 	if err != nil {
 		return nil, err
 	}
-	return &domain.FlowResult{}, nil
-}
-
-// FlowStatus for offline payment is always finished
-func (o *OfflineWebCartPaymentGateway) FlowStatus(ctx context.Context, cart *cartDomain.Cart, correlationID string) (*domain.FlowStatus, error) {
-	return &domain.FlowStatus{
-		Status: "complete",
-		Action: "SHOW_SUCCESS_PAGE",
+	return &domain.FlowResult{
+		Status: domain.FlowStatus{
+			Status: domain.PaymentFlowStatusCompleted,
+		},
 	}, nil
 }
 
-//ConfirmResult - nothing to confirm  for offline payment
+// FlowStatus for offline payment is always completed
+func (o *OfflineWebCartPaymentGateway) FlowStatus(ctx context.Context, cart *cartDomain.Cart, correlationID string) (*domain.FlowStatus, error) {
+	return &domain.FlowStatus{
+		Status: domain.PaymentFlowStatusCompleted,
+	}, nil
+}
+
+//ConfirmResult nothing to confirm  for offline payment
 func (o *OfflineWebCartPaymentGateway) ConfirmResult(ctx context.Context, cart *cartDomain.Cart, cartPayment *placeorder.Payment) error {
 	return nil
 }
 
-// OrderPaymentFromFlow create the order payment from the current cat/flow
+// OrderPaymentFromFlow create the order payment from the current cart/flow
 func (o *OfflineWebCartPaymentGateway) OrderPaymentFromFlow(ctx context.Context, currentCart *cartDomain.Cart, correlationID string) (*placeorder.Payment, error) {
 	err := o.checkCart(currentCart)
 	if err != nil {

--- a/payment/interfaces/offlinePaymentGateway.go
+++ b/payment/interfaces/offlinePaymentGateway.go
@@ -68,7 +68,7 @@ func (o *OfflineWebCartPaymentGateway) checkCart(currentCart *cartDomain.Cart) e
 	return nil
 }
 
-//StartFlow for offline payment
+// StartFlow for offline payment
 func (o *OfflineWebCartPaymentGateway) StartFlow(ctx context.Context, currentCart *cartDomain.Cart, correlationID string, returnURL *url.URL) (*domain.FlowResult, error) {
 	err := o.checkCart(currentCart)
 	if err != nil {
@@ -77,17 +77,16 @@ func (o *OfflineWebCartPaymentGateway) StartFlow(ctx context.Context, currentCar
 	return &domain.FlowResult{}, nil
 }
 
-//StartWebFlow for offline payment requires not much - just redirect to the returnUrl :-)
-func (o *OfflineWebCartPaymentGateway) StartWebFlow(ctx context.Context, currentCart *cartDomain.Cart, correlationID string, returnURL *url.URL) (web.Result, error) {
-	err := o.checkCart(currentCart)
-	if err != nil {
-		return nil, err
-	}
-	return o.responder.URLRedirect(returnURL), nil
+// FlowStatus for offline payment is always finished
+func (o *OfflineWebCartPaymentGateway) FlowStatus(ctx context.Context, cart *cartDomain.Cart, correlationID string) (*domain.FlowStatus, error) {
+	return &domain.FlowStatus{
+		Status: "complete",
+		Action: "SHOW_SUCCESS_PAGE",
+	}, nil
 }
 
-// GetFlowResult for offline payment can always return a simple valid payment that matches the given cart
-func (o *OfflineWebCartPaymentGateway) GetFlowResult(ctx context.Context, currentCart *cartDomain.Cart, correlationID string) (*placeorder.Payment, error) {
+// FlowResult for offline payment can always return a simple valid payment that matches the given cart
+func (o *OfflineWebCartPaymentGateway) FlowResult(ctx context.Context, currentCart *cartDomain.Cart, correlationID string) (*placeorder.Payment, error) {
 	err := o.checkCart(currentCart)
 	if err != nil {
 		return nil, err

--- a/payment/interfaces/offlinePaymentGateway.go
+++ b/payment/interfaces/offlinePaymentGateway.go
@@ -85,17 +85,6 @@ func (o *OfflineWebCartPaymentGateway) FlowStatus(ctx context.Context, cart *car
 	}, nil
 }
 
-// FlowResult for offline payment can always return a simple valid payment that matches the given cart
-func (o *OfflineWebCartPaymentGateway) FlowResult(ctx context.Context, currentCart *cartDomain.Cart, correlationID string) (*placeorder.Payment, error) {
-	err := o.checkCart(currentCart)
-	if err != nil {
-		return nil, err
-	}
-
-	cartPayment, _ := o.OrderPaymentFromFlow(ctx, currentCart, correlationID)
-	return cartPayment, nil
-}
-
 //ConfirmResult - nothing to confirm  for offline payment
 func (o *OfflineWebCartPaymentGateway) ConfirmResult(ctx context.Context, cart *cartDomain.Cart, cartPayment *placeorder.Payment) error {
 	return nil

--- a/payment/interfaces/offlinePaymentGateway.go
+++ b/payment/interfaces/offlinePaymentGateway.go
@@ -91,6 +91,23 @@ func (o *OfflineWebCartPaymentGateway) FlowResult(ctx context.Context, currentCa
 	if err != nil {
 		return nil, err
 	}
+
+	cartPayment, _ := o.OrderPaymentFromFlow(ctx, currentCart, correlationID)
+	return cartPayment, nil
+}
+
+//ConfirmResult - nothing to confirm  for offline payment
+func (o *OfflineWebCartPaymentGateway) ConfirmResult(ctx context.Context, cart *cartDomain.Cart, cartPayment *placeorder.Payment) error {
+	return nil
+}
+
+// OrderPaymentFromFlow create the order payment from the current cat/flow
+func (o *OfflineWebCartPaymentGateway) OrderPaymentFromFlow(ctx context.Context, currentCart *cartDomain.Cart, correlationID string) (*placeorder.Payment, error) {
+	err := o.checkCart(currentCart)
+	if err != nil {
+		return nil, err
+	}
+
 	cartPayment := placeorder.Payment{
 		Gateway: OfflineWebCartPaymentGatewayCode,
 	}
@@ -105,9 +122,4 @@ func (o *OfflineWebCartPaymentGateway) FlowResult(ctx context.Context, currentCa
 	}
 
 	return &cartPayment, nil
-}
-
-//ConfirmResult - nothing to confirm  for offline payment
-func (o *OfflineWebCartPaymentGateway) ConfirmResult(ctx context.Context, cart *cartDomain.Cart, cartPayment *placeorder.Payment) error {
-	return nil
 }

--- a/payment/interfaces/webpayment.go
+++ b/payment/interfaces/webpayment.go
@@ -32,6 +32,6 @@ type (
 		ConfirmResult(ctx context.Context, cart *cart.Cart, cartPayment *placeorder.Payment) error
 
 		// OrderPaymentFromFlow generates a place order payment for a previously created flow
-		OrderPaymentFromFlow(ctx context.Context, cart *cart.Cart, flow *domain.FlowResult) (*placeorder.Payment, error)
+		OrderPaymentFromFlow(ctx context.Context, cart *cart.Cart, correlationID string) (*placeorder.Payment, error)
 	}
 )

--- a/payment/interfaces/webpayment.go
+++ b/payment/interfaces/webpayment.go
@@ -24,10 +24,6 @@ type (
 		// FlowStatus returns the status of a previously started flow (see StartFlow())
 		FlowStatus(ctx context.Context, cart *cart.Cart, correlationID string) (*domain.FlowStatus, error)
 
-		// FlowResult returns the flow result of a payment, should use OrderPaymentFromFlow() to generate the placeorder.Payment
-		// @param correlationID is used to fetch the result of a processing request started by this correlationId
-		FlowResult(ctx context.Context, cart *cart.Cart, correlationID string) (*placeorder.Payment, error)
-
 		// ConfirmResult used to finally confirm the result
 		ConfirmResult(ctx context.Context, cart *cart.Cart, cartPayment *placeorder.Payment) error
 

--- a/payment/interfaces/webpayment.go
+++ b/payment/interfaces/webpayment.go
@@ -24,11 +24,14 @@ type (
 		// FlowStatus returns the status of a previously started flow (see StartFlow())
 		FlowStatus(ctx context.Context, cart *cart.Cart, correlationID string) (*domain.FlowStatus, error)
 
-		// FlowResult returns the flow result of a payment
+		// FlowResult returns the flow result of a payment, should use OrderPaymentFromFlow() to generate the placeorder.Payment
 		// @param correlationID is used to fetch the result of a processing request started by this correlationId
 		FlowResult(ctx context.Context, cart *cart.Cart, correlationID string) (*placeorder.Payment, error)
 
 		// ConfirmResult used to finally confirm the result
 		ConfirmResult(ctx context.Context, cart *cart.Cart, cartPayment *placeorder.Payment) error
+
+		// OrderPaymentFromFlow generates a place order payment for a previously created flow
+		OrderPaymentFromFlow(ctx context.Context, cart *cart.Cart, flow *domain.FlowResult) (*placeorder.Payment, error)
 	}
 )

--- a/payment/interfaces/webpayment.go
+++ b/payment/interfaces/webpayment.go
@@ -7,34 +7,28 @@ import (
 	"flamingo.me/flamingo-commerce/v3/cart/domain/cart"
 	"flamingo.me/flamingo-commerce/v3/cart/domain/placeorder"
 	"flamingo.me/flamingo-commerce/v3/payment/domain"
-	"flamingo.me/flamingo/v3/framework/web"
 )
 
 type (
-
 	// WebCartPaymentGatewayProvider defines the map of providers for payment providers
 	WebCartPaymentGatewayProvider func() map[string]WebCartPaymentGateway
 
 	// WebCartPaymentGateway is an interface offering (online) payment service - most probably against a external payment gateway API
 	WebCartPaymentGateway interface {
-
 		// Methods returns the PaymentGateway available Payment Methods
 		Methods() []domain.Method
 
-		// StartWebFlow - starts the processing of an asyncronous Payment Flow for the cart
-		// @param correlationID - is used later to fetch the result of this processing request
-		// @param returnUrl - this is the desired end of the async payment flow.
-		// @return the web.Result need to be executed(returned) by the call to give control to the Flow
-		StartWebFlow(ctx context.Context, cart *cart.Cart, correlationID string, returnURL *url.URL) (web.Result, error)
-
-		// StartFlow - returns the data for a new flow
+		// StartFlow returns the data for a new flow
 		StartFlow(ctx context.Context, cart *cart.Cart, correlationID string, returnURL *url.URL) (*domain.FlowResult, error)
 
-		// GetFlowResult - will be used to fetch the result of the payment flow
-		// @param correlationID - is used to fetch the result of a processing request started by this correlationId
-		GetFlowResult(ctx context.Context, cart *cart.Cart, correlationID string) (*placeorder.Payment, error)
+		// FlowStatus returns the status of a previously started flow (see StartFlow())
+		FlowStatus(ctx context.Context, cart *cart.Cart, correlationID string) (*domain.FlowStatus, error)
 
-		// ConfirmResult - used to finally confirm the result
+		// FlowResult returns the flow result of a payment
+		// @param correlationID is used to fetch the result of a processing request started by this correlationId
+		FlowResult(ctx context.Context, cart *cart.Cart, correlationID string) (*placeorder.Payment, error)
+
+		// ConfirmResult used to finally confirm the result
 		ConfirmResult(ctx context.Context, cart *cart.Cart, cartPayment *placeorder.Payment) error
 	}
 )

--- a/payment/module.go
+++ b/payment/module.go
@@ -3,6 +3,8 @@ package payment
 import (
 	"flamingo.me/dingo"
 	"flamingo.me/flamingo-commerce/v3/payment/interfaces"
+	"flamingo.me/flamingo-commerce/v3/payment/interfaces/controller"
+	"flamingo.me/flamingo/v3/framework/web"
 )
 
 type (
@@ -17,4 +19,20 @@ func (m *Module) Configure(injector *dingo.Injector) {
 	if m.EnableOfflinePayment {
 		injector.BindMap((*interfaces.WebCartPaymentGateway)(nil), interfaces.OfflineWebCartPaymentGatewayCode).To(interfaces.OfflineWebCartPaymentGateway{})
 	}
+
+	web.BindRoutes(injector, new(routes))
+}
+
+type routes struct {
+	paymentAPIController *controller.PaymentAPIController
+}
+
+func (r *routes) Inject(apiController *controller.PaymentAPIController) {
+	r.paymentAPIController = apiController
+}
+
+func (r *routes) Routes(registry *web.RouterRegistry) {
+	registry.HandleGet("payment.status", r.paymentAPIController.Status)
+	registry.Route("/api/payment/status", "payment.status")
+
 }

--- a/payment/module_test.go
+++ b/payment/module_test.go
@@ -1,0 +1,14 @@
+package payment_test
+
+import (
+	"testing"
+
+	"flamingo.me/dingo"
+	"flamingo.me/flamingo-commerce/v3/payment"
+)
+
+func TestModule_Configure(t *testing.T) {
+	if err := dingo.TryModule(new(payment.Module)); err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
Currently the order is placed after the payment process is finished. Due to cross device payment options some payment adapters could demand an early order placement and flamingo-commerce should offer an polling option ask the payment adapter in which state the payment flow is. According to that payment status certain messages can be displayed to the customer.

To avoid polluting the SubmitCheckoutAction/PlaceOrderAction this handling should happen in a separate action which should display an intermediate payment page. This page can then react to the current payment flow status and display certain messages through polling or redirecting to the SuccessAction if the payment adapter tells us to do so.