### PR TITLE
rearrange CHANGELOG.md so most recent version is at top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,39 @@
 # Changelog
+## v3.2.X [upcoming]
+**w3cdatalayer**
+* Fixed a bug that causes the datalayer to panic if it failed to build an absolute url
+* Introduced a configuration option to choose between base64url and hex encoding for the hashed values
+* Move config to commerce namespace, from `w3cDatalayer` to `commerce.w3cDatalayer`
+* Add legacy config mapping so old mappings can still be used
+* Add cue based config to have config validation in place
 
-## v3
+**checkout**
+* Controller
+  * Allow checkout for fully discounted carts without payment processing. Previously all checkouts needed a valid payment to continue.
+    In case there is nothing to pay this can be skipped.
+    * Order ID will be reserved as soon as the user hits the checkout previously it was done before starting the payment
+* GraphQL
+  * Update place order process to also allow zero carts which don't need payment, this leads to a state flow that lacks the payment steps.
+    See module readme for further details.
+* Update source service to support external location codes.
+  * Adds `ExternalLocationCode` to the `Source` struct.
+  * Update `SetSourcesForCartItems()` to use the new `SourcingServiceDetail` functionality if the bound service implements the interface
+  
+**cart**
+* inMemoryBehaviour: Allow custom logic for GiftCard / Voucher handling
+  * We introduced two new interfaces `GiftCardHandler` + `VoucherHandler`
+  * This enables users of the in-memory cart to add project specific gift card and voucher handling 
+* Fix `CreateInitialDeliveryIfNotPresent` so that cache gets updated now when an initial delivery is created
+* GraphQL: Add new cart validation query `Commerce_Cart_Validator` to check if cart contains valid items
 
-- general cleanups and linting fixes - that includes several renames of packagenames and types.
-- price object introduced:
-    - cart and product model don't use float64 anymore but a Price type
-    - use commercePriceFormat templatefunc instead (core) priceFormat where you want to render a price object. This will automatically render a "Payable" price.
-- cart module:
-    - Has a new secondary port: PlaceOrderService
-    - The meaning of DeliveryInfo.Method has changed! The former meaning is now represented in the property DeliveryInfo.Workflow. See Readme of cart ackage for details
-    - The complete pricefields are changed! Check readme for details on the new price fields and methods
-- checkout: 
-    - removed depricated viewdata (CartTotals)
-- products:
-    - product category breadcrumb is not filled in controller - if you want a breadcrum you can use category data functions
-    - product category fields are changed to use a categoryTeaser    
-- category:
-    - Tree object uses a Tree Entity now which contains NOT all category properties. You have to fetch the category details separate on demand:
-        - search for usages of the data funcs - they may need changes in rendering the data: `data('category´´..`
+**price**
+* IsZero() now uses LikelyEqual() instead of Equal() to avoid issues occurring due to floating-point arithmetic
 
-## v3.0.1
-- Update dingo and form dependency to latest version
-        
+**product**
+* product attributes:
+  * Added `AttributesByKey` domain method to filter attributes by key and exposed this method as `getAttributesByKey` in GraphQL
+  * GraphQL: Exposing `codeLabel` property in the `Commerce_ProductAttribute` type
+
 ## v3.1.0
 **tests**
 * Added GraphQL integration tests for new Place Order Process, run manually with `make integrationtest`
@@ -91,37 +103,23 @@ the cart has been adjusted and written back to cache
 **search**
 * Extend `Suggestion` struct with `Type` and `AdditionalAttributes` to be able to distinguish between product/category suggestions
 
-## v3.2.X [upcoming]
-**w3cdatalayer**
-* Fixed a bug that causes the datalayer to panic if it failed to build an absolute url
-* Introduced a configuration option to choose between base64url and hex encoding for the hashed values
-* Move config to commerce namespace, from `w3cDatalayer` to `commerce.w3cDatalayer`
-* Add legacy config mapping so old mappings can still be used
-* Add cue based config to have config validation in place
+## v3.0.1
+- Update dingo and form dependency to latest version
 
-**checkout**
-* Controller
-  * Allow checkout for fully discounted carts without payment processing. Previously all checkouts needed a valid payment to continue.
-    In case there is nothing to pay this can be skipped.
-    * Order ID will be reserved as soon as the user hits the checkout previously it was done before starting the payment
-* GraphQL
-  * Update place order process to also allow zero carts which don't need payment, this leads to a state flow that lacks the payment steps.
-    See module readme for further details.
-* Update source service to support external location codes.
-  * Adds `ExternalLocationCode` to the `Source` struct.
-  * Update `SetSourcesForCartItems()` to use the new `SourcingServiceDetail` functionality if the bound service implements the interface
-  
-**cart**
-* inMemoryBehaviour: Allow custom logic for GiftCard / Voucher handling
-  * We introduced two new interfaces `GiftCardHandler` + `VoucherHandler`
-  * This enables users of the in-memory cart to add project specific gift card and voucher handling 
-* Fix `CreateInitialDeliveryIfNotPresent` so that cache gets updated now when an initial delivery is created
-* GraphQL: Add new cart validation query `Commerce_Cart_Validator` to check if cart contains valid items
-
-**price**
-* IsZero() now uses LikelyEqual() instead of Equal() to avoid issues occurring due to floating-point arithmetic
-
-**product**
-* product attributes:
-  * Added `AttributesByKey` domain method to filter attributes by key and exposed this method as `getAttributesByKey` in GraphQL
-  * GraphQL: Exposing `codeLabel` property in the `Commerce_ProductAttribute` type
+## v3.0.0
+- general cleanups and linting fixes - that includes several renames of packagenames and types.
+- price object introduced:
+    - cart and product model don't use float64 anymore but a Price type
+    - use commercePriceFormat templatefunc instead (core) priceFormat where you want to render a price object. This will automatically render a "Payable" price.
+- cart module:
+    - Has a new secondary port: PlaceOrderService
+    - The meaning of DeliveryInfo.Method has changed! The former meaning is now represented in the property DeliveryInfo.Workflow. See Readme of cart ackage for details
+    - The complete pricefields are changed! Check readme for details on the new price fields and methods
+- checkout: 
+    - removed depricated viewdata (CartTotals)
+- products:
+    - product category breadcrumb is not filled in controller - if you want a breadcrum you can use category data functions
+    - product category fields are changed to use a categoryTeaser
+- category:
+    - Tree object uses a Tree Entity now which contains NOT all category properties. You have to fetch the category details separate on demand:
+        - search for usages of the data funcs - they may need changes in rendering the data: `data('category´´..`


### PR DESCRIPTION
Most recent changes / versions should be at the top of the CHANGELOG, this reorders the changelog entries.