### PR TITLE
Allow adding variants to in-memory cart

### DIFF
--- a/cart/infrastructure/InMemoryBehaviour.go
+++ b/cart/infrastructure/InMemoryBehaviour.go
@@ -198,6 +198,16 @@ func (cob *InMemoryBehaviour) buildItemForCart(ctx context.Context, addRequest d
 	if err != nil {
 		return nil, err
 	}
+
+	// Get variant of configurable product
+	if configurableProduct, ok := product.(domain.ConfigurableProduct); ok && addRequest.VariantMarketplaceCode != "" {
+		productWithActiveVariant, err := configurableProduct.GetConfigurableWithActiveVariant(addRequest.VariantMarketplaceCode)
+		if err != nil {
+			return nil, err
+		}
+		product = productWithActiveVariant
+	}
+
 	itemBuilder.SetQty(addRequest.Qty).AddTaxInfo("default", big.NewFloat(cob.defaultTaxRate), nil).SetByProduct(product).SetID(strconv.Itoa(rand.Int())).SetExternalReference(strconv.Itoa(rand.Int()))
 
 	return itemBuilder.Build()


### PR DESCRIPTION
It was not possible to add a variant to the in-memory cart because it always tried to add the configurable product instead of the selected variant. It then failed because configurable product are not saleable.

Now, when building the cart item we get the product with active variant first.