### PR TITLE
Add custom attributes to CouponCode

### DIFF
--- a/cart/domain/cart/cart.go
+++ b/cart/domain/cart/cart.go
@@ -63,6 +63,8 @@ type (
 	// CouponCode value object
 	CouponCode struct {
 		Code string
+		// CustomAttributes can hold additional data for coupon code - keys and values are project specific
+		CustomAttributes map[string]interface{}
 	}
 
 	// Person value object


### PR DESCRIPTION
Coupon codes sometimes need to have additional data. e.g. restrictions that can only be evaluated later in process.