### PR TITLE
cart: Fix validators/restrictors not able to handle configurable product

### DIFF
--- a/cart/application/cartService.go
+++ b/cart/application/cartService.go
@@ -906,8 +906,6 @@ func (cs *CartService) AdjustItemsToRestrictedQty(ctx context.Context, session *
 
 	for _, delivery := range cart.Deliveries {
 		for _, item := range delivery.Cartitems {
-			// TODO Configurable
-
 			product, err := cs.productService.Get(ctx, item.MarketplaceCode)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
When working with products we always need to check if its an configurable and get the active variant to be able to restrict and validate the variant instead of the base product.