### PR TITLE
clear last placed order before showing the success page

### DIFF
--- a/checkout/interfaces/controller/checkoutcontroller.go
+++ b/checkout/interfaces/controller/checkoutcontroller.go
@@ -298,6 +298,7 @@ func (cc *CheckoutController) SuccessAction(ctx context.Context, r *web.Request)
 				PlacedOrderInfos:    placeOrderFlashData.PlacedOrderInfos,
 			}
 
+			cc.orderService.ClearLastPlacedOrder(ctx)
 			return cc.responder.Render("checkout/success", viewData).SetNoCache()
 		}
 	}

--- a/checkout/interfaces/controller/checkoutcontroller.go
+++ b/checkout/interfaces/controller/checkoutcontroller.go
@@ -258,6 +258,7 @@ func (cc *CheckoutController) placeOrderAction(ctx context.Context, r *web.Reque
 		cc.orderService.ClearLastPlacedOrder(ctx)
 	} else {
 		placedOrderInfo, err = cc.orderService.CurrentCartPlaceOrderWithPaymentProcessing(ctx, session)
+		cc.orderService.ClearLastPlacedOrder(ctx)
 
 		if err != nil {
 			cc.logger.WithContext(ctx).WithField("subcategory", "checkoutError").WithField("errorMsg", err.Error()).Error(fmt.Sprintf("place order failed: cart id: %v / total-amount: %v", decoratedCart.Cart.EntityID, decoratedCart.Cart.GrandTotal()))
@@ -298,7 +299,6 @@ func (cc *CheckoutController) SuccessAction(ctx context.Context, r *web.Request)
 				PlacedOrderInfos:    placeOrderFlashData.PlacedOrderInfos,
 			}
 
-			cc.orderService.ClearLastPlacedOrder(ctx)
 			return cc.responder.Render("checkout/success", viewData).SetNoCache()
 		}
 	}


### PR DESCRIPTION
If you try to place two orders right after each other, the second order will show the success page of the first order. Also, the second order is not placed and you keep your cart, despite seeing a success page. This is because the last placed order is still contained in the session. Then, the placeOrderActions only clears the session and does not place an order (see https://github.com/i-love-flamingo/flamingo-commerce/blob/650f15f00af5799dc2779165c785bbf4341ffbc0/checkout/interfaces/controller/checkoutcontroller.go#L256)

To avoid that behavior, we clear the last placed order right before showing the success page. 