### PR TITLE
Add module tests to all modules lacking one

### DIFF
--- a/breadcrumbs/module_test.go
+++ b/breadcrumbs/module_test.go
@@ -1,0 +1,14 @@
+package breadcrumbs_test
+
+import (
+	"testing"
+
+	"flamingo.me/flamingo-commerce/v3/breadcrumbs"
+	"flamingo.me/flamingo/v3/framework/config"
+)
+
+func TestModule_Configure(t *testing.T) {
+	if err := config.TryModules(nil, new(breadcrumbs.Module)); err != nil {
+		t.Error(err)
+	}
+}

--- a/category/module_test.go
+++ b/category/module_test.go
@@ -3,12 +3,12 @@ package category_test
 import (
 	"testing"
 
-	"flamingo.me/dingo"
 	"flamingo.me/flamingo-commerce/v3/category"
+	"flamingo.me/flamingo/v3/framework/config"
 )
 
 func TestModule_Configure(t *testing.T) {
-	if err := dingo.TryModule(new(category.Module)); err != nil {
+	if err := config.TryModules(config.Map{"commerce.category.useCategoryFixedAdapter": true}, new(category.Module)); err != nil {
 		t.Error(err)
 	}
 }

--- a/customer/module_test.go
+++ b/customer/module_test.go
@@ -1,0 +1,14 @@
+package customer_test
+
+import (
+	"testing"
+
+	"flamingo.me/flamingo-commerce/v3/customer"
+	"flamingo.me/flamingo/v3/framework/config"
+)
+
+func TestModule_Configure(t *testing.T) {
+	if err := config.TryModules(config.Map{"commerce.customer.useNilCustomerAdapter": true}, new(customer.Module)); err != nil {
+		t.Error(err)
+	}
+}

--- a/order/module.go
+++ b/order/module.go
@@ -5,14 +5,12 @@ import (
 	"flamingo.me/flamingo-commerce/v3/order/domain"
 	"flamingo.me/flamingo-commerce/v3/order/infrastructure/fake"
 	"flamingo.me/flamingo-commerce/v3/order/interfaces/controller"
-	"flamingo.me/flamingo/v3/framework/flamingo"
 	"flamingo.me/flamingo/v3/framework/web"
 )
 
 type (
 	// Module definition of the order module
 	Module struct {
-		logger             flamingo.Logger
 		useFakeAdapters    bool
 		useInMemoryService bool
 	}
@@ -25,12 +23,10 @@ const (
 
 // Inject dependencies
 func (m *Module) Inject(
-	logger flamingo.Logger,
 	config *struct {
 		UseFakeAdapters bool `inject:"config:order.useFakeAdapters,optional"`
 	},
 ) {
-	m.logger = logger
 	if config != nil {
 		m.useFakeAdapters = config.UseFakeAdapters
 	}

--- a/order/module_test.go
+++ b/order/module_test.go
@@ -1,0 +1,14 @@
+package order_test
+
+import (
+	"testing"
+
+	"flamingo.me/flamingo-commerce/v3/order"
+	"flamingo.me/flamingo/v3/framework/config"
+)
+
+func TestModule_Configure(t *testing.T) {
+	if err := config.TryModules(config.Map{"order.useFakeAdapters": true}, new(order.Module)); err != nil {
+		t.Error(err)
+	}
+}

--- a/payment/module_test.go
+++ b/payment/module_test.go
@@ -3,12 +3,12 @@ package payment_test
 import (
 	"testing"
 
-	"flamingo.me/dingo"
 	"flamingo.me/flamingo-commerce/v3/payment"
+	"flamingo.me/flamingo/v3/framework/config"
 )
 
 func TestModule_Configure(t *testing.T) {
-	if err := dingo.TryModule(new(payment.Module)); err != nil {
+	if err := config.TryModules(nil, new(payment.Module)); err != nil {
 		t.Error(err)
 	}
 }

--- a/price/module_test.go
+++ b/price/module_test.go
@@ -1,0 +1,14 @@
+package price_test
+
+import (
+	"testing"
+
+	"flamingo.me/flamingo-commerce/v3/price"
+	"flamingo.me/flamingo/v3/framework/config"
+)
+
+func TestModule_Configure(t *testing.T) {
+	if err := config.TryModules(nil, new(price.Module)); err != nil {
+		t.Error(err)
+	}
+}

--- a/product/module_test.go
+++ b/product/module_test.go
@@ -3,12 +3,12 @@ package product_test
 import (
 	"testing"
 
-	"flamingo.me/dingo"
 	"flamingo.me/flamingo-commerce/v3/product"
+	"flamingo.me/flamingo/v3/framework/config"
 )
 
 func TestModule_Configure(t *testing.T) {
-	if err := dingo.TryModule(new(product.Module)); err != nil {
+	if err := config.TryModules(nil, new(product.Module)); err != nil {
 		t.Error(err)
 	}
 }

--- a/search/module_test.go
+++ b/search/module_test.go
@@ -1,0 +1,14 @@
+package search_test
+
+import (
+	"testing"
+
+	"flamingo.me/flamingo-commerce/v3/search"
+	"flamingo.me/flamingo/v3/framework/config"
+)
+
+func TestModule_Configure(t *testing.T) {
+	if err := config.TryModules(nil, new(search.Module)); err != nil {
+		t.Error(err)
+	}
+}

--- a/w3cdatalayer/module_test.go
+++ b/w3cdatalayer/module_test.go
@@ -1,0 +1,14 @@
+package w3cdatalayer_test
+
+import (
+	"testing"
+
+	"flamingo.me/flamingo-commerce/v3/w3cdatalayer"
+	"flamingo.me/flamingo/v3/framework/config"
+)
+
+func TestModule_Configure(t *testing.T) {
+	if err := config.TryModules(nil, new(w3cdatalayer.Module)); err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
A basic Flamingo module should always include an according test case that ensures that dingo dependencies and config is working properly. 

This PR adds the missing ones and updates existing ones for better test coverage.