### PR TITLE
checkout: Improve controller error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@
     * flamingo_commerce_checkout_placeorder_state_run_count
     * flamingo_commerce_checkout_placeorder_state_failed_count
 * Expose placeorder endpoints also via rest
+* In case of a payment error the checkoutcontroller will no redirect to the review form instead of just rendering it.
+* In case of an error during place order, the checkoutcontroller will no redirect to the checkout step instead of just rendering it.
+* In both cases the error will be stored in the session and restored from the corresponding action. 
     
 **search**
 * Switch module config to CUE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,10 @@
     * flamingo_commerce_checkout_placeorder_state_run_count
     * flamingo_commerce_checkout_placeorder_state_failed_count
 * Expose placeorder endpoints also via rest
-* In case of a payment error the checkoutcontroller will no redirect to the review form instead of just rendering it.
-* In case of an error during place order, the checkoutcontroller will no redirect to the checkout step instead of just rendering it.
-* In both cases the error will be stored in the session and restored from the corresponding action. 
+* Checkout controller, update to the error handling:
+  * In case of a payment error the checkout controller will now redirect to the checkout/review action instead of just rendering the matching template on the current route.
+  * Same applies in case of an error during place order, the checkout controller will now redirect to the checkout step.
+  * In both cases the error will be stored as a flash message in the session before redirecting, the target action will then receive it and pass it to the template view data. 
     
 **search**
 * Switch module config to CUE

--- a/cart/application/cartService.go
+++ b/cart/application/cartService.go
@@ -647,7 +647,7 @@ func (cs *CartService) DeleteDelivery(ctx context.Context, session *web.Session,
 }
 
 // BuildAddRequest Helper to build
