### PR TITLE
cart: item validation must rely on given cart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * exposed loyalty earnings
 
 **cart**
+* **Breaking**: Cart item validation now requires the decorated cart to be passed to assure that validators don't rely on a cart from any other source (e.g. session)
 * GraphQL
   * Add new mutation to set / update one or multiple delivery addresses `Commerce_Cart_UpdateDeliveryAddresses`
   * Add new mutation to update the shipping options (carrier / method) of an existing delivery `Commerce_Cart_UpdateDeliveryShippingOptions`
@@ -26,7 +27,6 @@
   * `Commerce_Customer` returns the logged-in customer
  
 **checkout**
-* Cart item validation now requires the decorated cart to be passed to assure that validators don't rely on a cart from any other source (e.g. session)
 * State Machine
   * Add additional metrics to monitor place order flow
     * flamingo_commerce_checkout_placeorder_starts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
   * `Commerce_Customer` returns the logged-in customer
  
 **checkout**
-* Make cart validation before place order optional with configuration
+* Cart item validation now requires the decorated cart to be passed to assure that validators don't rely on a cart from any other source (e.g. session)
 * State Machine
   * Add additional metrics to monitor place order flow
     * flamingo_commerce_checkout_placeorder_starts

--- a/cart/Changelog.md
+++ b/cart/Changelog.md
@@ -96,3 +96,7 @@ the cart has been adjusted and written back to cache
 
 * Update pagination module configuration. Use "commerce.pagination" namespace for configuration now.
 * search and product module configuration is using CueConfig - and therefore config options can be looked up in the commandline
+
+# 26. May 2020
+
+* Change `ItemValidator` interface to require the decorated cart, so that implemented validators don't ave to load the cart again which can be the wrong cart after all. 

