### PR TITLE
checkout: Add metrics to the standard place order process.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@
     * type `Commerce_Cart_BillingAddressFormData` is now `Commerce_Cart_AddressForm`
     * input `Commerce_BillingAddressFormInput` is now `Commerce_Cart_AddressFormInput`
 
+**checkout**
+* State Machine
+  * Add additional metrics to monitor place order flow
+    * flamingo_commerce_checkout_placeorder_starts
+    * flamingo_commerce_checkout_placeorder_state_run_count
+    * flamingo_commerce_checkout_placeorder_state_failed_count
+
 ## v3.2.0
 **w3cdatalayer**
 * Fixed a bug that causes the datalayer to panic if it failed to build an absolute url

--- a/checkout/application/placeorder/coordinator.go
+++ b/checkout/application/placeorder/coordinator.go
@@ -65,12 +65,12 @@ var (
 	maxLockDuration = 2 * time.Minute
 
 	// newUUIDCount counts generation of new UUIDs
-	newUUIDCount = stats.Int64("flamingo/standard_place_order/new_uuid", "Count of logs", stats.UnitDimensionless)
+	newUUIDCount = stats.Int64("flamingo-commerce/checkout/placeorder/starts", "", stats.UnitDimensionless)
 )
 
 func init() {
 	gob.Register(process.Context{})
-	err := opencensus.View("flamingo/standard_place_order/new_uuid", newUUIDCount, view.Count())
+	err := opencensus.View("flamingo-commerce/checkout/placeorder/starts", newUUIDCount, view.Count())
 	if err != nil {
 		panic(err)
 	}

--- a/checkout/application/placeorder/coordinator.go
+++ b/checkout/application/placeorder/coordinator.go
@@ -66,13 +66,13 @@ var (
 
 	maxLockDuration = 2 * time.Minute
 
-	// newUUIDCount counts generation of new UUIDs
-	newUUIDCount = stats.Int64("flamingo-commerce/checkout/placeorder/starts", "", stats.UnitDimensionless)
+	// startCount counts starts of new place order processes
+	startCount = stats.Int64("flamingo-commerce/checkout/placeorder/starts", "Counts how often a new place order process was started", stats.UnitDimensionless)
 )
 
 func init() {
 	gob.Register(process.Context{})
-	err := opencensus.View("flamingo-commerce/checkout/placeorder/starts", newUUIDCount, view.Count())
+	err := opencensus.View("flamingo-commerce/checkout/placeorder/starts", startCount, view.Count())
 	if err != nil {
 		panic(err)
 	}
@@ -137,7 +137,7 @@ func (c *Coordinator) New(ctx context.Context, cart cartDomain.Cart, returnURL *
 		}
 
 		censusCtx, _ := tag.New(ctx, tag.Upsert(opencensus.KeyArea, c.area))
-		stats.Record(censusCtx, newUUIDCount.M(1))
+		stats.Record(censusCtx, startCount.M(1))
 		newProcess, err := c.processFactory.New(returnURL, cart)
 		if err != nil {
 			runErr = err

--- a/checkout/domain/placeorder/process/process.go
+++ b/checkout/domain/placeorder/process/process.go
@@ -78,9 +78,9 @@ type (
 
 var (
 	// processedState counts processed states
-	processedState = stats.Int64("flamingo/standard_place_order/processed_state", "Count of processed states", stats.UnitDimensionless)
+	processedState = stats.Int64("flamingo-commerce/checkout/placeorder/state_run_count", "", stats.UnitDimensionless)
 	// failedStateTransition counts failed state transitions
-	failedStateTransition = stats.Int64("flamingo/standard_place_order/failed_state_transition", "Count of processed states", stats.UnitDimensionless)
+	failedStateTransition = stats.Int64("flamingo-commerce/checkout/placeorder/state_failed_count", "", stats.UnitDimensionless)
 	keyState, _           = tag.NewKey("state")
 )
 
@@ -91,10 +91,10 @@ func init() {
 	gob.Register(CartValidationErrorReason{})
 	gob.Register(CanceledByCustomerReason{})
 
-	if err := opencensus.View("flamingo/standard_place_order/processed_state", processedState, view.Count(), keyState); err != nil {
+	if err := opencensus.View("flamingo-commerce/checkout/placeorder/state_run_count", processedState, view.Count(), keyState); err != nil {
 		panic(err)
 	}
-	if err := opencensus.View("flamingo/standard_place_order/failed_state_transition", failedStateTransition, view.Count(), keyState); err != nil {
+	if err := opencensus.View("flamingo-commerce/checkout/placeorder/state_failed_count", failedStateTransition, view.Count(), keyState); err != nil {
 		panic(err)
 	}
 }
@@ -187,7 +187,7 @@ func (p *Process) Run(ctx context.Context) {
 		return
 	}
 
-	censusCtx, _ := tag.New(ctx, tag.Upsert(opencensus.KeyArea, "-"), tag.Upsert(keyState, currentState.Name()))
+	censusCtx, _ := tag.New(ctx, tag.Upsert(keyState, currentState.Name()))
 	stats.Record(censusCtx, processedState.M(1))
 
 	runResult := currentState.Run(ctx, p)

--- a/checkout/domain/placeorder/process/process.go
+++ b/checkout/domain/placeorder/process/process.go
@@ -79,9 +79,9 @@ type (
 
 var (
 	// processedState counts processed states
-	processedState = stats.Int64("flamingo-commerce/checkout/placeorder/state_run_count", "", stats.UnitDimensionless)
+	processedState = stats.Int64("flamingo-commerce/checkout/placeorder/state_run_count", "Counts how often a state is run", stats.UnitDimensionless)
 	// failedStateTransition counts failed state transitions
-	failedStateTransition = stats.Int64("flamingo-commerce/checkout/placeorder/state_failed_count", "", stats.UnitDimensionless)
+	failedStateTransition = stats.Int64("flamingo-commerce/checkout/placeorder/state_failed_count", "Counts how often running a state resulted in a failure", stats.UnitDimensionless)
 	keyState, _           = tag.NewKey("state")
 )
 


### PR DESCRIPTION
checkout: Add metrics to the standard place order process.

The following open census metrics are now exposed:
-  no of starts w/ new uuid
    - flamingo_standard_place_order_new_uuid{area=""} 1
-  no of runs for each state (bucket)
    - example for a state: flamingo_standard_place_order_processed_state{area="-",state="CompleteCart"} 3
-  no of failed state transitions by state name (bucket)
    - example for a state: flamingo_standard_place_order_failed_state_transition{area="-",state="CompleteCart"} 1