### PR TITLE
checkout: orderservice should pass through errors

### DIFF
--- a/checkout/application/orderService.go
+++ b/checkout/application/orderService.go
@@ -362,7 +362,7 @@ func (os *OrderService) placeOrderWithPaymentProcessing(ctx context.Context, dec
 		// record fail count metric
 		stats.Record(ctx, orderFailedStat.M(1))
 		os.logger.WithContext(ctx).Error("Error during place Order:" + err.Error())
-		return nil, errors.New("error while placing the order. please contact customer support")
+		return nil, err
 	}
 
 	placeOrderInfo := os.preparePlaceOrderInfo(ctx, decoratedCart.Cart, placedOrderInfos, *cartPayment)


### PR DESCRIPTION
The orderservice should pass through arbitrary errors from the infrastructure layer instead of overwriting it. 

The client might want to react on custom errors depending on the situation.