--- a/cart/application/cartReceiver_test.go
+++ b/cart/application/cartReceiver_test.go
@@ -6,14 +6,6 @@ import (
 	"reflect"
 	"testing"
 
-	cartApplication "flamingo.me/flamingo-commerce/v3/cart/application"
-	cartDomain "flamingo.me/flamingo-commerce/v3/cart/domain/cart"
-	"flamingo.me/flamingo-commerce/v3/cart/domain/decorator"
-	"flamingo.me/flamingo-commerce/v3/cart/domain/events"
-	"flamingo.me/flamingo-commerce/v3/cart/domain/placeorder"
-	"flamingo.me/flamingo-commerce/v3/cart/domain/validation"
-	cartInfrastructure "flamingo.me/flamingo-commerce/v3/cart/infrastructure"
-	productDomain "flamingo.me/flamingo-commerce/v3/product/domain"
 	authApplication "flamingo.me/flamingo/v3/core/oauth/application"
 	"flamingo.me/flamingo/v3/core/oauth/domain"
 	"flamingo.me/flamingo/v3/framework/flamingo"
@@ -23,6 +15,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"golang.org/x/oauth2"
+
+	cartApplication "flamingo.me/flamingo-commerce/v3/cart/application"
+	cartDomain "flamingo.me/flamingo-commerce/v3/cart/domain/cart"
+	"flamingo.me/flamingo-commerce/v3/cart/domain/decorator"
+	"flamingo.me/flamingo-commerce/v3/cart/domain/events"
+	"flamingo.me/flamingo-commerce/v3/cart/domain/placeorder"
+	cartInfrastructure "flamingo.me/flamingo-commerce/v3/cart/infrastructure"
+	productDomain "flamingo.me/flamingo-commerce/v3/product/domain"
 )
 
 type (
@@ -178,27 +178,6 @@ func (m *MockEventPublisher) PublishChangedQtyInCartEvent(ctx context.Context, c
 func (m *MockEventPublisher) PublishOrderPlacedEvent(ctx context.Context, cart *cartDomain.Cart, placedOrderInfos placeorder.PlacedOrderInfos) {
 	m.Called()
 }
-
-// MockCartValidator
-type (
-	MockCartValidator struct{}
-)
-
-func (m *MockCartValidator) Validate(ctx context.Context, session *web.Session, cart *decorator.DecoratedCart) validation.Result {
-	return validation.Result{}
-}
-
-// MockItemValidator
-
-type (
-	MockItemValidator struct{}
-)
-
-func (m *MockItemValidator) Validate(ctx context.Context, session *web.Session, deliveryCode string, request cartDomain.AddRequest, product productDomain.BasicProduct) error {
-	return nil
-}
-
-// MockDeliveryInfoBuilder
 
 type (
 	MockDeliveryInfoBuilder struct{}

--- a/cart/domain/validation/itemValidator.go
+++ b/cart/domain/validation/itemValidator.go
@@ -3,6 +3,8 @@ package validation
 import (
 	"context"
 	"flamingo.me/flamingo-commerce/v3/cart/domain/cart"
+	"flamingo.me/flamingo-commerce/v3/cart/domain/decorator"
+
 	"fmt"
 
 	"flamingo.me/flamingo-commerce/v3/product/domain"
@@ -12,7 +14,7 @@ import (
 type (
 	// ItemValidator checks a cart item
 	ItemValidator interface {
-		Validate(ctx context.Context, session *web.Session, deliveryCode string, request cart.AddRequest, product domain.BasicProduct) error
+		Validate(ctx context.Context, session *web.Session, cart *decorator.DecoratedCart, deliveryCode string, request cart.AddRequest, product domain.BasicProduct) error
 	}
 
 	// AddToCartNotAllowed error

--- a/checkout/Changelog.md
+++ b/checkout/Changelog.md
@@ -23,6 +23,3 @@
     * Add new `TryLocker` port to provide an easy way to sync multiple order processes across different nodes
         * Provide InMemory and Redis Adapter
     * Breaking: Add new GraphQL mutations / queries to start / stop / refresh the place order process
-
-# 22. April 2020
-* Add coniguration to switch off cart validation on place order

--- a/checkout/Readme.md
+++ b/checkout/Readme.md
@@ -47,7 +47,6 @@ commerce:
 
     # GraphQL place order process
     placeorder:
-      validateBeforePlace: true
       lock: 
         type: "memory" # only suited for single node applications, use "redis" for multi node setup
       contextstore:

--- a/checkout/application/orderService_test.go
+++ b/checkout/application/orderService_test.go
@@ -46,7 +46,7 @@ func TestOrderService_LastPlacedOrder(t *testing.T) {
 			}
 
 			os := &application.OrderService{}
-			os.Inject(nil, flamingo.NullLogger{}, nil, nil, nil, fakeGatewayProvider, nil, nil)
+			os.Inject(nil, flamingo.NullLogger{}, nil, nil, nil, fakeGatewayProvider, nil)
 			got, err := os.LastPlacedOrder(tt.args.ctx)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("LastPlacedOrder() error = %v, wantErr %v", err, tt.wantErr)
@@ -65,7 +65,7 @@ func TestOrderService_ClearLastPlacedOrder(t *testing.T) {
 	}
 
 	os := &application.OrderService{}
-	os.Inject(nil, flamingo.NullLogger{}, nil, nil, nil, fakeGatewayProvider, nil, nil)
+	os.Inject(nil, flamingo.NullLogger{}, nil, nil, nil, fakeGatewayProvider, nil)
 
 	want := &application.PlaceOrderInfo{
 		PaymentInfos: nil,

--- a/checkout/module.go
+++ b/checkout/module.go
@@ -118,7 +118,6 @@ commerce: checkout: {
 	redirectToCartOnInvalidCart?:     bool
 	privacyPolicyRequired?:           bool
 	placeorder: {
-		validateBeforePlace: bool | *true
 		lock: {
 			type: *"memory" | "redis"
 			if type == "redis" {


### PR DESCRIPTION
The cart item validation gets the cart passed as argument to prevent single validator implementations to load the cart again from different sources (like session or cart service)

This assures that the correct cart is validated