### PR TITLE
search: Make searchService implementation optional 

### DIFF
--- a/search/application/searchService.go
+++ b/search/application/searchService.go
@@ -6,6 +6,7 @@ package application
 
 import (
 	"context"
+	"errors"
 	"net/url"
 
 	"flamingo.me/flamingo-commerce/v3/search/domain"
@@ -63,6 +64,9 @@ func (s *SearchService) Inject(
 
 // FindBy returns a SearchResult for the given Request
 func (s *SearchService) FindBy(ctx context.Context, documentType string, searchRequest SearchRequest) (*SearchResult, error) {
+	if s.searchService == nil {
+		return nil, errors.New("No searchservice available")
+	}
 	var currentURL *url.URL
 	request := web.RequestFromContext(ctx)
 	if request == nil {
@@ -112,6 +116,9 @@ func (s *SearchService) FindBy(ctx context.Context, documentType string, searchR
 
 // Find returns a Searchresult for all document types for the given Request
 func (s *SearchService) Find(ctx context.Context, searchRequest SearchRequest) (map[string]*SearchResult, error) {
+	if s.searchService == nil {
+		return nil, errors.New("No searchservice available")
+	}
 	var currentURL *url.URL
 	request := web.RequestFromContext(ctx)
 	if request == nil {


### PR DESCRIPTION
Background:
- interface layer of product and category package depend on search package - e.g. they reuse dto and graphQL types
- it should be possible to reuse them without a searchservice adapter. Currently thats not possible since in Module the controller and its dependencies request a Searchservice

=> We should make this DI optional