### PR TITLE
cart + checkout: Don't use cached cart when placing order

### DIFF
--- a/cart/Changelog.md
+++ b/cart/Changelog.md
@@ -34,3 +34,6 @@
 * Removed `ShippingItem.DiscountAmount` 
   * Added `ShippingItem.AppliedDiscounts`
     * ShippingItem now implements interface `WithDiscount`
+    
+# 9. October 2019
+* Add `PlaceOrderWithCart` to `CartService` to be able to place an already fetched cart instead of triggering an additional call to the `CartReceiverService`

--- a/cart/application/cartService.go
+++ b/cart/application/cartService.go
@@ -787,8 +787,8 @@ func (cs *CartService) ReserveOrderIDAndSave(ctx context.Context, session *web.S
 	return data, err
 }
 
-// PlaceOrderFromCart converts the given cart with payments into orders by calling the Service
-func (cs *CartService) PlaceOrderFromCart(ctx context.Context, session *web.Session, cart *cartDomain.Cart, payment *placeorder.Payment) (placeorder.PlacedOrderInfos, error) {
+// PlaceOrderWithCart converts the given cart with payments into orders by calling the Service
+func (cs *CartService) PlaceOrderWithCart(ctx context.Context, session *web.Session, cart *cartDomain.Cart, payment *placeorder.Payment) (placeorder.PlacedOrderInfos, error) {
 	return cs.placeOrder(ctx, session, cart, payment)
 }
 
@@ -806,7 +806,6 @@ func (cs *CartService) placeOrder(ctx context.Context, session *web.Session, car
 		return nil, errors.New("No placeOrderService registered")
 	}
 	var placeOrderInfos placeorder.PlacedOrderInfos
-	var err error
 	var errPlaceOrder error
 	if cs.cartReceiverService.IsLoggedIn(ctx, session) {
 		auth, err := cs.authManager.Auth(ctx, session)
@@ -828,7 +827,7 @@ func (cs *CartService) placeOrder(ctx context.Context, session *web.Session, car
 	cs.DeleteSavedSessionGuestCartID(session)
 	cs.DeleteCartInCache(ctx, session, cart)
 
-	return placeOrderInfos, err
+	return placeOrderInfos, nil
 }
 
 // CancelOrder cancels a previously placed order and restores the cart content

--- a/cart/application/cartService.go
+++ b/cart/application/cartService.go
@@ -787,16 +787,26 @@ func (cs *CartService) ReserveOrderIDAndSave(ctx context.Context, session *web.S
 	return data, err
 }
 
-// PlaceOrder converts the given cart with payments into orders by calling the Service
+// PlaceOrderFromCart converts the given cart with payments into orders by calling the Service
+func (cs *CartService) PlaceOrderFromCart(ctx context.Context, session *web.Session, cart *cartDomain.Cart, payment *placeorder.Payment) (placeorder.PlacedOrderInfos, error) {
+	return cs.placeOrder(ctx, session, cart, payment)
+}
+
+// PlaceOrder converts the cart (possibly cached) with payments into orders by calling the Service
 func (cs *CartService) PlaceOrder(ctx context.Context, session *web.Session, payment *placeorder.Payment) (placeorder.PlacedOrderInfos, error) {
-	if cs.placeOrderService == nil {
-		return nil, errors.New("No placeOrderService registered")
-	}
 	cart, _, err := cs.cartReceiverService.GetCart(ctx, session)
 	if err != nil {
 		return nil, err
 	}
+	return cs.placeOrder(ctx, session, cart, payment)
+}
+
+func (cs *CartService) placeOrder(ctx context.Context, session *web.Session, cart *cartDomain.Cart, payment *placeorder.Payment) (placeorder.PlacedOrderInfos, error) {
+	if cs.placeOrderService == nil {
+		return nil, errors.New("No placeOrderService registered")
+	}
 	var placeOrderInfos placeorder.PlacedOrderInfos
+	var err error
 	var errPlaceOrder error
 	if cs.cartReceiverService.IsLoggedIn(ctx, session) {
 		auth, err := cs.authManager.Auth(ctx, session)

--- a/checkout/application/orderService.go
+++ b/checkout/application/orderService.go
@@ -376,7 +376,7 @@ func (os *OrderService) placeOrderWithPaymentProcessing(ctx context.Context, dec
 		return nil, err
 	}
 
-	placedOrderInfos, err := os.cartService.PlaceOrderFromCart(ctx, session, &decoratedCart.Cart, cartPayment)
+	placedOrderInfos, err := os.cartService.PlaceOrderWithCart(ctx, session, &decoratedCart.Cart, cartPayment)
 	if err != nil {
 		// record fail count metric
 		stats.Record(ctx, orderFailedStat.M(1))

--- a/checkout/application/orderService.go
+++ b/checkout/application/orderService.go
@@ -376,7 +376,7 @@ func (os *OrderService) placeOrderWithPaymentProcessing(ctx context.Context, dec
 		return nil, err
 	}
 
-	placedOrderInfos, err := os.cartService.PlaceOrder(ctx, session, cartPayment)
+	placedOrderInfos, err := os.cartService.PlaceOrderFromCart(ctx, session, &decoratedCart.Cart, cartPayment)
 	if err != nil {
 		// record fail count metric
 		stats.Record(ctx, orderFailedStat.M(1))


### PR DESCRIPTION
Using the cached cart (after already completing the cart) may potentially return an empty cart from the cart receiver service if no cache is used or the cache died.