### PR TITLE
cart: fix GraphQL for cart, due to new type alias in cart model

### DIFF
--- a/cart/application/cartService.go
+++ b/cart/application/cartService.go
@@ -970,7 +970,8 @@ func (cs *CartService) AdjustItemsToRestrictedQty(ctx context.Context, session *
 		if err != nil {
 			return nil, err
 		}
-		qtyAdjustmentResult.HasRemovedCouponCodes = !couponCodes.ContainedIn(cart.AppliedCouponCodes)
+
+		qtyAdjustmentResult.HasRemovedCouponCodes = !cartDomain.AppliedCouponCodes(couponCodes).ContainedIn(cart.AppliedCouponCodes)
 		qtyAdjustmentResults[index] = qtyAdjustmentResult
 	}
 

--- a/cart/domain/cart/cart.go
+++ b/cart/domain/cart/cart.go
@@ -42,7 +42,7 @@ type (
 		BelongsToAuthenticatedUser bool
 		AuthenticatedUserID        string
 
-		AppliedCouponCodes AppliedCouponCodes
+		AppliedCouponCodes []CouponCode
 
 		DefaultCurrency string
 


### PR DESCRIPTION
A new type alias for applied coupons was introduced in the cart model, this messed up the GraphQL mapping. This commit reverts the type alias while maintaining the needed behaviour in cartService.go