### PR TITLE
price: return payable on SplitInPayables

### DIFF
--- a/price/domain/price.go
+++ b/price/domain/price.go
@@ -325,14 +325,14 @@ func (p Price) GetPayableByRoundingMode(mode string, precision int) Price {
 	if p.IsNegative() {
 		negative = -1
 	}
-	offsetToCheckRounding := new(big.Float).Mul(p.precisionF(precision), new(big.Float).SetInt64(10))
+	offsetToCheckRounding := new(big.Float).Mul(p.precisionF(precision), new(big.Float).SetInt64(100))
 
 	amountTruncatedFloat, _ := new(big.Float).Mul(amountForRound, p.precisionF(precision)).Float64()
 	amountTruncatedInt := int64(amountTruncatedFloat)
 
 	amountRoundingCheckFloat, _ := new(big.Float).Mul(amountForRound, offsetToCheckRounding).Float64()
 	amountRoundingCheckInt := int64(amountRoundingCheckFloat)
-	valueAfterPrecision := (amountRoundingCheckInt - (amountTruncatedInt * 10)) * negative
+	valueAfterPrecision := (amountRoundingCheckInt - (amountTruncatedInt * 100)) * negative
 	if amountTruncatedFloat >= float64(math.MaxInt64) {
 		// will not work if we are already above MaxInt - so we return unrounded price:
 		newPrice.amount = p.amount
@@ -345,11 +345,11 @@ func (p Price) GetPayableByRoundingMode(mode string, precision int) Price {
 			amountTruncatedInt = amountTruncatedInt + (1 * negative)
 		}
 	case mode == RoundingModeHalfUp:
-		if negative == 1 && valueAfterPrecision >= 5 {
+		if negative == 1 && valueAfterPrecision >= 45 {
 			amountTruncatedInt = amountTruncatedInt + (1 * negative)
 		}
 	case mode == RoundingModeHalfDown:
-		if negative == 1 && valueAfterPrecision > 5 {
+		if negative == 1 && valueAfterPrecision > 55 {
 			amountTruncatedInt = amountTruncatedInt + (1 * negative)
 		}
 	case mode == RoundingModeFloor:
@@ -424,7 +424,7 @@ func (p Price) SplitInPayables(count int) ([]Price, error) {
 		if p.IsNegative() {
 			splittedAmount *= -1
 		}
-		prices[i] = NewFromInt(splittedAmount, precision, p.Currency()).GetPayable()
+		prices[i] = NewFromInt(splittedAmount, precision, p.Currency())
 	}
 
 	return prices, nil

--- a/price/domain/price.go
+++ b/price/domain/price.go
@@ -389,6 +389,11 @@ func (p Price) SplitInPayables(count int) ([]Price, error) {
 	if count <= 0 {
 		return nil, errors.New("Split must be higher than zero")
 	}
+
+	if count == 1 {
+		return []Price{p.Clone().GetPayable()}, nil
+	}
+
 	// guard clause invert negative values
 	_, precision := p.payableRoundingPrecision()
 	amount := p.GetPayable().Amount()
@@ -419,7 +424,7 @@ func (p Price) SplitInPayables(count int) ([]Price, error) {
 		if p.IsNegative() {
 			splittedAmount *= -1
 		}
-		prices[i] = NewFromInt(splittedAmount, precision, p.Currency())
+		prices[i] = NewFromInt(splittedAmount, precision, p.Currency()).GetPayable()
 	}
 
 	return prices, nil

--- a/price/domain/price.go
+++ b/price/domain/price.go
@@ -391,7 +391,7 @@ func (p Price) SplitInPayables(count int) ([]Price, error) {
 	}
 
 	if count == 1 {
-		return []Price{p.Clone().GetPayable()}, nil
+		return []Price{p.GetPayable()}, nil
 	}
 
 	// guard clause invert negative values

--- a/price/domain/price_test.go
+++ b/price/domain/price_test.go
@@ -71,6 +71,9 @@ func TestPrice_GetPayable(t *testing.T) {
 
 	price = domain.NewFromFloat(math.MaxInt64, "EUR").GetPayable()
 	assert.Equal(t, float64(math.MaxInt64), price.FloatAmount())
+
+	price = domain.NewFromFloat(88.39499, "EUR")
+	assert.Equal(t, float64(88.40), price.GetPayable().FloatAmount())
 }
 
 func TestNewFromInt(t *testing.T) {
@@ -159,7 +162,7 @@ func TestPrice_SplitInPayables(t *testing.T) {
 		{
 			name: "return payables",
 			fields: fields{
-				amount:   88.39551,
+				amount:   88.39499,
 				currency: "EUR",
 			},
 			args: args{
@@ -283,7 +286,7 @@ func TestPrice_MarshalBinaryForGob(t *testing.T) {
 }
 
 func TestPrice_GetPayableByRoundingMode(t *testing.T) {
-	price := domain.NewFromFloat(12.34567, "EUR")
+	price := domain.NewFromFloat(12.34557, "EUR")
 
 	payable := price.GetPayableByRoundingMode(domain.RoundingModeCeil, 100)
 	assert.Equal(t, domain.NewFromInt(1235, 100, "EUR").Amount(), payable.Amount())


### PR DESCRIPTION
Price.SplitInPayables should return payable prices. Only creating new price from int with precision does not result into payable price values.