-func (cs *CartService) BuildAddRequest(ctx context.Context, marketplaceCode string, variantMarketplaceCode string, qty int, additionalData map[string]string) cartDomain.AddRequest {
+func (cs *CartService) BuildAddRequest(_ context.Context, marketplaceCode string, variantMarketplaceCode string, qty int, additionalData map[string]string) cartDomain.AddRequest {
 	if qty < 0 {
 		qty = 0
 	}
@@ -844,7 +844,7 @@ func (cs *CartService) executeVoucherBehaviour(ctx context.Context, session *web
 
 func (cs *CartService) handleCartNotFound(session *web.Session, err error) {
 	if err == cartDomain.ErrCartNotFound {
-		cs.DeleteSavedSessionGuestCartID(session)
+		_ = cs.DeleteSavedSessionGuestCartID(session)
 	}
 }
 
@@ -915,7 +915,7 @@ func (cs *CartService) updateCartInCacheIfCacheIsEnabled(ctx context.Context, se
 }
 
 // DeleteCartInCache removes the cart from cache
-func (cs *CartService) DeleteCartInCache(ctx context.Context, session *web.Session, cart *cartDomain.Cart) {
+func (cs *CartService) DeleteCartInCache(ctx context.Context, session *web.Session, _ *cartDomain.Cart) {
 	if cs.cartCache != nil {
 		id, err := cs.cartCache.BuildIdentifier(ctx, session)
 		if err != nil {
@@ -1005,12 +1005,11 @@ func (cs *CartService) placeOrder(ctx context.Context, session *web.Session, car
 
 	if errPlaceOrder != nil {
 		cs.handleCartNotFound(session, errPlaceOrder)
-		cs.logger.WithContext(ctx).Error(errPlaceOrder)
 		return nil, errPlaceOrder
 	}
 
 	cs.eventPublisher.PublishOrderPlacedEvent(ctx, cart, placeOrderInfos)
-	cs.DeleteSavedSessionGuestCartID(session)
+	_ = cs.DeleteSavedSessionGuestCartID(session)
 	cs.DeleteCartInCache(ctx, session, cart)
 
 	return placeOrderInfos, nil
@@ -1173,7 +1172,7 @@ func (cs *CartService) generateRestrictedQtyAdjustments(ctx context.Context, ses
 	return result, nil
 }
 
-func (cs *CartService) getProductWithActiveVariantIfProductIsConfigurable(ctx context.Context, product productDomain.BasicProduct, variantMarketplaceCode string) (productDomain.BasicProduct, error) {
+func (cs *CartService) getProductWithActiveVariantIfProductIsConfigurable(_ context.Context, product productDomain.BasicProduct, variantMarketplaceCode string) (productDomain.BasicProduct, error) {
 	var err error
 	if product.Type() != productDomain.TypeConfigurable {
 		return product, nil

--- a/cart/application/cartService_test.go
+++ b/cart/application/cartService_test.go
@@ -794,7 +794,6 @@ func (m *MockGuestCartServiceWithModifyBehaviour) GetModifyBehaviour(context.Con
 		nil,
 		nil,
 		nil,
-		nil,
 	)
 
 	return cob, nil

--- a/cart/infrastructure/InMemoryBehaviour.go
+++ b/cart/infrastructure/InMemoryBehaviour.go
@@ -72,7 +72,6 @@ func (cob *InMemoryBehaviour) Inject(
 	itemBuilderProvider domaincart.ItemBuilderProvider,
 	deliveryBuilderProvider domaincart.DeliveryBuilderProvider,
 	cartBuilderProvider domaincart.BuilderProvider,
-	eventPublisher events.EventPublisher,
 	voucherHandler VoucherHandler,
 	giftCardHandler GiftCardHandler,
 	config *struct {
@@ -308,7 +307,7 @@ func (cob *InMemoryBehaviour) buildItemForCart(ctx context.Context, addRequest d
 }
 
 // CleanCart removes all deliveries and their items from the cart
-func (cob *InMemoryBehaviour) CleanCart(ctx context.Context, cart *domaincart.Cart) (*domaincart.Cart, domaincart.DeferEvents, error) {
+func (cob *InMemoryBehaviour) CleanCart(_ context.Context, cart *domaincart.Cart) (*domaincart.Cart, domaincart.DeferEvents, error) {
 	if !cob.cartStorage.HasCart(cart.ID) {
 		return nil, nil, fmt.Errorf("cart.infrastructure.InMemoryBehaviour: Cannot delete - Guestcart with id %v not existent", cart.ID)
 	}
@@ -355,13 +354,21 @@ func (cob *InMemoryBehaviour) CleanDelivery(ctx context.Context, cart *domaincar
 	return cob.resetPaymentSelectionIfInvalid(ctx, cart)
 }
 
-// UpdatePurchaser @todo implement when needed
-func (cob *InMemoryBehaviour) UpdatePurchaser(ctx context.Context, cart *domaincart.Cart, purchaser *domaincart.Person, additionalData *domaincart.AdditionalData) (*domaincart.Cart, domaincart.DeferEvents, error) {
+// UpdatePurchaser sets the purchaser data and the additional data on the cart
+func (cob *InMemoryBehaviour) UpdatePurchaser(_ context.Context, cart *domaincart.Cart, purchaser *domaincart.Person, additionalData *domaincart.AdditionalData) (*domaincart.Cart, domaincart.DeferEvents, error) {
+	cart.Purchaser = purchaser
+	cart.AdditionalData = *additionalData
+
+	err := cob.cartStorage.StoreCart(cart)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "cart.infrastructure.InMemoryBehaviour: error on saving cart")
+	}
+
 	return cart, nil, nil
 }
 
-// UpdateBillingAddress - updates address
-func (cob *InMemoryBehaviour) UpdateBillingAddress(ctx context.Context, cart *domaincart.Cart, billingAddress domaincart.Address) (*domaincart.Cart, domaincart.DeferEvents, error) {
+// UpdateBillingAddress updates the billing address
+func (cob *InMemoryBehaviour) UpdateBillingAddress(_ context.Context, cart *domaincart.Cart, billingAddress domaincart.Address) (*domaincart.Cart, domaincart.DeferEvents, error) {
 
 	cart.BillingAddress = &billingAddress
 
@@ -374,7 +381,7 @@ func (cob *InMemoryBehaviour) UpdateBillingAddress(ctx context.Context, cart *do
 }
 
 // UpdateAdditionalData updates additional data
-func (cob *InMemoryBehaviour) UpdateAdditionalData(ctx context.Context, cart *domaincart.Cart, additionalData *domaincart.AdditionalData) (*domaincart.Cart, domaincart.DeferEvents, error) {
+func (cob *InMemoryBehaviour) UpdateAdditionalData(_ context.Context, cart *domaincart.Cart, additionalData *domaincart.AdditionalData) (*domaincart.Cart, domaincart.DeferEvents, error) {
 	cart.AdditionalData = *additionalData
 	err := cob.cartStorage.StoreCart(cart)
 
@@ -430,12 +437,12 @@ func (cob *InMemoryBehaviour) UpdateDeliveryInfo(ctx context.Context, cart *doma
 }
 
 // UpdateDeliveryInfoAdditionalData @todo implement when needed
-func (cob *InMemoryBehaviour) UpdateDeliveryInfoAdditionalData(ctx context.Context, cart *domaincart.Cart, deliveryCode string, additionalData *domaincart.AdditionalData) (*domaincart.Cart, domaincart.DeferEvents, error) {
+func (cob *InMemoryBehaviour) UpdateDeliveryInfoAdditionalData(_ context.Context, cart *domaincart.Cart, _ string, _ *domaincart.AdditionalData) (*domaincart.Cart, domaincart.DeferEvents, error) {
 	return cart, nil, nil
 }
 
 // GetCart returns the current cart from storage
-func (cob *InMemoryBehaviour) GetCart(ctx context.Context, cartID string) (*domaincart.Cart, error) {
+func (cob *InMemoryBehaviour) GetCart(_ context.Context, cartID string) (*domaincart.Cart, error) {
 	if cob.cartStorage.HasCart(cartID) {
 		// if cart exists, there is no error ;)
 		cart, err := cob.cartStorage.GetCart(cartID)
@@ -531,7 +538,7 @@ func (cob *InMemoryBehaviour) isCurrentPaymentSelectionValid(ctx context.Context
 }
 
 // isPaymentSelectionValid checks if the grand total of the cart matches the total of the supplied payment selection
-func (cob *InMemoryBehaviour) checkPaymentSelection(ctx context.Context, cart *domaincart.Cart, paymentSelection domaincart.PaymentSelection) error {
+func (cob *InMemoryBehaviour) checkPaymentSelection(_ context.Context, cart *domaincart.Cart, paymentSelection domaincart.PaymentSelection) error {
 	if paymentSelection == nil {
 		return nil
 	}

--- a/cart/infrastructure/InMemoryBehaviour.go
+++ b/cart/infrastructure/InMemoryBehaviour.go
@@ -357,7 +357,10 @@ func (cob *InMemoryBehaviour) CleanDelivery(ctx context.Context, cart *domaincar
 // UpdatePurchaser sets the purchaser data and the additional data on the cart
 func (cob *InMemoryBehaviour) UpdatePurchaser(_ context.Context, cart *domaincart.Cart, purchaser *domaincart.Person, additionalData *domaincart.AdditionalData) (*domaincart.Cart, domaincart.DeferEvents, error) {
 	cart.Purchaser = purchaser
-	cart.AdditionalData = *additionalData
+
+	if additionalData != nil {
+		cart.AdditionalData.CustomAttributes = additionalData.CustomAttributes
+	}
 
 	err := cob.cartStorage.StoreCart(cart)
 	if err != nil {

--- a/cart/infrastructure/InMemoryBehaviour_test.go
+++ b/cart/infrastructure/InMemoryBehaviour_test.go
@@ -49,7 +49,6 @@ func TestInMemoryBehaviour_CleanCart(t *testing.T) {
 				nil,
 				nil,
 				nil,
-				nil,
 			)
 			cart := &domaincart.Cart{
 				ID: "17",
@@ -177,7 +176,6 @@ func TestInMemoryBehaviour_CleanDelivery(t *testing.T) {
 				nil,
 				nil,
 				nil,
-				nil,
 			)
 			if err := cob.cartStorage.StoreCart(tt.args.cart); err != nil {
 				t.Fatalf("cart could not be initialized")
@@ -241,7 +239,6 @@ func TestInMemoryBehaviour_ApplyVoucher(t *testing.T) {
 				&InMemoryCartStorage{},
 				nil,
 				flamingo.NullLogger{},
-				nil,
 				nil,
 				nil,
 				nil,
@@ -339,7 +336,6 @@ func TestInMemoryBehaviour_RemoveVoucher(t *testing.T) {
 				func() *domaincart.Builder {
 					return &domaincart.Builder{}
 				},
-				nil,
 				&DefaultVoucherHandler{},
 				&DefaultGiftCardHandler{},
 				nil,
@@ -403,7 +399,6 @@ func TestInMemoryBehaviour_ApplyGiftCard(t *testing.T) {
 				&InMemoryCartStorage{},
 				nil,
 				flamingo.NullLogger{},
-				nil,
 				nil,
 				nil,
 				nil,
@@ -475,7 +470,6 @@ func TestInMemoryBehaviour_RemoveGiftCard(t *testing.T) {
 				nil,
 				nil,
 				nil,
-				nil,
 				&DefaultVoucherHandler{},
 				&DefaultGiftCardHandler{},
 				nil,
@@ -505,7 +499,6 @@ func TestInMemoryBehaviour_Complete(t *testing.T) {
 			nil,
 			nil,
 			nil,
-			nil,
 		)
 		cart := &domaincart.Cart{ID: "test-id"}
 		require.NoError(t, cob.storeCart(cart))
@@ -526,7 +519,6 @@ func TestInMemoryBehaviour_Restore(t *testing.T) {
 			&InMemoryCartStorage{},
 			nil,
 			flamingo.NullLogger{},
-			nil,
 			nil,
 			nil,
 			nil,

--- a/checkout/application/orderService.go
+++ b/checkout/application/orderService.go
@@ -222,7 +222,7 @@ func (os *OrderService) CurrentCartSaveInfos(ctx context.Context, session *web.S
 }
 
 // GetPaymentGateway tries to get the supplied payment gateway by code from the registered payment gateways
-func (os *OrderService) GetPaymentGateway(ctx context.Context, paymentGatewayCode string) (interfaces.WebCartPaymentGateway, error) {
+func (os *OrderService) GetPaymentGateway(_ context.Context, paymentGatewayCode string) (interfaces.WebCartPaymentGateway, error) {
 	gateway, ok := os.webCartPaymentGateways[paymentGatewayCode]
 	if !ok {
 		return nil, errors.New("Payment gateway " + paymentGatewayCode + " not found")
@@ -232,7 +232,7 @@ func (os *OrderService) GetPaymentGateway(ctx context.Context, paymentGatewayCod
 }
 
 // GetAvailablePaymentGateways returns the list of registered WebCartPaymentGateway
-func (os *OrderService) GetAvailablePaymentGateways(ctx context.Context) map[string]interfaces.WebCartPaymentGateway {
+func (os *OrderService) GetAvailablePaymentGateways(_ context.Context) map[string]interfaces.WebCartPaymentGateway {
 	return os.webCartPaymentGateways
 }
 
@@ -481,7 +481,7 @@ func (os *OrderService) placeOrderWithPaymentProcessing(ctx context.Context, dec
 	if err != nil {
 		// record placeOrderFailCount metric
 		stats.Record(ctx, placeOrderFailCount.M(1))
-		os.logger.WithContext(ctx).Error("Error during place Order:" + err.Error())
+		os.logger.WithContext(ctx).Error("Error during place Order: " + err.Error())
 
 		return nil, err
 	}
@@ -493,7 +493,7 @@ func (os *OrderService) placeOrderWithPaymentProcessing(ctx context.Context, dec
 
 	err = gateway.ConfirmResult(ctx, &decoratedCart.Cart, cartPayment)
 	if err != nil {
-		os.logger.WithContext(ctx).Error("Error during gateway.ConfirmResult:" + err.Error())
+		os.logger.WithContext(ctx).Error("Error during gateway.ConfirmResult: " + err.Error())
 
 		return nil, err
 	}
@@ -504,7 +504,7 @@ func (os *OrderService) placeOrderWithPaymentProcessing(ctx context.Context, dec
 	return placeOrderInfo, nil
 }
 
-func (os *OrderService) preparePlaceOrderInfo(ctx context.Context, currentCart cart.Cart, placedOrderInfos placeorder.PlacedOrderInfos, cartPayment placeorder.Payment) *PlaceOrderInfo {
+func (os *OrderService) preparePlaceOrderInfo(_ context.Context, currentCart cart.Cart, placedOrderInfos placeorder.PlacedOrderInfos, cartPayment placeorder.Payment) *PlaceOrderInfo {
 	email := os.GetContactMail(currentCart)
 
 	placeOrderInfo := &PlaceOrderInfo{

--- a/checkout/interfaces/controller/checkoutcontroller.go
+++ b/checkout/interfaces/controller/checkoutcontroller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/gob"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -23,6 +22,13 @@ import (
 	paymentDomain "flamingo.me/flamingo-commerce/v3/payment/domain"
 )
 
+const (
+	// CheckoutErrorFlashKey is the flash key that stores error infos that are shown on the checkout form page
+	CheckoutErrorFlashKey = "checkout.error.data"
+	// CheckoutSuccessFlashKey is the flash key that stores the order infos which are used on the checkout success page
+	CheckoutSuccessFlashKey = "checkout.success.data"
+)
+
 type (
 	// CheckoutViewData represents the checkout view data
 	CheckoutViewData struct {
@@ -36,11 +42,11 @@ type (
 
 	// ViewErrorInfos defines the error info struct of the checkout controller views
 	ViewErrorInfos struct {
-		//HasError  indicates that an general error happened
+		// HasError  indicates that an general error happened
 		HasError bool
-		//If there is a general error this field is filled and can be used in the template
+		// If there is a general error this field is filled and can be used in the template
 		ErrorMessage string
-		//if the Error happens during processing payment (can be used in template to behave special in case of payment errors)
+		// if the Error happens during processing payment (can be used in template to behave special in case of payment errors)
 		HasPaymentError bool
 	}
 
@@ -107,6 +113,7 @@ type (
 
 func init() {
 	gob.Register(PlaceOrderFlashData{})
+	gob.Register(ViewErrorInfos{})
 }
 
 // Inject dependencies
@@ -177,7 +184,7 @@ The checkoutController implements a default process for a checkout:
 
 // StartAction handles the checkout start action
 func (cc *CheckoutController) StartAction(ctx context.Context, r *web.Request) web.Result {
-	//Guard Clause if Cart cannot be fetched
+	// Guard Clause if Cart cannot be fetched
 	decoratedCart, e := cc.applicationCartReceiverService.ViewDecoratedCart(ctx, r.Session())
 	if e != nil {
 		cc.logger.WithContext(ctx).Error("cart.checkoutcontroller.viewaction: Error ", e)
@@ -189,7 +196,7 @@ func (cc *CheckoutController) StartAction(ctx context.Context, r *web.Request) w
 	}
 
 	viewData := cc.getBasicViewData(ctx, r.Session(), *decoratedCart)
-	//Guard Clause if Cart is empty
+	// Guard Clause if Cart is empty
 	if decoratedCart.Cart.ItemCount() == 0 {
 		if cc.showEmptyCartPageIfNoItems {
 			return cc.responder.Render("checkout/emptycart", nil)
@@ -210,7 +217,7 @@ func (cc *CheckoutController) StartAction(ctx context.Context, r *web.Request) w
 
 // SubmitCheckoutAction handles the main checkout
 func (cc *CheckoutController) SubmitCheckoutAction(ctx context.Context, r *web.Request) web.Result {
-	//Guard Clause if Cart can not be fetched
+	// Guard Clause if Cart can not be fetched
 	decoratedCart, e := cc.applicationCartReceiverService.ViewDecoratedCart(ctx, r.Session())
 	if e != nil {
 		cc.logger.WithContext(ctx).Error("cart.checkoutcontroller.submitaction: Error ", e)
@@ -274,13 +281,12 @@ func (cc *CheckoutController) placeOrderAction(ctx context.Context, r *web.Reque
 		cc.orderService.ClearLastPlacedOrder(ctx)
 
 		if err != nil {
-			cc.logger.WithContext(ctx).WithField("subcategory", "checkoutError").WithField("errorMsg", err.Error()).Error(fmt.Sprintf("place order failed: cart id: %v / total-amount: %v", decoratedCart.Cart.EntityID, decoratedCart.Cart.GrandTotal()))
 			if paymentError, ok := err.(*paymentDomain.Error); ok {
 				if cc.showReviewStepAfterPaymentError && !cc.skipReviewAction {
-					return cc.showReviewFormWithErrors(ctx, *decoratedCart, paymentError)
+					return cc.redirectToReviewFormWithErrors(ctx, r, paymentError)
 				}
 			}
-			return cc.showCheckoutFormWithErrors(ctx, r, *decoratedCart, nil, err)
+			return cc.redirectToCheckoutFormWithErrors(ctx, r, err)
 		}
 	}
 
@@ -289,18 +295,18 @@ func (cc *CheckoutController) placeOrderAction(ctx context.Context, r *web.Reque
 		Email:            placedOrderInfo.ContactEmail,
 		PlacedCart:       decoratedCart.Cart,
 		PaymentInfos:     placedOrderInfo.PaymentInfos,
-	}, "checkout.success.data")
+	}, CheckoutSuccessFlashKey)
 	return cc.responder.RouteRedirect("checkout.success", nil)
 }
 
 // SuccessAction handles the order success action
 func (cc *CheckoutController) SuccessAction(ctx context.Context, r *web.Request) web.Result {
-	flashes := r.Session().Flashes("checkout.success.data")
+	flashes := r.Session().Flashes(CheckoutSuccessFlashKey)
 	if len(flashes) > 0 {
 
 		// if in development mode, then restore the last order in flash session.
 		if cc.devMode {
-			r.Session().AddFlash(flashes[len(flashes)-1], "checkout.success.data")
+			r.Session().AddFlash(flashes[len(flashes)-1], CheckoutSuccessFlashKey)
 		}
 
 		if placeOrderFlashData, ok := flashes[len(flashes)-1].(PlaceOrderFlashData); ok {
@@ -319,7 +325,7 @@ func (cc *CheckoutController) SuccessAction(ctx context.Context, r *web.Request)
 }
 
 // ExpiredAction handles the expired cart action
-func (cc *CheckoutController) ExpiredAction(ctx context.Context, r *web.Request) web.Result {
+func (cc *CheckoutController) ExpiredAction(_ context.Context, _ *web.Request) web.Result {
 	if cc.showEmptyCartPageIfNoItems {
 		return cc.responder.Render("checkout/emptycart", EmptyCartInfo{
 			CartExpired: true,
@@ -346,11 +352,11 @@ func (cc *CheckoutController) getBasicViewData(ctx context.Context, session *web
 	}
 }
 
-//showCheckoutFormAndHandleSubmit - Action that shows the form
+// showCheckoutFormAndHandleSubmit - Action that shows the form
 func (cc *CheckoutController) showCheckoutFormAndHandleSubmit(ctx context.Context, r *web.Request, template string) web.Result {
 	session := r.Session()
 
-	//Guard Clause if Cart cannout be fetched
+	// Guard Clause if Cart can't be fetched
 	decoratedCart, e := cc.applicationCartReceiverService.ViewDecoratedCart(ctx, session)
 	if e != nil {
 		cc.logger.WithContext(ctx).Error("cart.checkoutcontroller.submitaction: Error ", e)
@@ -362,7 +368,7 @@ func (cc *CheckoutController) showCheckoutFormAndHandleSubmit(ctx context.Contex
 		return cc.responder.Render("checkout/carterror", nil).SetNoCache()
 	}
 	viewData := cc.getBasicViewData(ctx, session, *decoratedCart)
-	//Guard Clause if Cart is empty
+	// Guard Clause if Cart is empty
 	if decoratedCart.Cart.ItemCount() == 0 {
 		if cc.showEmptyCartPageIfNoItems {
 			return cc.responder.Render("checkout/emptycart", nil).SetNoCache()
@@ -371,17 +377,27 @@ func (cc *CheckoutController) showCheckoutFormAndHandleSubmit(ctx context.Contex
 	}
 
 	if r.Request().Method != http.MethodPost {
-		//Form not Submitted:
+		// Form not Submitted:
+		flashErrors := r.Session().Flashes(CheckoutErrorFlashKey)
+		if len(flashErrors) == 1 {
+			flashViewErrorInfos, ok := flashErrors[0].(ViewErrorInfos)
+			if ok {
+				viewData.ErrorInfos = flashViewErrorInfos
+			}
+		}
+
 		form, err := cc.checkoutFormController.GetUnsubmittedForm(ctx, r)
 		if err != nil {
-			viewData.ErrorInfos = getViewErrorInfo(err)
+			if len(flashErrors) == 0 {
+				viewData.ErrorInfos = getViewErrorInfo(err)
+			}
 			return cc.responder.Render(template, viewData).SetNoCache()
 		}
 		viewData.Form = *form
 		return cc.responder.Render(template, viewData).SetNoCache()
 	}
 
-	//Form submitted:
+	// Form submitted:
 	form, success, err := cc.checkoutFormController.HandleFormAction(ctx, r)
 	if err != nil {
 		viewData.ErrorInfos = getViewErrorInfo(err)
@@ -406,35 +422,22 @@ func (cc *CheckoutController) showCheckoutFormAndHandleSubmit(ctx context.Contex
 		return response
 	}
 
-	//Default: show form with its validation result
+	// Default: show form with its validation result
 	return cc.responder.Render(template, viewData).SetNoCache()
 }
 
-// showCheckoutFormWithErrors - error handling that is called from many places... It will show the checkoutform and the error
-// template and form is optional - if it is not given it is autodetected and prefilled from the infos in the cart
-func (cc *CheckoutController) showCheckoutFormWithErrors(ctx context.Context, r *web.Request, decoratedCart decorator.DecoratedCart, form *forms.CheckoutFormComposite, err error) web.Result {
-	template := "checkout/checkout"
-
-	cc.logger.WithContext(ctx).Warn("showCheckoutFormWithErrors / Error:", err)
-	viewData := cc.getBasicViewData(ctx, r.Session(), decoratedCart)
-	if form == nil {
-		form, _ = cc.checkoutFormController.GetUnsubmittedForm(ctx, r)
-	}
-	if form != nil {
-		viewData.Form = *form
-	}
-	viewData.ErrorInfos = getViewErrorInfo(err)
-	return cc.responder.Render(template, viewData).SetNoCache()
+// redirectToCheckoutFormWithErrors will store the error as a flash message and redirect to the checkout form where it is then displayed
+func (cc *CheckoutController) redirectToCheckoutFormWithErrors(ctx context.Context, r *web.Request, err error) web.Result {
+	cc.logger.WithContext(ctx).Info("redirect to checkout form and display error: ", err)
+	r.Session().AddFlash(getViewErrorInfo(err), CheckoutErrorFlashKey)
+	return cc.responder.RouteRedirect("checkout", nil).SetNoCache()
 }
 
-// showReviewFormWithErrors
-func (cc *CheckoutController) showReviewFormWithErrors(ctx context.Context, decoratedCart decorator.DecoratedCart, err error) web.Result {
-	cc.logger.WithContext(ctx).Warn("Show Error (review step):", err)
-	viewData := ReviewStepViewData{
-		DecoratedCart: decoratedCart,
-		ErrorInfos:    getViewErrorInfo(err),
-	}
-	return cc.responder.Render("checkout/review", viewData).SetNoCache()
+// redirectToReviewFormWithErrors will store the error as a flash message and redirect to the review form where it is then displayed
+func (cc *CheckoutController) redirectToReviewFormWithErrors(ctx context.Context, r *web.Request, err error) web.Result {
+	cc.logger.WithContext(ctx).Info("redirect to review form and display error: ", err)
+	r.Session().AddFlash(getViewErrorInfo(err), CheckoutErrorFlashKey)
+	return cc.responder.RouteRedirect("checkout.review", nil).SetNoCache()
 }
 
 func getViewErrorInfo(err error) ViewErrorInfos {
@@ -484,7 +487,7 @@ func (cc *CheckoutController) processPayment(ctx context.Context, r *web.Request
 	// get the payment gateway for the specified payment selection
 	gateway, err := cc.orderService.GetPaymentGateway(ctx, decoratedCart.Cart.PaymentSelection.Gateway())
 	if err != nil {
-		return cc.showCheckoutFormWithErrors(ctx, r, *decoratedCart, nil, err)
+		return cc.redirectToCheckoutFormWithErrors(ctx, r, err)
 	}
 
 	returnURL := cc.getPaymentReturnURL(r)
@@ -492,24 +495,24 @@ func (cc *CheckoutController) processPayment(ctx context.Context, r *web.Request
 	// start the payment flow
 	flowResult, err := gateway.StartFlow(ctx, &decoratedCart.Cart, application.PaymentFlowStandardCorrelationID, returnURL)
 	if err != nil {
-		return cc.showCheckoutFormWithErrors(ctx, r, *decoratedCart, nil, err)
+		return cc.redirectToCheckoutFormWithErrors(ctx, r, err)
 	}
 
 	// payment flow requires an early place order
 	if flowResult.EarlyPlaceOrder {
 		payment, err := gateway.OrderPaymentFromFlow(ctx, &decoratedCart.Cart, application.PaymentFlowStandardCorrelationID)
 		if err != nil {
-			return cc.showCheckoutFormWithErrors(ctx, r, *decoratedCart, nil, err)
+			return cc.redirectToCheckoutFormWithErrors(ctx, r, err)
 		}
 
 		err = cc.orderService.SetSources(ctx, session)
 		if err != nil {
-			return cc.showCheckoutFormWithErrors(ctx, r, *decoratedCart, nil, err)
+			return cc.redirectToCheckoutFormWithErrors(ctx, r, err)
 		}
 
 		_, err = cc.orderService.CurrentCartPlaceOrder(ctx, session, *payment)
 		if err != nil {
-			return cc.showCheckoutFormWithErrors(ctx, r, *decoratedCart, nil, err)
+			return cc.redirectToCheckoutFormWithErrors(ctx, r, err)
 		}
 	}
 
@@ -527,7 +530,7 @@ func (cc *CheckoutController) ReviewAction(ctx context.Context, r *web.Request) 
 		return cc.responder.RouteRedirect("checkout.payment", nil)
 	}
 
-	//Guard Clause if cart can not be fetched
+	// Guard Clause if cart can not be fetched
 	decoratedCart, err := cc.applicationCartReceiverService.ViewDecoratedCartWithoutCache(ctx, r.Session())
 	if err != nil {
 		cc.logger.WithContext(ctx).Error("cart.checkoutcontroller.submitaction: Error ", err)
@@ -546,13 +549,22 @@ func (cc *CheckoutController) ReviewAction(ctx context.Context, r *web.Request) 
 		DecoratedCart: *decoratedCart,
 	}
 
+	flashErrors := r.Session().Flashes(CheckoutErrorFlashKey)
+	if len(flashErrors) == 1 {
+		flashViewErrorInfos, ok := flashErrors[0].(ViewErrorInfos)
+		if ok {
+			viewData.ErrorInfos = flashViewErrorInfos
+			return cc.responder.Render("checkout/review", viewData).SetNoCache()
+		}
+	}
+
 	// check for terms and conditions and privacy policy
 	canProceed, err := cc.checkTermsAndPrivacyPolicy(r)
 	if err != nil {
 		viewData.ErrorInfos = getViewErrorInfo(err)
 	}
 
-	//Everything valid then return
+	// Everything valid then return
 	if canProceed && err == nil {
 		if decoratedCart.Cart.IsPaymentSelected() {
 			return cc.processPayment(ctx, r)
@@ -584,7 +596,7 @@ func (cc *CheckoutController) PaymentAction(ctx context.Context, r *web.Request)
 
 	gateway, err := cc.orderService.GetPaymentGateway(ctx, decoratedCart.Cart.PaymentSelection.Gateway())
 	if err != nil {
-		return cc.showCheckoutFormWithErrors(ctx, r, *decoratedCart, nil, err)
+		return cc.redirectToCheckoutFormWithErrors(ctx, r, err)
 	}
 
 	flowStatus, err := gateway.FlowStatus(ctx, &decoratedCart.Cart, application.PaymentFlowStandardCorrelationID)
@@ -609,7 +621,7 @@ func (cc *CheckoutController) PaymentAction(ctx context.Context, r *web.Request)
 			cc.orderService.ClearLastPlacedOrder(ctx)
 		}
 
-		return cc.showCheckoutFormWithErrors(ctx, r, *decoratedCart, nil, err)
+		return cc.redirectToCheckoutFormWithErrors(ctx, r, err)
 	}
 
 	viewData := &PaymentStepViewData{
@@ -656,17 +668,18 @@ func (cc *CheckoutController) PaymentAction(ctx context.Context, r *web.Request)
 		if cc.orderService.HasLastPlacedOrder(ctx) {
 			infos, err := cc.orderService.LastPlacedOrder(ctx)
 			if err != nil {
-				viewData.ErrorInfos = getViewErrorInfo(err)
 				cc.logger.WithContext(ctx).Error(err)
-				return cc.responder.Render("checkout/payment", viewData).SetNoCache()
+				if cc.showReviewStepAfterPaymentError && !cc.skipReviewAction {
+					return cc.redirectToReviewFormWithErrors(ctx, r, flowStatus.Error)
+				}
+
+				return cc.redirectToCheckoutFormWithErrors(ctx, r, err)
 			}
 
 			// ignore restored cart here since it gets fetched newly in checkout
 			_, err = cc.orderService.CancelOrder(ctx, session, infos)
 			if err != nil {
-				viewData.ErrorInfos = getViewErrorInfo(err)
 				cc.logger.WithContext(ctx).Error(err)
-				return cc.responder.Render("checkout/payment", viewData).SetNoCache()
 			}
 
 			cc.orderService.ClearLastPlacedOrder(ctx)
@@ -693,31 +706,44 @@ func (cc *CheckoutController) PaymentAction(ctx context.Context, r *web.Request)
 		if cc.orderService.HasLastPlacedOrder(ctx) {
 			infos, err := cc.orderService.LastPlacedOrder(ctx)
 			if err != nil {
-				viewData.ErrorInfos = getViewErrorInfo(err)
 				cc.logger.WithContext(ctx).Error(err)
-				return cc.responder.Render("checkout/payment", viewData).SetNoCache()
+				if cc.showReviewStepAfterPaymentError && !cc.skipReviewAction {
+					return cc.redirectToReviewFormWithErrors(ctx, r, flowStatus.Error)
+				}
+
+				return cc.redirectToCheckoutFormWithErrors(ctx, r, err)
 			}
 
-			restoredCart, err := cc.orderService.CancelOrder(ctx, session, infos)
+			_, err = cc.orderService.CancelOrder(ctx, session, infos)
 			if err != nil {
-				viewData.ErrorInfos = getViewErrorInfo(err)
 				cc.logger.WithContext(ctx).Error(err)
-				return cc.responder.Render("checkout/payment", viewData).SetNoCache()
 			}
 
-			decoratedCart = cc.decoratedCartFactory.Create(ctx, *restoredCart)
 			cc.orderService.ClearLastPlacedOrder(ctx)
 		}
 
+		err = flowStatus.Error
 		if flowStatus.Error == nil {
-			flowStatus.Error = &paymentDomain.Error{}
+			// fallback if payment gateway didn't respond with a proper error
+			switch flowStatus.Status {
+			case paymentDomain.PaymentFlowStatusCancelled:
+				err = &paymentDomain.Error{
+					ErrorCode:    paymentDomain.PaymentErrorCodeCancelled,
+					ErrorMessage: paymentDomain.PaymentErrorCodeCancelled,
+				}
+			case paymentDomain.PaymentFlowStatusFailed:
+				err = &paymentDomain.Error{
+					ErrorCode:    paymentDomain.PaymentErrorCodeFailed,
+					ErrorMessage: paymentDomain.PaymentErrorCodeFailed,
+				}
+			}
 		}
 
 		if cc.showReviewStepAfterPaymentError && !cc.skipReviewAction {
-			return cc.showReviewFormWithErrors(ctx, *decoratedCart, flowStatus.Error)
+			return cc.redirectToReviewFormWithErrors(ctx, r, err)
 		}
 
-		return cc.showCheckoutFormWithErrors(ctx, r, *decoratedCart, nil, flowStatus.Error)
+		return cc.redirectToCheckoutFormWithErrors(ctx, r, err)
 	case paymentDomain.PaymentFlowWaitingForCustomer:
 		// payment pending, waiting for customer
 		return cc.responder.Render("checkout/payment", viewData).SetNoCache()
@@ -732,7 +758,7 @@ func (cc *CheckoutController) getCommonGuardRedirects(ctx context.Context, sessi
 	if cc.redirectToCartOnInvalideCart {
 		result := cc.applicationCartService.ValidateCart(ctx, session, decoratedCart)
 		if !result.IsValid() {
-			cc.logger.WithContext(ctx).Info("StartAction > RedirectToCartOnInvalideCart")
+			cc.logger.WithContext(ctx).Info("StartAction > RedirectToCartOnInvalidCart")
 			resp := cc.responder.RouteRedirect("cart.view", nil)
 			resp.SetNoCache()
 			return resp
@@ -761,7 +787,7 @@ func (cc *CheckoutController) checkTermsAndPrivacyPolicy(r *web.Request) (bool, 
 		errorMessages = append(errorMessages, "terms_and_conditions_required")
 	}
 
-	canProceed := (proceed == "1" && (!cc.privacyPolicyRequired || privacyPolicy == "1") && termsAndConditions == "1")
+	canProceed := proceed == "1" && (!cc.privacyPolicyRequired || privacyPolicy == "1") && termsAndConditions == "1"
 
 	if 0 == len(errorMessages) {
 		return canProceed, nil

--- a/search/interfaces/graphql/graphql.go
+++ b/search/interfaces/graphql/graphql.go
@@ -193,7 +193,7 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"schema.graphql": {schemaGraphql, map[string]*bintree{}},
+	"schema.graphql": &bintree{schemaGraphql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory

--- a/search/interfaces/graphql/service.go
+++ b/search/interfaces/graphql/service.go
@@ -8,7 +8,7 @@ import (
 	"github.com/99designs/gqlgen/codegen/config"
 )
 
-//go:generate go run github.com/go-bindata/go-bindata/go-bindata -nometadata -o fs.go -pkg graphql schema.graphql
+//go:generate go run github.com/go-bindata/go-bindata/go-bindata -nometadata -o graphql.go -pkg graphql schema.graphql
 
 // Service is the Graphql-Service of this module
 type Service struct{}

--- a/test/integrationtest/projecttest/config/config.yml
+++ b/test/integrationtest/projecttest/config/config.yml
@@ -63,16 +63,21 @@ commerce:
     defaultPageSize: 8
     showAroundActivePageAmount: 2
   cart:
-    defaultDeliveryCode: delivery
+    personalDataForm:
+      additionalFormFields:
+        - "place-order-error"
+        - "reserve-order-id-error"
+    defaultDeliveryCode: "delivery"
     enableCartCache: false
     useInMemoryCartServiceAdapters: true
     emailAdapter:
-      emailAddress: test@test.de
+      emailAddress: "test@test.de"
     useEmailPlaceOrderAdapter: false
     inMemoryCartServiceAdapter:
       defaultTaxRate: 19
   checkout:
     showEmptyCartPageIfNoItems: true
+    usePersonalDataForm: true
   product:
     fakeservice:
       enabled: true

--- a/test/integrationtest/projecttest/modules/placeorder/fake_service.go
+++ b/test/integrationtest/projecttest/modules/placeorder/fake_service.go
@@ -13,8 +13,12 @@ import (
 	"flamingo.me/flamingo-commerce/v3/cart/domain/placeorder"
 )
 
-// AttributeErrorKey is used to store a forced test error to the cart's additional attributes
-const AttributeErrorKey = "test-error"
+const (
+	// CustomAttributesKeyPlaceOrderError can be used to force an error during place order
+	CustomAttributesKeyPlaceOrderError = "place-order-error"
+	// CustomAttributesKeyReserveOrderIDError can be used to force an error during reserve order id
+	CustomAttributesKeyReserveOrderIDError = "reserve-order-id-error"
+)
 
 type (
 	// FakeAdapter provides fake place order adapter
@@ -38,19 +42,19 @@ func (f *FakeAdapter) Inject() *FakeAdapter {
 }
 
 // PlaceGuestCart places a guest cart order
-func (f *FakeAdapter) PlaceGuestCart(ctx context.Context, cart *cartDomain.Cart, payment *placeorder.Payment) (placeorder.PlacedOrderInfos, error) {
+func (f *FakeAdapter) PlaceGuestCart(_ context.Context, cart *cartDomain.Cart, _ *placeorder.Payment) (placeorder.PlacedOrderInfos, error) {
 	return f.placeCart(cart)
 }
 
 // PlaceCustomerCart places a customer cart
-func (f *FakeAdapter) PlaceCustomerCart(ctx context.Context, auth authDomain.Auth, cart *cartDomain.Cart, payment *placeorder.Payment) (placeorder.PlacedOrderInfos, error) {
+func (f *FakeAdapter) PlaceCustomerCart(_ context.Context, _ authDomain.Auth, cart *cartDomain.Cart, _ *placeorder.Payment) (placeorder.PlacedOrderInfos, error) {
 	return f.placeCart(cart)
 }
 
 func (f *FakeAdapter) placeCart(cart *cartDomain.Cart) (placeorder.PlacedOrderInfos, error) {
 	f.locker.Lock()
 	defer f.locker.Unlock()
-	forcedError := cart.AdditionalData.CustomAttributes[AttributeErrorKey]
+	forcedError := cart.AdditionalData.CustomAttributes[CustomAttributesKeyPlaceOrderError]
 	if forcedError != "" {
 		return nil, errors.New(forcedError)
 	}
@@ -75,7 +79,7 @@ func (f *FakeAdapter) placeCart(cart *cartDomain.Cart) (placeorder.PlacedOrderIn
 
 // ReserveOrderID returns the reserved order id
 func (f *FakeAdapter) ReserveOrderID(_ context.Context, cart *cartDomain.Cart) (string, error) {
-	forcedError := cart.AdditionalData.CustomAttributes[AttributeErrorKey]
+	forcedError := cart.AdditionalData.CustomAttributes[CustomAttributesKeyReserveOrderIDError]
 	if forcedError != "" {
 		return "", errors.New(forcedError)
 	}
@@ -83,12 +87,12 @@ func (f *FakeAdapter) ReserveOrderID(_ context.Context, cart *cartDomain.Cart) (
 }
 
 // CancelGuestOrder cancels a guest order
-func (f *FakeAdapter) CancelGuestOrder(ctx context.Context, orderInfos placeorder.PlacedOrderInfos) error {
+func (f *FakeAdapter) CancelGuestOrder(_ context.Context, orderInfos placeorder.PlacedOrderInfos) error {
 	return f.cancelOrder(orderInfos)
 }
 
 // CancelCustomerOrder cancels a customer order
-func (f *FakeAdapter) CancelCustomerOrder(ctx context.Context, orderInfos placeorder.PlacedOrderInfos, auth authDomain.Auth) error {
+func (f *FakeAdapter) CancelCustomerOrder(_ context.Context, orderInfos placeorder.PlacedOrderInfos, _ authDomain.Auth) error {
 	return f.cancelOrder(orderInfos)
 }
 

--- a/test/integrationtest/projecttest/tests/frontend/checkout_test.go
+++ b/test/integrationtest/projecttest/tests/frontend/checkout_test.go
@@ -238,6 +238,8 @@ func Test_Checkout_ReviewActionAndPlaceOrderAction(t *testing.T) {
 
 		assert.Equal(t, routeCheckoutSubmit, response.Raw().Request.URL.RequestURI())
 		response.JSON().Object().Value("ErrorInfos").Object().Value("HasPaymentError").Boolean().True()
+		response.JSON().Object().Value("ErrorInfos").Object().Value("HasError").Boolean().True()
+		response.JSON().Object().Value("ErrorInfos").Object().Value("ErrorMessage").String().Equal(domain.PaymentErrorCodeFailed)
 	})
 
 	t.Run("error during place order should lead to checkout page", func(t *testing.T) {

--- a/test/integrationtest/projecttest/tests/frontend/checkout_test.go
+++ b/test/integrationtest/projecttest/tests/frontend/checkout_test.go
@@ -9,6 +9,8 @@ import (
 	"flamingo.me/flamingo-commerce/v3/payment/domain"
 	"flamingo.me/flamingo-commerce/v3/test/integrationtest"
 	"flamingo.me/flamingo-commerce/v3/test/integrationtest/projecttest/modules/payment"
+	"flamingo.me/flamingo-commerce/v3/test/integrationtest/projecttest/modules/placeorder"
+
 	"gotest.tools/assert"
 )
 
@@ -196,5 +198,90 @@ func Test_Checkout_ReviewActionAndPlaceOrderAction(t *testing.T) {
 
 		assert.Equal(t, routeCheckoutSuccess, response.Raw().Request.URL.RequestURI())
 		response.JSON().Object().Value("PaymentInfos").Null()
+	})
+
+	t.Run("error during payment should lead to checkout page", func(t *testing.T) {
+		e := integrationtest.NewHTTPExpect(t, "http://"+FlamingoURL)
+		// prepare cart
+		CartAddProduct(t, e, "fake_simple", 5, "", "inflight")
+
+		// submit checkout form
+		response := SubmitCheckoutForm(t, e, map[string]interface{}{
+			"billingAddress": map[string]interface{}{
+				"firstname": "firstname",
+				"lastname":  "lastname",
+				"email":     "test@test.com",
+			},
+			"deliveries": map[string]interface{}{
+				"inflight": map[string]interface{}{
+					"deliveryAddress": map[string]interface{}{
+						"firstname": "firstname",
+						"lastname":  "lastname",
+						"email":     "test@test.com",
+					},
+				},
+			},
+			"payment": map[string]interface{}{
+				"gateway": payment.FakePaymentGateway,
+				"method":  domain.PaymentFlowStatusFailed,
+			},
+		})
+
+		assert.Equal(t, routeCheckoutReview, response.Raw().Request.URL.RequestURI())
+
+		// submit review form
+		response = SubmitReviewForm(t, e, map[string]interface{}{
+			"proceed":            "1",
+			"termsAndConditions": "1",
+			"privacyPolicy":      "1",
+		})
+
+		assert.Equal(t, routeCheckoutSubmit, response.Raw().Request.URL.RequestURI())
+		response.JSON().Object().Value("ErrorInfos").Object().Value("HasPaymentError").Boolean().True()
+	})
+
+	t.Run("error during place order should lead to checkout page", func(t *testing.T) {
+		e := integrationtest.NewHTTPExpect(t, "http://"+FlamingoURL)
+		// prepare cart
+		CartAddProduct(t, e, "fake_simple", 5, "", "inflight")
+
+		// submit checkout form
+		response := SubmitCheckoutForm(t, e, map[string]interface{}{
+			"billingAddress": map[string]interface{}{
+				"firstname": "firstname",
+				"lastname":  "lastname",
+				"email":     "test@test.com",
+			},
+			"personalData": map[string]interface{}{
+				placeorder.CustomAttributesKeyPlaceOrderError: "generic error during place order",
+			},
+			"deliveries": map[string]interface{}{
+				"inflight": map[string]interface{}{
+					"deliveryAddress": map[string]interface{}{
+						"firstname": "firstname",
+						"lastname":  "lastname",
+						"email":     "test@test.com",
+					},
+				},
+			},
+			"payment": map[string]interface{}{
+				"gateway": payment.FakePaymentGateway,
+				"method":  domain.PaymentFlowStatusCompleted,
+			},
+		})
+
+		assert.Equal(t, routeCheckoutReview, response.Raw().Request.URL.RequestURI())
+
+		// submit review form
+		response = SubmitReviewForm(t, e, map[string]interface{}{
+			"proceed":            "1",
+			"termsAndConditions": "1",
+			"privacyPolicy":      "1",
+		})
+
+		assert.Equal(t, routeCheckoutSubmit, response.Raw().Request.URL.RequestURI())
+		response.JSON().Object().Value("ErrorInfos").Object().Value("HasError").Boolean().True()
+		response.JSON().Object().Value("ErrorInfos").Object().Value("HasPaymentError").Boolean().False()
+		response.JSON().Object().Value("ErrorInfos").Object().Value("ErrorMessage").String().Equal("generic error during place order")
 	})
 }


### PR DESCRIPTION
In case of error during payment always redirect back to checkout/review page in stead of rendering the template under a different route

Currently in case of a error during payment/placing the order we just render the checkout / review template again on the same route.

If the user then reloads the page he is still on the placeorder route and will trigger the error again or cause other potential side effects.
Its therefore better to send him back on the checkout route and render the error in the matching action. So that the customer then can start a new try.