### PR TITLE
datalayer: fix panic if not able to build absolute url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 ## v3.0.1
 - Update dingo and form dependency to latest version
         
-## v3.1.0 [upcoming]
+## v3.1.0
 **tests**
 * Added GraphQL integration tests for new Place Order Process, run manually with `make integrationtest`
 * To run the GraphQL Demo project use `make run-integrationtest-demo-project`
@@ -90,3 +90,7 @@ the cart has been adjusted and written back to cache
  
 **search**
 * Extend `Suggestion` struct with `Type` and `AdditionalAttributes` to be able to distinguish between product/category suggestions
+
+## v3.1.1 [upcoming]
+**w3cdatalayer**
+* Fixed a bug that causes the datalayer to panic if it failed to build an absolute url

--- a/w3cdatalayer/application/factory.go
+++ b/w3cdatalayer/application/factory.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha512"
 	"encoding/base64"
 	"flamingo.me/flamingo-commerce/v3/cart/domain/decorator"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -12,13 +13,16 @@ import (
 	productDomain "flamingo.me/flamingo-commerce/v3/product/domain"
 	"flamingo.me/flamingo-commerce/v3/w3cdatalayer/domain"
 	authApplication "flamingo.me/flamingo/v3/core/oauth/application"
+	"flamingo.me/flamingo/v3/framework/flamingo"
 	"flamingo.me/flamingo/v3/framework/web"
+	"github.com/pkg/errors"
 	"go.opencensus.io/tag"
 )
 
 // Factory is used to build new datalayers
 type Factory struct {
 	router            *web.Router
+	logger            flamingo.Logger
 	datalayerProvider domain.DatalayerProvider
 	userService       *authApplication.UserService
 
@@ -38,6 +42,7 @@ type Factory struct {
 // Inject factory dependencies
 func (s *Factory) Inject(
 	router2 *web.Router,
+	logger flamingo.Logger,
 	provider domain.DatalayerProvider,
 	userService *authApplication.UserService,
 	config *struct {
@@ -54,6 +59,7 @@ func (s *Factory) Inject(
 	},
 ) {
 	s.router = router2
+	s.logger = logger
 	s.datalayerProvider = provider
 	s.userService = userService
 
@@ -87,7 +93,11 @@ func (s Factory) BuildForCurrentRequest(ctx context.Context, request *web.Reques
 		language = localeParts[0]
 	}
 
-	baseURL, _ := s.router.Absolute(request, request.Request().URL.Path, nil)
+	baseURL, err := s.router.Absolute(request, request.Request().URL.Path, nil)
+	if err != nil {
+		s.logger.Warn(errors.Wrap(err, "cannot build absolute url"))
+		baseURL = new(url.URL)
+	}
 	layer.Page = &domain.Page{
 		PageInfo: domain.PageInfo{
 			PageID:         request.Request().URL.Path,

--- a/w3cdatalayer/application/factory.go
+++ b/w3cdatalayer/application/factory.go
@@ -59,7 +59,7 @@ func (s *Factory) Inject(
 	},
 ) {
 	s.router = router2
-	s.logger = logger
+	s.logger = logger.WithField(flamingo.LogKeyModule, "w3cdatalayer")
 	s.datalayerProvider = provider
 	s.userService = userService
 


### PR DESCRIPTION
If the router fails to build an absolute url, the datalayer would cause a panic. To avoid that, we now check the error and provide an empty url instead.