### PR TITLE
cart: Use returned cart for defer functions, otherwise we would use old carts

### DIFF
--- a/cart/application/cartService.go
+++ b/cart/application/cartService.go
@@ -419,7 +419,7 @@ func (cs *CartService) Clean(ctx context.Context, session *web.Session) error {
 		}
 	}
 
-	_, defers, err = behaviour.CleanCart(ctx, cart)
+	cart, defers, err = behaviour.CleanCart(ctx, cart)
 	if err != nil {
 		cs.logger.WithContext(ctx).WithField("subCategory", "DeleteAllItems").Error(err)
 		return err


### PR DESCRIPTION
The current implementation does not work as expected as the cart pointer needs to be overwritten for the defer function.