### PR TITLE
cart: Adjust behaviour of add event and update qty event

### DIFF
--- a/cart/Changelog.md
+++ b/cart/Changelog.md
@@ -60,6 +60,7 @@
 include a cart as a parameter
 * Breaking Change to behaviour of `AddToCartEvent` and `ChangedQtyInCartEvent`, they are now thrown after
 the cart has been adjusted and written back to cache
+* Events deferred from `ModifyBehaviour` are dispatched before `AddToCartEvent` and `ChangedQtyInCartEvent`
 * The `AddToCartEvent` includes the current cart (with added product)
 * The `ChangedQtyInCartEvent` includes the current cart (with updated quantities)
 * Add Whitebox Test `TestCartService_CartInEvent` to check `AddToCartEvent`

--- a/cart/Changelog.md
+++ b/cart/Changelog.md
@@ -58,6 +58,8 @@
 # 6. February 2020
 * Breaking Change to `EventPublisher` interface, `PublishChangedQtyInCartEvent` and `PublishAddToCartEvent` now
 include a cart as a parameter
+* Breaking Change to behaviour of `AddToCartEvent` and `ChangedQtyInCartEvent`, they are now thrown after
+the cart has been adjusted and written back to cache
 * The `AddToCartEvent` includes the current cart (with added product)
 * The `ChangedQtyInCartEvent` includes the current cart (with updated quantities)
 * Add Whitebox Test `TestCartService_CartInEvent` to check `AddToCartEvent`

--- a/cart/Changelog.md
+++ b/cart/Changelog.md
@@ -54,3 +54,10 @@
 
 # 17. January 2020
 * Add `AppliedGiftCard` convenience function `Total()`
+
+# 6. February 2020
+* Breaking Change to `EventPublisher` interface, `PublishChangedQtyInCartEvent` and `PublishAddToCartEvent` now
+include a cart as a parameter
+* The `AddToCartEvent` includes the current cart (with added product)
+* The `ChangedQtyInCartEvent` includes the current cart (with updated quantities)
+* Add Whitebox Test `TestCartService_CartInEvent` to check `AddToCartEvent`

