### PR TITLE
cart: Reopen cart in case of a payment flow issue

### DIFF
--- a/checkout/interfaces/controller/checkoutcontroller.go
+++ b/checkout/interfaces/controller/checkoutcontroller.go
@@ -622,7 +622,7 @@ func (cc *CheckoutController) PaymentAction(ctx context.Context, r *web.Request)
 	case paymentDomain.PaymentFlowStatusCompleted:
 		// payment is done and confirmed, place order
 		return cc.responder.RouteRedirect("checkout.placeorder", nil)
-	case paymentDomain.PaymentFlowStatusAborted, paymentDomain.PaymentFlowStatusCancelled:
+	case paymentDomain.PaymentFlowStatusAborted:
 		// payment was aborted or cancelled by user, redirect to checkout so a new payment can be started
 		if cc.orderService.HasLastPlacedOrder(ctx) {
 			infos, err := cc.orderService.LastPlacedOrder(ctx)

--- a/payment/domain/payment.go
+++ b/payment/domain/payment.go
@@ -58,6 +58,8 @@ const (
 	PaymentFlowStatusCompleted = "payment_completed"
 	// PaymentFlowWaitingForCustomer payment waiting for customer
 	PaymentFlowWaitingForCustomer = "payment_waiting_for_customer"
+	// PaymentFlowStatusCancelled payment cancelled by provider
+	PaymentFlowStatusCancelled = "payment_cancelled"
 )
 
 // Error getter

--- a/payment/domain/payment.go
+++ b/payment/domain/payment.go
@@ -58,6 +58,8 @@ const (
 	PaymentFlowStatusCompleted = "payment_completed"
 	// PaymentFlowWaitingForCustomer payment waiting for customer
 	PaymentFlowWaitingForCustomer = "payment_waiting_for_customer"
+	// PaymentFlowStatusCancelled payment cancelled by user
+	PaymentFlowStatusCancelled = "payment_cancelled"
 )
 
 // Error getter

--- a/payment/domain/payment.go
+++ b/payment/domain/payment.go
@@ -58,8 +58,6 @@ const (
 	PaymentFlowStatusCompleted = "payment_completed"
 	// PaymentFlowWaitingForCustomer payment waiting for customer
 	PaymentFlowWaitingForCustomer = "payment_waiting_for_customer"
-	// PaymentFlowStatusCancelled payment cancelled by user
-	PaymentFlowStatusCancelled = "payment_cancelled"
 )
 
 // Error getter


### PR DESCRIPTION
cart: Reopen cart in case of a payment flow issue to keep checkout still usable. Handle PaymentFlowStatusCancelled accordingly.