### PR TITLE
Behaviour of ProductCount() in cart.go should be unique #184

### DIFF
--- a/cart/domain/cart/cart.go
+++ b/cart/domain/cart/cart.go
@@ -276,7 +276,7 @@ func (c Cart) ItemCount() int {
 	return count
 }
 
-// ProductCount - returns amount of different products
+// ProductCount returns the amount of different products, but a product is counted twice if it is in different deliveries
 func (c Cart) ProductCount() int {
 	count := 0
 	for _, delivery := range c.Deliveries {
@@ -284,6 +284,19 @@ func (c Cart) ProductCount() int {
 	}
 
 	return count
+}
+
+// ProductCountUnique returns the amount of unique products across all deliveries
+func (c Cart) ProductCountUnique() int {
+	marketplaceCodes := make(map[string]string)
+	for _, delivery := range c.Deliveries {
+		for _, item := range delivery.Cartitems {
+			if _, ok := marketplaceCodes[item.MarketplaceCode]; !ok {
+				marketplaceCodes[item.MarketplaceCode] = item.MarketplaceCode
+			}
+		}
+	}
+	return len(marketplaceCodes)
 }
 
 // IsPaymentSelected - returns true if a valid payment is selected

--- a/cart/domain/cart/cart.go
+++ b/cart/domain/cart/cart.go
@@ -288,11 +288,11 @@ func (c Cart) ProductCount() int {
 
 // ProductCountUnique returns the amount of unique products across all deliveries
 func (c Cart) ProductCountUnique() int {
-	marketplaceCodes := make(map[string]string)
+	marketplaceCodes := make(map[string]struct{})
 	for _, delivery := range c.Deliveries {
 		for _, item := range delivery.Cartitems {
 			if _, ok := marketplaceCodes[item.MarketplaceCode]; !ok {
-				marketplaceCodes[item.MarketplaceCode] = item.MarketplaceCode
+				marketplaceCodes[item.MarketplaceCode] = struct{}{}
 			}
 		}
 	}

--- a/cart/domain/cart/cart_test.go
+++ b/cart/domain/cart/cart_test.go
@@ -684,3 +684,89 @@ func TestAppliedCouponCodes_ContainedIn(t *testing.T) {
 		})
 	}
 }
+
+func TestCart_ProductCountAndUniqueProductCount(t *testing.T) {
+	tests := []struct {
+		name                   string
+		cart                   cartDomain.Cart
+		wantProductCount       int
+		wantProductUniqueCount int
+	}{
+		{
+			name:                   "empty cart",
+			cart:                   cartDomain.Cart{},
+			wantProductCount:       0,
+			wantProductUniqueCount: 0,
+		},
+		{
+			name: "single delivery in cart",
+			cart: cartDomain.Cart{
+				Deliveries: []cartDomain.Delivery{
+					{
+						Cartitems: []cartDomain.Item{
+							{
+								MarketplaceCode: "product1",
+							},
+						},
+					},
+				},
+			},
+			wantProductCount:       1,
+			wantProductUniqueCount: 1,
+		},
+		{
+			name: "two deliveries in cart with different products",
+			cart: cartDomain.Cart{
+				Deliveries: []cartDomain.Delivery{
+					{
+						Cartitems: []cartDomain.Item{
+							{
+								MarketplaceCode: "product1",
+							},
+						},
+					},
+					{
+						Cartitems: []cartDomain.Item{
+							{
+								MarketplaceCode: "product2",
+							},
+						},
+					},
+				},
+			},
+			wantProductCount:       2,
+			wantProductUniqueCount: 2,
+		},
+		{
+			name: "two deliveries in cart with a product in both deliveries",
+			cart: cartDomain.Cart{
+				Deliveries: []cartDomain.Delivery{
+					{
+						Cartitems: []cartDomain.Item{
+							{
+								MarketplaceCode: "product1",
+							},
+						},
+					},
+					{
+						Cartitems: []cartDomain.Item{
+							{
+								MarketplaceCode: "product1",
+							},
+							{
+								MarketplaceCode: "product2",
+							},
+						},
+					},
+				},
+			},
+			wantProductCount:       3,
+			wantProductUniqueCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.wantProductCount, tt.cart.ProductCount(), "ProductCount has wrong result, expected %#v but got %#v", tt.wantProductCount, tt.cart.ProductCount())
+		assert.Equal(t, tt.wantProductUniqueCount, tt.cart.ProductCountUnique(), "ProductCountUnique has wrong result, expected %#v but got %#v", tt.wantProductUniqueCount, tt.cart.ProductCountUnique())
+	}
+}


### PR DESCRIPTION
#184 will be solved with this pull request. Old function stays the same, but there is a ProductCountUnique now, that will check across deliveries.