### PR TITLE
checkout: optional cart validation before place order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
   * **Breaking**: renamed the following GraphQL types
     * type `Commerce_Cart_BillingAddressFormData` is now `Commerce_Cart_AddressForm`
     * input `Commerce_BillingAddressFormInput` is now `Commerce_Cart_AddressFormInput`
+ 
+**checkout**
+* Make cart validation before place order optional with configuration
 
 ## v3.2.0
 **w3cdatalayer**

--- a/checkout/Changelog.md
+++ b/checkout/Changelog.md
@@ -23,3 +23,6 @@
     * Add new `TryLocker` port to provide an easy way to sync multiple order processes across different nodes
         * Provide InMemory and Redis Adapter
     * Breaking: Add new GraphQL mutations / queries to start / stop / refresh the place order process
+
+# 22. April 2020
+* Add coniguration to switch off cart validation on place order

--- a/checkout/Readme.md
+++ b/checkout/Readme.md
@@ -47,6 +47,7 @@ commerce:
 
     # GraphQL place order process
     placeorder:
+      validateBeforePlace: true
       lock: 
         type: "memory" # only suited for single node applications, use "redis" for multi node setup
       contextstore:

--- a/checkout/application/orderService_test.go
+++ b/checkout/application/orderService_test.go
@@ -46,7 +46,7 @@ func TestOrderService_LastPlacedOrder(t *testing.T) {
 			}
 
 			os := &application.OrderService{}
-			os.Inject(nil, flamingo.NullLogger{}, nil, nil, nil, fakeGatewayProvider, nil)
+			os.Inject(nil, flamingo.NullLogger{}, nil, nil, nil, fakeGatewayProvider, nil, nil)
 			got, err := os.LastPlacedOrder(tt.args.ctx)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("LastPlacedOrder() error = %v, wantErr %v", err, tt.wantErr)
@@ -65,7 +65,7 @@ func TestOrderService_ClearLastPlacedOrder(t *testing.T) {
 	}
 
 	os := &application.OrderService{}
-	os.Inject(nil, flamingo.NullLogger{}, nil, nil, nil, fakeGatewayProvider, nil)
+	os.Inject(nil, flamingo.NullLogger{}, nil, nil, nil, fakeGatewayProvider, nil, nil)
 
 	want := &application.PlaceOrderInfo{
 		PaymentInfos: nil,

--- a/checkout/module.go
+++ b/checkout/module.go
@@ -118,6 +118,7 @@ commerce: checkout: {
 	redirectToCartOnInvalidCart?:     bool
 	privacyPolicyRequired?:           bool
 	placeorder: {
+		validateBeforePlace: bool | *true
 		lock: {
 			type: *"memory" | "redis"
 			if type == "redis" {


### PR DESCRIPTION
When using the place order state machine, one of the first steps during the process is already validating the cart.
Afterwards the cart is closed and stored inside the context store.
When then later placing the order the OrderService performs the cart validation again.

At this time the cart is already closed and if a validator tries to fetch the cart from the session, an empty cart returns which can lead to invalid validation results.