### PR TITLE
Make toString function for attributes

### DIFF
--- a/category/domain/category.go
+++ b/category/domain/category.go
@@ -129,13 +129,23 @@ func (a Attributes) All() []Attribute {
 	return att
 }
 
+// ToString returns a concatenated string of all the values of all attributes
+func (a Attributes) ToString() string {
+	var attValue []string
+	for _, v := range a {
+		attValue = append(attValue, v.ToString())
+	}
+
+	return strings.Join(attValue[:], ",")
+}
+
 // ToString returns a concatenated string of all the values of an attribute
 func (a Attribute) ToString() string {
 	var attValue []string
 	for _, v := range a.Values {
 		attValue = append(attValue, v.Value())
 	}
-	return strings.Join(attValue, ",")
+	return strings.Join(attValue[:], ",")
 }
 
 // Value returns string representation of the RawValue

--- a/category/domain/category.go
+++ b/category/domain/category.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"fmt"
+	"strings"
 )
 
 type (
@@ -126,6 +127,25 @@ func (a Attributes) All() []Attribute {
 		att = append(att, v)
 	}
 	return att
+}
+
+// ToString returns a concatenated string of all the values of all attributes
+func (a Attributes) ToString() string {
+	var attValue []string
+	for _, v := range a {
+		attValue = append(attValue, v.ToString())
+	}
+
+	return strings.Join(attValue[:], ",")
+}
+
+// ToString returns a concatenated string of all the values of an attribute
+func (a Attribute) ToString() string {
+	var attValue []string
+	for _, v := range a.Values {
+		attValue = append(attValue, v.Value())
+	}
+	return strings.Join(attValue[:], ",")
 }
 
 // Value returns string representation of the RawValue

--- a/category/domain/category.go
+++ b/category/domain/category.go
@@ -129,23 +129,13 @@ func (a Attributes) All() []Attribute {
 	return att
 }
 
-// ToString returns a concatenated string of all the values of all attributes
-func (a Attributes) ToString() string {
-	var attValue []string
-	for _, v := range a {
-		attValue = append(attValue, v.ToString())
-	}
-
-	return strings.Join(attValue[:], ",")
-}
-
 // ToString returns a concatenated string of all the values of an attribute
 func (a Attribute) ToString() string {
 	var attValue []string
 	for _, v := range a.Values {
 		attValue = append(attValue, v.Value())
 	}
-	return strings.Join(attValue[:], ",")
+	return strings.Join(attValue, ",")
 }
 
 // Value returns string representation of the RawValue


### PR DESCRIPTION
A proper attribute struct was introduce recently for categories. To make the values more accessible we added two "toString" functions to return a concatenated string of all the values of an attribute, and all the values of an attribute value.