--- a/cart/application/cartReceiver_test.go
+++ b/cart/application/cartReceiver_test.go
@@ -18,6 +18,7 @@ import (
 	"flamingo.me/flamingo/v3/framework/flamingo"
 	"flamingo.me/flamingo/v3/framework/web"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/mock"
 )
 
 type (
@@ -153,20 +154,28 @@ func (m *MockCartCache) BuildIdentifier(context.Context, *web.Session) (cartAppl
 // MockEventPublisher
 
 type (
-	MockEventPublisher struct{}
+	MockEventPublisher struct {
+		mock.Mock
+	}
 )
 
 var (
 	_ events.EventPublisher = (*MockEventPublisher)(nil)
 )
 
-func (m *MockEventPublisher) PublishAddToCartEvent(ctx context.Context, marketPlaceCode string, variantMarketPlaceCode string, qty int) {
+func (m *MockEventPublisher) PublishAddToCartEvent(ctx context.Context, cart *cartDomain.Cart, marketPlaceCode string, variantMarketPlaceCode string, qty int) {
+	// we just add item count for white box test
+	m.Called(ctx, cart.ItemCount(), marketPlaceCode, variantMarketPlaceCode, qty)
 }
 
-func (m *MockEventPublisher) PublishChangedQtyInCartEvent(ctx context.Context, item *cartDomain.Item, qtyBefore int, qtyAfter int, cartID string) {
+func (m *MockEventPublisher) PublishChangedQtyInCartEvent(ctx context.Context, cart *cartDomain.Cart, item *cartDomain.Item, qtyBefore int, qtyAfter int) {
+	// we just add item count for white box test
+	m.Called(ctx, cart.ItemCount(), item, qtyBefore, qtyAfter)
 }
 
 func (m *MockEventPublisher) PublishOrderPlacedEvent(ctx context.Context, cart *cartDomain.Cart, placedOrderInfos placeorder.PlacedOrderInfos) {
+	// we just add item count for white box test
+	m.Called(ctx, cart.ItemCount(), placedOrderInfos)
 }
 
 // MockCartValidator

--- a/cart/application/cartReceiver_test.go
+++ b/cart/application/cartReceiver_test.go
@@ -232,10 +232,9 @@ var _ flamingo.EventRouter = new(MockEventRouter)
 func (m *MockEventRouter) Dispatch(ctx context.Context, event flamingo.Event) {
 	// we just write the event type and the marketplace code to the mock, so we don't have to compare
 	// the complete cart
-	switch event.(type) {
-	case events.AddToCartEvent:
-		addToCart, _ := event.(events.AddToCartEvent)
-		m.Called(ctx, fmt.Sprintf("%T", event), addToCart.MarketplaceCode)
+	switch eventType := event.(type) {
+	case *events.AddToCartEvent:
+		m.Called(ctx, fmt.Sprintf("%T", event), eventType.MarketplaceCode)
 	}
 }
 

--- a/cart/application/cartService.go
+++ b/cart/application/cartService.go
@@ -298,7 +298,7 @@ func (cs *CartService) UpdateItemQty(ctx context.Context, session *web.Session, 
 		return err
 	}
 
-	cs.eventPublisher.PublishChangedQtyInCartEvent(ctx, item, qtyBefore, qty, cart.ID)
+	cs.eventPublisher.PublishChangedQtyInCartEvent(ctx, cart, item, qtyBefore, qty)
 	itemUpdate := cartDomain.ItemUpdateCommand{
 		Qty:            &qty,
 		ItemID:         itemID,
@@ -411,7 +411,7 @@ func (cs *CartService) DeleteItem(ctx context.Context, session *web.Session, ite
 	}
 
 	qtyBefore := item.Qty
-	cs.eventPublisher.PublishChangedQtyInCartEvent(ctx, item, qtyBefore, 0, cart.ID)
+	cs.eventPublisher.PublishChangedQtyInCartEvent(ctx, cart, item, qtyBefore, 0)
 
 	cart, defers, err = behaviour.DeleteItem(ctx, cart, itemID, deliveryCode)
 	if err != nil {
@@ -440,7 +440,7 @@ func (cs *CartService) DeleteAllItems(ctx context.Context, session *web.Session)
 	for _, delivery := range cart.Deliveries {
 		for _, item := range delivery.Cartitems {
 			qtyBefore := item.Qty
-			cs.eventPublisher.PublishChangedQtyInCartEvent(ctx, &item, qtyBefore, 0, cart.ID)
+			cs.eventPublisher.PublishChangedQtyInCartEvent(ctx, cart, &item, qtyBefore, 0)
 
 			cart, defers, err = behaviour.DeleteItem(ctx, cart, item.ID, delivery.DeliveryInfo.Code)
 			if err != nil {
@@ -471,7 +471,7 @@ func (cs *CartService) Clean(ctx context.Context, session *web.Session) error {
 	for _, delivery := range cart.Deliveries {
 		for _, item := range delivery.Cartitems {
 			qtyBefore := item.Qty
-			cs.eventPublisher.PublishChangedQtyInCartEvent(ctx, &item, qtyBefore, 0, cart.ID)
+			cs.eventPublisher.PublishChangedQtyInCartEvent(ctx, cart, &item, qtyBefore, 0)
 		}
 	}
 
@@ -503,7 +503,7 @@ func (cs *CartService) DeleteDelivery(ctx context.Context, session *web.Session,
 	}
 	for _, item := range delivery.Cartitems {
 		qtyBefore := item.Qty
-		cs.eventPublisher.PublishChangedQtyInCartEvent(ctx, &item, qtyBefore, 0, cart.ID)
+		cs.eventPublisher.PublishChangedQtyInCartEvent(ctx, cart, &item, qtyBefore, 0)
 	}
 
 	cart, defers, err = behaviour.CleanDelivery(ctx, cart, deliveryCode)
@@ -751,7 +751,7 @@ func (cs *CartService) checkProductQtyRestrictions(ctx context.Context, product 
 
 func (cs *CartService) publishAddtoCartEvent(ctx context.Context, currentCart cartDomain.Cart, addRequest cartDomain.AddRequest) {
 	if cs.eventPublisher != nil {
-		cs.eventPublisher.PublishAddToCartEvent(ctx, addRequest.MarketplaceCode, addRequest.VariantMarketplaceCode, addRequest.Qty)
+		cs.eventPublisher.PublishAddToCartEvent(ctx, &currentCart, addRequest.MarketplaceCode, addRequest.VariantMarketplaceCode, addRequest.Qty)
 	}
 }
 

--- a/cart/application/cartService.go
+++ b/cart/application/cartService.go
@@ -298,7 +298,6 @@ func (cs *CartService) UpdateItemQty(ctx context.Context, session *web.Session, 
 		return err
 	}
 
-	cs.eventPublisher.PublishChangedQtyInCartEvent(ctx, cart, item, qtyBefore, qty)
 	itemUpdate := cartDomain.ItemUpdateCommand{
 		Qty:            &qty,
 		ItemID:         itemID,
@@ -312,6 +311,18 @@ func (cs *CartService) UpdateItemQty(ctx context.Context, session *web.Session, 
 
 		return err
 	}
+
+	// append deferred events of behaviour with changed qty event
+	updateEvent := events.ChangedQtyInCartEvent{
+		Cart:                   cart,
+		CartID:                 cart.ID,
+		MarketplaceCode:        item.MarketplaceCode,
+		VariantMarketplaceCode: item.VariantMarketPlaceCode,
+		ProductName:            product.TeaserData().ShortTitle,
+		QtyBefore:              qtyBefore,
+		QtyAfter:               qty,
+	}
+	defers = append(defers, updateEvent)
 
 	return nil
 }
@@ -411,8 +422,6 @@ func (cs *CartService) DeleteItem(ctx context.Context, session *web.Session, ite
 	}
 
 	qtyBefore := item.Qty
-	cs.eventPublisher.PublishChangedQtyInCartEvent(ctx, cart, item, qtyBefore, 0)
-
 	cart, defers, err = behaviour.DeleteItem(ctx, cart, itemID, deliveryCode)
 	if err != nil {
 		cs.handleCartNotFound(session, err)
@@ -420,6 +429,18 @@ func (cs *CartService) DeleteItem(ctx context.Context, session *web.Session, ite
 
 		return err
 	}
+
+	// append deferred events of behaviour with changed qty event
+	updateEvent := events.ChangedQtyInCartEvent{
+		Cart:                   cart,
+		CartID:                 cart.ID,
+		MarketplaceCode:        item.MarketplaceCode,
+		VariantMarketplaceCode: item.VariantMarketPlaceCode,
+		ProductName:            item.ProductName,
+		QtyBefore:              qtyBefore,
+		QtyAfter:               0,
+	}
+	defers = append(defers, updateEvent)
 
 	return nil
 }
@@ -432,15 +453,25 @@ func (cs *CartService) DeleteAllItems(ctx context.Context, session *web.Session)
 	}
 	// cart cache must be updated - with the current value of cart
 	var defers cartDomain.DeferEvents
+	var deleteItemEvents cartDomain.DeferEvents
 	defer func() {
 		cs.updateCartInCacheIfCacheIsEnabled(ctx, session, cart)
 		cs.dispatchAllEvents(ctx, defers)
 	}()
 
+	// we throw a qty changed event for every item in delivery
 	for _, delivery := range cart.Deliveries {
 		for _, item := range delivery.Cartitems {
-			qtyBefore := item.Qty
-			cs.eventPublisher.PublishChangedQtyInCartEvent(ctx, cart, &item, qtyBefore, 0)
+			updateEvent := events.ChangedQtyInCartEvent{
+				Cart:                   cart,
+				CartID:                 cart.ID,
+				MarketplaceCode:        item.MarketplaceCode,
+				VariantMarketplaceCode: item.VariantMarketPlaceCode,
+				ProductName:            item.ProductName,
+				QtyBefore:              item.Qty,
+				QtyAfter:               0,
+			}
+			deleteItemEvents = append(deleteItemEvents, updateEvent)
 
 			cart, defers, err = behaviour.DeleteItem(ctx, cart, item.ID, delivery.DeliveryInfo.Code)
 			if err != nil {
@@ -451,6 +482,8 @@ func (cs *CartService) DeleteAllItems(ctx context.Context, session *web.Session)
 			}
 		}
 	}
+	// append deferred events of behaviour with changed qty events
+	defers = append(defers, deleteItemEvents)
 
 	return nil
 }
@@ -463,15 +496,25 @@ func (cs *CartService) Clean(ctx context.Context, session *web.Session) error {
 	}
 	// cart cache must be updated - with the current value of cart
 	var defers cartDomain.DeferEvents
+	var deleteItemEvents cartDomain.DeferEvents
 	defer func() {
 		cs.updateCartInCacheIfCacheIsEnabled(ctx, session, cart)
 		cs.dispatchAllEvents(ctx, defers)
 	}()
 
+	// we throw a qty changed event for every item of each delivery
 	for _, delivery := range cart.Deliveries {
 		for _, item := range delivery.Cartitems {
-			qtyBefore := item.Qty
-			cs.eventPublisher.PublishChangedQtyInCartEvent(ctx, cart, &item, qtyBefore, 0)
+			updateEvent := events.ChangedQtyInCartEvent{
+				Cart:                   cart,
+				CartID:                 cart.ID,
+				MarketplaceCode:        item.MarketplaceCode,
+				VariantMarketplaceCode: item.VariantMarketPlaceCode,
+				ProductName:            item.ProductName,
+				QtyBefore:              item.Qty,
+				QtyAfter:               0,
+			}
+			deleteItemEvents = append(deleteItemEvents, updateEvent)
 		}
 	}
 
@@ -480,6 +523,8 @@ func (cs *CartService) Clean(ctx context.Context, session *web.Session) error {
 		cs.logger.WithContext(ctx).WithField("subCategory", "DeleteAllItems").Error(err)
 		return err
 	}
+	// append deferred events of behaviour with changed qty events for every deleted item
+	defers = append(defers, deleteItemEvents)
 
 	return nil
 }
@@ -492,6 +537,7 @@ func (cs *CartService) DeleteDelivery(ctx context.Context, session *web.Session,
 	}
 	// cart cache must be updated - with the current value of cart
 	var defers cartDomain.DeferEvents
+	var deleteItemEvents cartDomain.DeferEvents
 	defer func() {
 		cs.updateCartInCacheIfCacheIsEnabled(ctx, session, cart)
 		cs.dispatchAllEvents(ctx, defers)
@@ -501,9 +547,18 @@ func (cs *CartService) DeleteDelivery(ctx context.Context, session *web.Session,
 	if !found {
 		return nil, errors.New("delivery not found: " + deliveryCode)
 	}
+	// we throw a qty changed event for every item in delivery// we throw a qty changed event for every item in delivery
 	for _, item := range delivery.Cartitems {
-		qtyBefore := item.Qty
-		cs.eventPublisher.PublishChangedQtyInCartEvent(ctx, cart, &item, qtyBefore, 0)
+		updateEvent := events.ChangedQtyInCartEvent{
+			Cart:                   cart,
+			CartID:                 cart.ID,
+			MarketplaceCode:        item.MarketplaceCode,
+			VariantMarketplaceCode: item.VariantMarketPlaceCode,
+			ProductName:            item.ProductName,
+			QtyBefore:              item.Qty,
+			QtyAfter:               0,
+		}
+		deleteItemEvents = append(deleteItemEvents, updateEvent)
 	}
 
 	cart, defers, err = behaviour.CleanDelivery(ctx, cart, deliveryCode)
@@ -511,6 +566,9 @@ func (cs *CartService) DeleteDelivery(ctx context.Context, session *web.Session,
 		cs.logger.WithContext(ctx).WithField("subCategory", "DeleteAllItems").Error(err)
 		return nil, err
 	}
+
+	// append deferred events of behaviour with changed qty events for every deleted item
+	defers = append(defers, deleteItemEvents)
 
 	return cart, nil
 }
@@ -580,7 +638,15 @@ func (cs *CartService) AddProduct(ctx context.Context, session *web.Session, del
 		return nil, err
 	}
 
-	cs.publishAddtoCartEvent(ctx, *cart, addRequest)
+	// append deferred events of behaviour with add to cart event
+	addToCart := events.AddToCartEvent{
+		Cart:                   cart,
+		MarketplaceCode:        addRequest.MarketplaceCode,
+		VariantMarketplaceCode: addRequest.VariantMarketplaceCode,
+		ProductName:            product.TeaserData().ShortTitle,
+		Qty:                    addRequest.Qty,
+	}
+	defers = append(defers, addToCart)
 
 	return product, nil
 }
@@ -747,12 +813,6 @@ func (cs *CartService) checkProductQtyRestrictions(ctx context.Context, product 
 	}
 
 	return nil
-}
-
-func (cs *CartService) publishAddtoCartEvent(ctx context.Context, currentCart cartDomain.Cart, addRequest cartDomain.AddRequest) {
-	if cs.eventPublisher != nil {
-		cs.eventPublisher.PublishAddToCartEvent(ctx, &currentCart, addRequest.MarketplaceCode, addRequest.VariantMarketplaceCode, addRequest.Qty)
-	}
 }
 
 func (cs *CartService) updateCartInCacheIfCacheIsEnabled(ctx context.Context, session *web.Session, cart *cartDomain.Cart) {

--- a/cart/application/cartService.go
+++ b/cart/application/cartService.go
@@ -313,7 +313,7 @@ func (cs *CartService) UpdateItemQty(ctx context.Context, session *web.Session, 
 	}
 
 	// append deferred events of behaviour with changed qty event
-	updateEvent := events.ChangedQtyInCartEvent{
+	updateEvent := &events.ChangedQtyInCartEvent{
 		Cart:                   cart,
 		CartID:                 cart.ID,
 		MarketplaceCode:        item.MarketplaceCode,
@@ -431,7 +431,7 @@ func (cs *CartService) DeleteItem(ctx context.Context, session *web.Session, ite
 	}
 
 	// append deferred events of behaviour with changed qty event
-	updateEvent := events.ChangedQtyInCartEvent{
+	updateEvent := &events.ChangedQtyInCartEvent{
 		Cart:                   cart,
 		CartID:                 cart.ID,
 		MarketplaceCode:        item.MarketplaceCode,
@@ -462,7 +462,7 @@ func (cs *CartService) DeleteAllItems(ctx context.Context, session *web.Session)
 	// we throw a qty changed event for every item in delivery
 	for _, delivery := range cart.Deliveries {
 		for _, item := range delivery.Cartitems {
-			updateEvent := events.ChangedQtyInCartEvent{
+			updateEvent := &events.ChangedQtyInCartEvent{
 				Cart:                   cart,
 				CartID:                 cart.ID,
 				MarketplaceCode:        item.MarketplaceCode,
@@ -505,7 +505,7 @@ func (cs *CartService) Clean(ctx context.Context, session *web.Session) error {
 	// we throw a qty changed event for every item of each delivery
 	for _, delivery := range cart.Deliveries {
 		for _, item := range delivery.Cartitems {
-			updateEvent := events.ChangedQtyInCartEvent{
+			updateEvent := &events.ChangedQtyInCartEvent{
 				Cart:                   cart,
 				CartID:                 cart.ID,
 				MarketplaceCode:        item.MarketplaceCode,
@@ -549,7 +549,7 @@ func (cs *CartService) DeleteDelivery(ctx context.Context, session *web.Session,
 	}
 	// we throw a qty changed event for every item in delivery// we throw a qty changed event for every item in delivery
 	for _, item := range delivery.Cartitems {
-		updateEvent := events.ChangedQtyInCartEvent{
+		updateEvent := &events.ChangedQtyInCartEvent{
 			Cart:                   cart,
 			CartID:                 cart.ID,
 			MarketplaceCode:        item.MarketplaceCode,
@@ -639,7 +639,7 @@ func (cs *CartService) AddProduct(ctx context.Context, session *web.Session, del
 	}
 
 	// append deferred events of behaviour with add to cart event
-	addToCart := events.AddToCartEvent{
+	addToCart := &events.AddToCartEvent{
 		Cart:                   cart,
 		MarketplaceCode:        addRequest.MarketplaceCode,
 		VariantMarketplaceCode: addRequest.VariantMarketplaceCode,

--- a/cart/application/cartService_test.go
+++ b/cart/application/cartService_test.go
@@ -1023,5 +1023,5 @@ func TestCartService_CartInEvent(t *testing.T) {
 	eventRouter.AssertNumberOfCalls(t, "Dispatch", 1)
 	// white box test that ensures router has been called with expected parameter (add to cart event)
 	// with the expected marketplace code of the item
-	eventRouter.AssertCalled(t, "Dispatch", ctx, fmt.Sprintf("%T", events.AddToCartEvent{}), addRequest.MarketplaceCode)
+	eventRouter.AssertCalled(t, "Dispatch", ctx, fmt.Sprintf("%T", new(events.AddToCartEvent)), addRequest.MarketplaceCode)
 }

--- a/cart/application/cartService_test.go
+++ b/cart/application/cartService_test.go
@@ -72,7 +72,7 @@ func TestCartService_DeleteSavedSessionGuestCartID(t *testing.T) {
 						&authApplication.AuthManager{},
 						&authApplication.UserService{},
 						flamingo.NullLogger{},
-						nil,
+						new(MockEventRouter),
 						&struct {
 							CartCache cartApplication.CartCache `inject:",optional"`
 						}{
@@ -150,7 +150,7 @@ func TestCartService_AdjustItemsToRestrictedQty(t *testing.T) {
 		ProductService      productDomain.ProductService
 		Logger              flamingo.Logger
 		EventPublisher      *MockEventPublisher
-		EventRouter         flamingo.EventRouter
+		EventRouter         *MockEventRouter
 		RestrictionService  *validation.RestrictionService
 		config              *struct {
 			DefaultDeliveryCode string `inject:"config:commerce.cart.defaultDeliveryCode,optional"`
@@ -190,7 +190,7 @@ func TestCartService_AdjustItemsToRestrictedQty(t *testing.T) {
 						authmanager,
 						userservice,
 						flamingo.NullLogger{},
-						nil,
+						new(MockEventRouter),
 						&struct {
 							CartCache cartApplication.CartCache `inject:",optional"`
 						}{
@@ -201,6 +201,7 @@ func TestCartService_AdjustItemsToRestrictedQty(t *testing.T) {
 				}(),
 				ProductService: &MockProductService{},
 				Logger:         flamingo.NullLogger{},
+				EventRouter:    new(MockEventRouter),
 				EventPublisher: new(MockEventPublisher),
 				config: &struct {
 					DefaultDeliveryCode string `inject:"config:commerce.cart.defaultDeliveryCode,optional"`
@@ -247,7 +248,7 @@ func TestCartService_AdjustItemsToRestrictedQty(t *testing.T) {
 						authmanager,
 						userservice,
 						flamingo.NullLogger{},
-						nil,
+						new(MockEventRouter),
 						&struct {
 							CartCache cartApplication.CartCache `inject:",optional"`
 						}{
@@ -258,6 +259,7 @@ func TestCartService_AdjustItemsToRestrictedQty(t *testing.T) {
 				}(),
 				ProductService: &MockProductService{},
 				Logger:         flamingo.NullLogger{},
+				EventRouter:    new(MockEventRouter),
 				EventPublisher: new(MockEventPublisher),
 				config: &struct {
 					DefaultDeliveryCode string `inject:"config:commerce.cart.defaultDeliveryCode,optional"`
@@ -320,7 +322,7 @@ func TestCartService_AdjustItemsToRestrictedQty(t *testing.T) {
 						authmanager,
 						userservice,
 						flamingo.NullLogger{},
-						nil,
+						new(MockEventRouter),
 						&struct {
 							CartCache cartApplication.CartCache `inject:",optional"`
 						}{
@@ -331,6 +333,7 @@ func TestCartService_AdjustItemsToRestrictedQty(t *testing.T) {
 				}(),
 				ProductService: &MockProductService{},
 				Logger:         flamingo.NullLogger{},
+				EventRouter:    new(MockEventRouter),
 				EventPublisher: new(MockEventPublisher),
 				config: &struct {
 					DefaultDeliveryCode string `inject:"config:commerce.cart.defaultDeliveryCode,optional"`
@@ -377,7 +380,6 @@ func TestCartService_AdjustItemsToRestrictedQty(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.fields.EventPublisher.On("PublishChangedQtyInCartEvent", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 			cs := &cartApplication.CartService{}
 			cs.Inject(
 				tt.fields.CartReceiverService,
@@ -391,7 +393,6 @@ func TestCartService_AdjustItemsToRestrictedQty(t *testing.T) {
 				tt.fields.config,
 				nil,
 			)
-
 			got, _ := cs.AdjustItemsToRestrictedQty(tt.args.ctx, tt.args.session)
 
 			if diff := deep.Equal(got, tt.want); diff != nil {
@@ -454,7 +455,7 @@ func TestCartService_ReserveOrderIDAndSave(t *testing.T) {
 						authmanager,
 						userservice,
 						flamingo.NullLogger{},
-						nil,
+						new(MockEventRouter),
 						&struct {
 							CartCache cartApplication.CartCache `inject:",optional"`
 						}{
@@ -465,6 +466,7 @@ func TestCartService_ReserveOrderIDAndSave(t *testing.T) {
 				}(),
 				ProductService: &MockProductService{},
 				Logger:         flamingo.NullLogger{},
+				EventRouter:    new(MockEventRouter),
 				EventPublisher: new(MockEventPublisher),
 				config: &struct {
 					DefaultDeliveryCode string `inject:"config:commerce.cart.defaultDeliveryCode,optional"`
@@ -504,7 +506,7 @@ func TestCartService_ReserveOrderIDAndSave(t *testing.T) {
 						authmanager,
 						userservice,
 						flamingo.NullLogger{},
-						nil,
+						new(MockEventRouter),
 						&struct {
 							CartCache cartApplication.CartCache `inject:",optional"`
 						}{
@@ -516,6 +518,7 @@ func TestCartService_ReserveOrderIDAndSave(t *testing.T) {
 				ProductService: &MockProductService{},
 				Logger:         flamingo.NullLogger{},
 				EventPublisher: new(MockEventPublisher),
+				EventRouter:    new(MockEventRouter),
 				config: &struct {
 					DefaultDeliveryCode string `inject:"config:commerce.cart.defaultDeliveryCode,optional"`
 					DeleteEmptyDelivery bool   `inject:"config:commerce.cart.deleteEmptyDelivery,optional"`
@@ -621,7 +624,7 @@ func TestCartService_ForceReserveOrderIDAndSave(t *testing.T) {
 						authmanager,
 						userservice,
 						flamingo.NullLogger{},
-						nil,
+						new(MockEventRouter),
 						&struct {
 							CartCache cartApplication.CartCache `inject:",optional"`
 						}{
@@ -633,6 +636,7 @@ func TestCartService_ForceReserveOrderIDAndSave(t *testing.T) {
 				ProductService: &MockProductService{},
 				Logger:         flamingo.NullLogger{},
 				EventPublisher: new(MockEventPublisher),
+				EventRouter:    new(MockEventRouter),
 				config: &struct {
 					DefaultDeliveryCode string `inject:"config:commerce.cart.defaultDeliveryCode,optional"`
 					DeleteEmptyDelivery bool   `inject:"config:commerce.cart.deleteEmptyDelivery,optional"`
@@ -671,7 +675,7 @@ func TestCartService_ForceReserveOrderIDAndSave(t *testing.T) {
 						authmanager,
 						userservice,
 						flamingo.NullLogger{},
-						nil,
+						new(MockEventRouter),
 						&struct {
 							CartCache cartApplication.CartCache `inject:",optional"`
 						}{
@@ -683,6 +687,7 @@ func TestCartService_ForceReserveOrderIDAndSave(t *testing.T) {
 				ProductService: &MockProductService{},
 				Logger:         flamingo.NullLogger{},
 				EventPublisher: new(MockEventPublisher),
+				EventRouter:    new(MockEventRouter),
 				config: &struct {
 					DefaultDeliveryCode string `inject:"config:commerce.cart.defaultDeliveryCode,optional"`
 					DeleteEmptyDelivery bool   `inject:"config:commerce.cart.deleteEmptyDelivery,optional"`
@@ -958,7 +963,7 @@ func TestCartService_CartInEvent(t *testing.T) {
 			authmanager,
 			userservice,
 			flamingo.NullLogger{},
-			nil,
+			new(MockEventRouter),
 			&struct {
 				CartCache cartApplication.CartCache `inject:",optional"`
 			}{
@@ -970,7 +975,8 @@ func TestCartService_CartInEvent(t *testing.T) {
 	productService := &MockProductService{}
 	logger := flamingo.NullLogger{}
 	eventPublisher := new(MockEventPublisher)
-	eventPublisher.On("PublishAddToCartEvent", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	eventRouter := new(MockEventRouter)
+	eventRouter.On("Dispatch", mock.Anything, mock.Anything, mock.Anything).Return()
 	config := &struct {
 		DefaultDeliveryCode string `inject:"config:commerce.cart.defaultDeliveryCode,optional"`
 		DeleteEmptyDelivery bool   `inject:"config:commerce.cart.deleteEmptyDelivery,optional"`
@@ -995,7 +1001,7 @@ func TestCartService_CartInEvent(t *testing.T) {
 		cartReceiverService,
 		productService,
 		eventPublisher,
-		nil,
+		eventRouter,
 		deliveryInfoBuilder,
 		restrictionService,
 		authmanager,
@@ -1013,9 +1019,9 @@ func TestCartService_CartInEvent(t *testing.T) {
 	session := web.EmptySession()
 	_, err := cartService.AddProduct(ctx, session, "default_delivery_code", addRequest)
 	assert.Nil(t, err)
-	// white box tests that event publisher has been called with the expected parameters
-	eventPublisher.AssertNumberOfCalls(t, "PublishAddToCartEvent", 1)
-	// quantity of item in cart receiver mock is 7, if product has been added should be 8
-	// this shows that the cart received by the event is the current updated cart
-	eventPublisher.AssertCalled(t, "PublishAddToCartEvent", ctx, 8, "code-1", "", 1)
+	// white box tests that event router has been called as expected (once)
+	eventRouter.AssertNumberOfCalls(t, "Dispatch", 1)
+	// white box test that ensures router has been called with expected parameter (add to cart event)
+	// with the expected marketplace code of the item
+	eventRouter.AssertCalled(t, "Dispatch", ctx, fmt.Sprintf("%T", events.AddToCartEvent{}), addRequest.MarketplaceCode)
 }

--- a/cart/application/cartService_test.go
+++ b/cart/application/cartService_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/go-test/deep"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
 	"flamingo.me/flamingo-commerce/v3/cart/infrastructure"
@@ -1010,8 +1011,8 @@ func TestCartService_CartInEvent(t *testing.T) {
 	}
 	ctx := context.Background()
 	session := web.EmptySession()
-	cartService.AddProduct(ctx, session, "default_delivery_code", addRequest)
-
+	_, err := cartService.AddProduct(ctx, session, "default_delivery_code", addRequest)
+	assert.Nil(t, err)
 	// white box tests that event publisher has been called with the expected parameters
 	eventPublisher.AssertNumberOfCalls(t, "PublishAddToCartEvent", 1)
 	// quantity of item in cart receiver mock is 7, if product has been added should be 8

--- a/cart/domain/events/events.go
+++ b/cart/domain/events/events.go
@@ -14,6 +14,7 @@ type (
 
 	// AddToCartEvent defines event properties
 	AddToCartEvent struct {
+		Cart                   *cartDomain.Cart
 		MarketplaceCode        string
 		VariantMarketplaceCode string
 		ProductName            string
@@ -22,6 +23,8 @@ type (
 
 	// ChangedQtyInCartEvent defines event properties
 	ChangedQtyInCartEvent struct {
+		Cart *cartDomain.Cart
+		// Deprecated: CartID exists for compatibility, use Cart instead
 		CartID                 string
 		MarketplaceCode        string
 		VariantMarketplaceCode string


### PR DESCRIPTION
Hello friends,

currently the `AddToCartEvent` and `ChangedQtyInCartEvent` are published before the cart
has been updated in the cache as they are not part of the deferred events.

When listening to the event as a client, I want to receive the updated cart for evaluation.
This PR addresses this issue by adding the cart to said events, analogue to the `OrderPlacedEvent `.

I think this is how this was intended anyway, as the function `publishAddtoCartEvent` already receives the cart, but it is not used.

Another issue is that the `ChangedQtyInCartEvent` is thrown before the Cart is even updated, which means that the event is thrown even if there is an error with the update.

I am aware that this is a breaking change, but I think the behaviour so far is not correct.

Please review!