### PR TITLE
product: expose unit codes of variant attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * GraphQL
   * Added values field of Attribute to schema
   * exposed loyalty earnings
+* Expose unit of product variant attributes
 
 **cart**
 * **Breaking**: Cart item validation now requires the decorated cart to be passed to assure that validators don't rely on a cart from any other source (e.g. session)

--- a/product/interfaces/controller/controller.go
+++ b/product/interfaces/controller/controller.go
@@ -51,6 +51,7 @@ type (
 		Title        string
 		Combinations map[string][]string
 		Selected     bool
+		Unit         string
 	}
 
 	viewVariant struct {
@@ -66,6 +67,7 @@ func (vc *View) variantSelection(configurable domain.ConfigurableProduct, active
 	var variants variantSelection
 	combinations := make(map[string]map[string]map[string]map[string]bool)
 	titles := make(map[string]map[string]string)
+	units := make(map[string]map[string]string)
 
 	combinationsOrder := make(map[string][]string)
 
@@ -73,9 +75,11 @@ func (vc *View) variantSelection(configurable domain.ConfigurableProduct, active
 		// attribute -> value -> combinableAttribute -> combinableValue -> true
 		combinations[attribute] = make(map[string]map[string]map[string]bool)
 		titles[attribute] = make(map[string]string)
+		units[attribute] = make(map[string]string)
 
 		for _, variant := range configurable.Variants {
 			titles[attribute][variant.Attributes[attribute].Value()] = variant.Attributes[attribute].Label
+			units[attribute][variant.Attributes[attribute].Value()] = variant.Attributes[attribute].UnitCode
 
 			for _, subattribute := range configurable.VariantVariationAttributes {
 				if _, ok := variant.Attributes[attribute]; !ok {
@@ -145,6 +149,7 @@ func (vc *View) variantSelection(configurable domain.ConfigurableProduct, active
 				Title:        label,
 				Selected:     selected,
 				Combinations: combinations,
+				Unit:         units[code][optionCode],
 			})
 		}
 

--- a/product/interfaces/controller/controller_test.go
+++ b/product/interfaces/controller/controller_test.go
@@ -321,6 +321,65 @@ func TestViewController_variantSelection(t *testing.T) {
 				},
 			},
 		},
+		{
+			variantVariationAttributesSorting: map[string][]string{"volume": {"500", "1"}},
+			variants: []domain.Variant{
+				{
+					BasicProductData: domain.BasicProductData{
+						Attributes: domain.Attributes{"volume": {Label: "500ML", CodeLabel: "Volume", RawValue: "500", UnitCode: "MILLILITER"}},
+						StockLevel: "high",
+					},
+				},
+				{
+					BasicProductData: domain.BasicProductData{
+						Attributes: domain.Attributes{"volume": {Label: "1L", CodeLabel: "Volume", RawValue: "1", UnitCode: "LITER"}},
+						StockLevel: "high",
+					},
+				},
+			},
+			activeVariant: &domain.Variant{
+				BasicProductData: domain.BasicProductData{
+					Attributes: map[string]domain.Attribute{
+						"volume": {Label: "500ML", CodeLabel: "Volume", RawValue: "500", UnitCode: "MILLILITER"},
+					},
+				},
+			},
+
+			out: variantSelection{
+				Attributes: []viewVariantAttribute{
+					{
+						Key:       "volume",
+						Title:     "Volume",
+						CodeLabel: "Volume",
+						Options: []viewVariantOption{
+							{
+								Key:      "500",
+								Title:    "500ML",
+								Selected: true,
+								Unit:     "MILLILITER",
+							},
+							{
+								Key:   "1",
+								Title: "1L",
+								Unit:  "LITER",
+							},
+						},
+					},
+				},
+				Variants: []viewVariant{
+					{
+						Attributes: map[string]string{"volume": "500"},
+						URL:        "/?marketplacecode=&name=&variantcode=",
+						InStock:    true,
+					},
+					{
+						Attributes: map[string]string{"volume": "1"},
+						URL:        "/?marketplacecode=&name=&variantcode=",
+						InStock:    true,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -396,6 +455,9 @@ func viewVariantOptionsEqual(t *testing.T, o1, o2 viewVariantOption) bool {
 		return false
 	}
 	if o1.Selected != o2.Selected {
+		return false
+	}
+	if o1.Unit != o2.Unit {
 		return false
 	}
 	if len(o1.Combinations) != len(o2.Combinations) {

--- a/product/interfaces/controller/controller_test.go
+++ b/product/interfaces/controller/controller_test.go
@@ -326,13 +326,13 @@ func TestViewController_variantSelection(t *testing.T) {
 			variants: []domain.Variant{
 				{
 					BasicProductData: domain.BasicProductData{
-						Attributes: domain.Attributes{"volume": {Label: "500ML", CodeLabel: "Volume", RawValue: "500", UnitCode: "MILLILITER"}},
+						Attributes: domain.Attributes{"volume": {CodeLabel: "Volume", RawValue: "500", UnitCode: "MILLILITRE"}},
 						StockLevel: "high",
 					},
 				},
 				{
 					BasicProductData: domain.BasicProductData{
-						Attributes: domain.Attributes{"volume": {Label: "1L", CodeLabel: "Volume", RawValue: "1", UnitCode: "LITER"}},
+						Attributes: domain.Attributes{"volume": {CodeLabel: "Volume", RawValue: "1", UnitCode: "LITRE"}},
 						StockLevel: "high",
 					},
 				},
@@ -340,7 +340,7 @@ func TestViewController_variantSelection(t *testing.T) {
 			activeVariant: &domain.Variant{
 				BasicProductData: domain.BasicProductData{
 					Attributes: map[string]domain.Attribute{
-						"volume": {Label: "500ML", CodeLabel: "Volume", RawValue: "500", UnitCode: "MILLILITER"},
+						"volume": {CodeLabel: "Volume", RawValue: "500", UnitCode: "MILLILITRE"},
 					},
 				},
 			},
@@ -354,14 +354,14 @@ func TestViewController_variantSelection(t *testing.T) {
 						Options: []viewVariantOption{
 							{
 								Key:      "500",
-								Title:    "500ML",
+								Title:    "500",
 								Selected: true,
-								Unit:     "MILLILITER",
+								Unit:     "MILLILITRE",
 							},
 							{
 								Key:   "1",
-								Title: "1L",
-								Unit:  "LITER",
+								Title: "1",
+								Unit:  "LITRE",
 							},
 						},
 					},


### PR DESCRIPTION
The viewVariantOption struct is missing the unit of the specific variant to be able to display it in the template.