### PR TITLE
Add configuration option for multistore setup to be able to have to different cart caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   * Session added as parameter to interface method `MaxQuantityRestrictor.Restrict`
   * Session added as parameter to `RestrictionService.RestrictQty`
 * Switch module config to CUE
+* SessionCacheHandling
+  * Add new config for multistore setup to be able to switch between the carts inside the different stores. ConfigKey: commerce.cart.cartCachePrefix
 * GraphQL
   * Add new mutation to set / update one or multiple delivery addresses `Commerce_Cart_UpdateDeliveryAddresses`
   * Add new mutation to update the shipping options (carrier / method) of an existing delivery `Commerce_Cart_UpdateDeliveryShippingOptions`

--- a/cart/application/cartCache_test.go
+++ b/cart/application/cartCache_test.go
@@ -278,6 +278,7 @@ func TestCartSessionCache_CartExpiry(t *testing.T) {
 		flamingo.NullLogger{},
 		&struct {
 			LifetimeSeconds float64 `inject:"config:commerce.cart.cacheLifetime"` // in seconds
+			CartCachePrefix string  `inject:"config:commerce.cart.cartCachePrefix,optional"`
 		}{
 			LifetimeSeconds: 1,
 		},

--- a/cart/application/cartReceiver_test.go
+++ b/cart/application/cartReceiver_test.go
@@ -35,13 +35,13 @@ var (
 	_ cartDomain.GuestCartService = (*MockGuestCartServiceAdapter)(nil)
 )
 
-func (m *MockGuestCartServiceAdapter) GetCart(ctx context.Context, cartID string) (*cartDomain.Cart, error) {
+func (m *MockGuestCartServiceAdapter) GetCart(_ context.Context, _ string) (*cartDomain.Cart, error) {
 	return &cartDomain.Cart{
 		ID: "mock_guest_cart",
 	}, nil
 }
 
-func (m *MockGuestCartServiceAdapter) GetNewCart(ctx context.Context) (*cartDomain.Cart, error) {
+func (m *MockGuestCartServiceAdapter) GetNewCart(_ context.Context) (*cartDomain.Cart, error) {
 	return &cartDomain.Cart{
 		ID: "mock_guest_cart",
 	}, nil
@@ -51,7 +51,7 @@ func (m *MockGuestCartServiceAdapter) GetModifyBehaviour(context.Context) (cartD
 	return new(cartInfrastructure.InMemoryBehaviour), nil
 }
 
-func (m *MockGuestCartServiceAdapter) RestoreCart(ctx context.Context, cart cartDomain.Cart) (*cartDomain.Cart, error) {
+func (m *MockGuestCartServiceAdapter) RestoreCart(_ context.Context, cart cartDomain.Cart) (*cartDomain.Cart, error) {
 	restoredCart := cart
 	restoredCart.ID = "1111"
 	return &restoredCart, nil
@@ -67,11 +67,11 @@ type (
 	MockGuestCartServiceAdapterError struct{}
 )
 
-func (m *MockGuestCartServiceAdapterError) GetCart(ctx context.Context, cartID string) (*cartDomain.Cart, error) {
+func (m *MockGuestCartServiceAdapterError) GetCart(_ context.Context, _ string) (*cartDomain.Cart, error) {
 	return nil, errors.New("defective")
 }
 
-func (m *MockGuestCartServiceAdapterError) GetNewCart(ctx context.Context) (*cartDomain.Cart, error) {
+func (m *MockGuestCartServiceAdapterError) GetNewCart(_ context.Context) (*cartDomain.Cart, error) {
 	return nil, errors.New("defective")
 }
 
@@ -79,7 +79,7 @@ func (m *MockGuestCartServiceAdapterError) GetModifyBehaviour(context.Context) (
 	return new(cartInfrastructure.InMemoryBehaviour), nil
 }
 
-func (m *MockGuestCartServiceAdapterError) RestoreCart(ctx context.Context, cart cartDomain.Cart) (*cartDomain.Cart, error) {
+func (m *MockGuestCartServiceAdapterError) RestoreCart(_ context.Context, _ cartDomain.Cart) (*cartDomain.Cart, error) {
 	return nil, errors.New("defective")
 }
 
@@ -98,13 +98,13 @@ func (m *MockCustomerCartService) GetModifyBehaviour(context.Context, domain.Aut
 	return new(cartInfrastructure.InMemoryBehaviour), nil
 }
 
-func (m *MockCustomerCartService) GetCart(ctx context.Context, auth domain.Auth, cartID string) (*cartDomain.Cart, error) {
+func (m *MockCustomerCartService) GetCart(_ context.Context, _ domain.Auth, _ string) (*cartDomain.Cart, error) {
 	return &cartDomain.Cart{
 		ID: "mock_customer_cart",
 	}, nil
 }
 
-func (m *MockCustomerCartService) RestoreCart(ctx context.Context, auth domain.Auth, cart cartDomain.Cart) (*cartDomain.Cart, error) {
+func (m *MockCustomerCartService) RestoreCart(_ context.Context, _ domain.Auth, _ cartDomain.Cart) (*cartDomain.Cart, error) {
 	panic("implement me")
 }
 
@@ -114,7 +114,7 @@ type (
 	MockProductService struct{}
 )
 
-func (m *MockProductService) Get(ctx context.Context, marketplaceCode string) (productDomain.BasicProduct, error) {
+func (m *MockProductService) Get(_ context.Context, _ string) (productDomain.BasicProduct, error) {
 	mockProduct := new(productDomain.SimpleProduct)
 
 	mockProduct.Identifier = "mock_product"
@@ -134,7 +134,7 @@ func (m *MockCartCache) GetCart(context.Context, *web.Session, cartApplication.C
 	return m.CachedCart, nil
 }
 
-func (m *MockCartCache) CacheCart(ctx context.Context, s *web.Session, cci cartApplication.CartCacheIdentifier, cart *cartDomain.Cart) error {
+func (m *MockCartCache) CacheCart(_ context.Context, _ *web.Session, _ cartApplication.CartCacheIdentifier, cart *cartDomain.Cart) error {
 	m.CachedCart = cart
 	return nil
 }
@@ -167,15 +167,15 @@ var (
 	_ events.EventPublisher = (*MockEventPublisher)(nil)
 )
 
-func (m *MockEventPublisher) PublishAddToCartEvent(ctx context.Context, cart *cartDomain.Cart, marketPlaceCode string, variantMarketPlaceCode string, qty int) {
+func (m *MockEventPublisher) PublishAddToCartEvent(_ context.Context, _ *cartDomain.Cart, _ string, _ string, _ int) {
 	m.Called()
 }
 
-func (m *MockEventPublisher) PublishChangedQtyInCartEvent(ctx context.Context, cart *cartDomain.Cart, item *cartDomain.Item, qtyBefore int, qtyAfter int) {
+func (m *MockEventPublisher) PublishChangedQtyInCartEvent(_ context.Context, _ *cartDomain.Cart, _ *cartDomain.Item, _ int, _ int) {
 	m.Called()
 }
 
-func (m *MockEventPublisher) PublishOrderPlacedEvent(ctx context.Context, cart *cartDomain.Cart, placedOrderInfos placeorder.PlacedOrderInfos) {
+func (m *MockEventPublisher) PublishOrderPlacedEvent(_ context.Context, _ *cartDomain.Cart, _ placeorder.PlacedOrderInfos) {
 	m.Called()
 }
 
@@ -183,7 +183,7 @@ type (
 	MockDeliveryInfoBuilder struct{}
 )
 
-func (m *MockDeliveryInfoBuilder) BuildByDeliveryCode(deliveryCode string) (*cartDomain.DeliveryInfo, error) {
+func (m *MockDeliveryInfoBuilder) BuildByDeliveryCode(_ string) (*cartDomain.DeliveryInfo, error) {
 	return &cartDomain.DeliveryInfo{}, nil
 }
 
@@ -195,13 +195,13 @@ type (
 
 var _ authApplication.UserServiceInterface = (*MockUserService)(nil)
 
-func (m *MockUserService) GetUser(ctx context.Context, session *web.Session) *domain.User {
+func (m *MockUserService) GetUser(_ context.Context, _ *web.Session) *domain.User {
 	return &domain.User{
 		Name: "Test",
 	}
 }
 
-func (m *MockUserService) IsLoggedIn(ctx context.Context, session *web.Session) bool {
+func (m *MockUserService) IsLoggedIn(_ context.Context, _ *web.Session) bool {
 	return m.LoggedIn
 }
 
@@ -333,6 +333,9 @@ func TestCartReceiverService_ShouldHaveGuestCart(t *testing.T) {
 				}{
 					CartCache: tt.fields.CartCache,
 				},
+				&struct {
+					CartCachePrefix string `inject:"config:commerce.cart.cartCachePrefix,optional"`
+				}{},
 			)
 
 			got := cs.ShouldHaveGuestCart(tt.args.session)
@@ -465,6 +468,9 @@ func TestCartReceiverService_ViewGuestCart(t *testing.T) {
 				}{
 					CartCache: tt.fields.CartCache,
 				},
+				&struct {
+					CartCachePrefix string `inject:"config:commerce.cart.cartCachePrefix,optional"`
+				}{},
 			)
 
 			got, err := cs.ViewGuestCart(tt.args.ctx, tt.args.session)
@@ -592,6 +598,9 @@ func TestCartReceiverService_DecorateCart(t *testing.T) {
 				}{
 					CartCache: tt.fields.CartCache,
 				},
+				&struct {
+					CartCachePrefix string `inject:"config:commerce.cart.cartCachePrefix,optional"`
+				}{},
 			)
 
 			got, err := cs.DecorateCart(tt.args.ctx, tt.args.cart)
@@ -716,6 +725,9 @@ func TestCartReceiverService_GetDecoratedCart(t *testing.T) {
 				}{
 					CartCache: tt.fields.CartCache,
 				},
+				&struct {
+					CartCachePrefix string `inject:"config:commerce.cart.cartCachePrefix,optional"`
+				}{},
 			)
 
 			got, got1, err := cs.GetDecoratedCart(tt.args.ctx, tt.args.session)
@@ -932,6 +944,9 @@ func TestCartReceiverService_RestoreCart(t *testing.T) {
 				}{
 					CartCache: tt.fields.cartCache,
 				},
+				&struct {
+					CartCachePrefix string `inject:"config:commerce.cart.cartCachePrefix,optional"`
+				}{},
 			)
 			got, err := cs.RestoreCart(tt.args.ctx, tt.args.session, tt.args.cartToRestore)
 			if (err != nil) != tt.wantErr {
@@ -979,6 +994,9 @@ func TestCartReceiverService_ModifyBehaviour(t *testing.T) {
 			}{
 				CartCache: &MockCartCache{},
 			},
+			&struct {
+				CartCachePrefix string `inject:"config:commerce.cart.cartCachePrefix,optional"`
+			}{},
 		)
 
 		behaviour, err := cs.ModifyBehaviour(context.Background())
@@ -1002,6 +1020,9 @@ func TestCartReceiverService_ModifyBehaviour(t *testing.T) {
 			}{
 				CartCache: &MockCartCache{},
 			},
+			&struct {
+				CartCachePrefix string `inject:"config:commerce.cart.cartCachePrefix,optional"`
+			}{},
 		)
 
 		behaviour, err := cs.ModifyBehaviour(context.Background())
@@ -1025,6 +1046,9 @@ func TestCartReceiverService_ModifyBehaviour(t *testing.T) {
 			}{
 				CartCache: &MockCartCache{},
 			},
+			&struct {
+				CartCachePrefix string `inject:"config:commerce.cart.cartCachePrefix,optional"`
+			}{},
 		)
 
 		behaviour, err := cs.ModifyBehaviour(context.Background())

--- a/cart/application/cartService_test.go
+++ b/cart/application/cartService_test.go
@@ -78,6 +78,9 @@ func TestCartService_DeleteSavedSessionGuestCartID(t *testing.T) {
 						}{
 							CartCache: new(MockCartCache),
 						},
+						&struct {
+							CartCachePrefix string `inject:"config:commerce.cart.cartCachePrefix,optional"`
+						}{},
 					)
 					return result
 				}(),
@@ -119,7 +122,7 @@ func TestCartService_DeleteSavedSessionGuestCartID(t *testing.T) {
 				tt.fields.RestrictionService,
 				authmanager,
 				tt.fields.Logger,
-				tt.fields.config,
+				nil,
 				nil,
 			)
 
@@ -155,6 +158,7 @@ func TestCartService_AdjustItemsToRestrictedQty(t *testing.T) {
 		config              *struct {
 			DefaultDeliveryCode string `inject:"config:commerce.cart.defaultDeliveryCode,optional"`
 			DeleteEmptyDelivery bool   `inject:"config:commerce.cart.deleteEmptyDelivery,optional"`
+			CartCachePrefix     string `inject:"config:commerce.cart.cartCachePrefix,optional"`
 		}
 		DeliveryInfoBuilder cartDomain.DeliveryInfoBuilder
 		CartCache           cartApplication.CartCache
@@ -196,6 +200,9 @@ func TestCartService_AdjustItemsToRestrictedQty(t *testing.T) {
 						}{
 							CartCache: new(MockCartWithItemCache),
 						},
+						&struct {
+							CartCachePrefix string `inject:"config:commerce.cart.cartCachePrefix,optional"`
+						}{},
 					)
 					return result
 				}(),
@@ -206,6 +213,7 @@ func TestCartService_AdjustItemsToRestrictedQty(t *testing.T) {
 				config: &struct {
 					DefaultDeliveryCode string `inject:"config:commerce.cart.defaultDeliveryCode,optional"`
 					DeleteEmptyDelivery bool   `inject:"config:commerce.cart.deleteEmptyDelivery,optional"`
+					CartCachePrefix     string `inject:"config:commerce.cart.cartCachePrefix,optional"`
 				}{
 					DefaultDeliveryCode: "default_delivery_code",
 					DeleteEmptyDelivery: false,
@@ -254,6 +262,9 @@ func TestCartService_AdjustItemsToRestrictedQty(t *testing.T) {
 						}{
 							CartCache: new(MockCartWithItemCache),
 						},
+						&struct {
+							CartCachePrefix string `inject:"config:commerce.cart.cartCachePrefix,optional"`
+						}{},
 					)
 					return result
 				}(),
@@ -264,6 +275,7 @@ func TestCartService_AdjustItemsToRestrictedQty(t *testing.T) {
 				config: &struct {
 					DefaultDeliveryCode string `inject:"config:commerce.cart.defaultDeliveryCode,optional"`
 					DeleteEmptyDelivery bool   `inject:"config:commerce.cart.deleteEmptyDelivery,optional"`
+					CartCachePrefix     string `inject:"config:commerce.cart.cartCachePrefix,optional"`
 				}{
 					DefaultDeliveryCode: "default_delivery_code",
 					DeleteEmptyDelivery: false,
@@ -328,6 +340,7 @@ func TestCartService_AdjustItemsToRestrictedQty(t *testing.T) {
 						}{
 							CartCache: new(MockCartWithItemCache),
 						},
+						nil,
 					)
 					return result
 				}(),
@@ -338,6 +351,7 @@ func TestCartService_AdjustItemsToRestrictedQty(t *testing.T) {
 				config: &struct {
 					DefaultDeliveryCode string `inject:"config:commerce.cart.defaultDeliveryCode,optional"`
 					DeleteEmptyDelivery bool   `inject:"config:commerce.cart.deleteEmptyDelivery,optional"`
+					CartCachePrefix     string `inject:"config:commerce.cart.cartCachePrefix,optional"`
 				}{
 					DefaultDeliveryCode: "default_delivery_code",
 					DeleteEmptyDelivery: false,
@@ -418,6 +432,7 @@ func TestCartService_ReserveOrderIDAndSave(t *testing.T) {
 		config              *struct {
 			DefaultDeliveryCode string `inject:"config:commerce.cart.defaultDeliveryCode,optional"`
 			DeleteEmptyDelivery bool   `inject:"config:commerce.cart.deleteEmptyDelivery,optional"`
+			CartCachePrefix     string `inject:"config:commerce.cart.cartCachePrefix,optional"`
 		}
 		DeliveryInfoBuilder cartDomain.DeliveryInfoBuilder
 		CartCache           cartApplication.CartCache
@@ -461,6 +476,9 @@ func TestCartService_ReserveOrderIDAndSave(t *testing.T) {
 						}{
 							CartCache: new(MockCartWithItemCacheWithAdditionalData),
 						},
+						&struct {
+							CartCachePrefix string `inject:"config:commerce.cart.cartCachePrefix,optional"`
+						}{},
 					)
 					return result
 				}(),
@@ -471,6 +489,7 @@ func TestCartService_ReserveOrderIDAndSave(t *testing.T) {
 				config: &struct {
 					DefaultDeliveryCode string `inject:"config:commerce.cart.defaultDeliveryCode,optional"`
 					DeleteEmptyDelivery bool   `inject:"config:commerce.cart.deleteEmptyDelivery,optional"`
+					CartCachePrefix     string `inject:"config:commerce.cart.cartCachePrefix,optional"`
 				}{
 					DefaultDeliveryCode: "default_delivery_code",
 					DeleteEmptyDelivery: false,
@@ -512,6 +531,9 @@ func TestCartService_ReserveOrderIDAndSave(t *testing.T) {
 						}{
 							CartCache: new(MockCartWithItemCache),
 						},
+						&struct {
+							CartCachePrefix string `inject:"config:commerce.cart.cartCachePrefix,optional"`
+						}{},
 					)
 					return result
 				}(),
@@ -522,6 +544,7 @@ func TestCartService_ReserveOrderIDAndSave(t *testing.T) {
 				config: &struct {
 					DefaultDeliveryCode string `inject:"config:commerce.cart.defaultDeliveryCode,optional"`
 					DeleteEmptyDelivery bool   `inject:"config:commerce.cart.deleteEmptyDelivery,optional"`
+					CartCachePrefix     string `inject:"config:commerce.cart.cartCachePrefix,optional"`
 				}{
 					DefaultDeliveryCode: "default_delivery_code",
 					DeleteEmptyDelivery: false,
@@ -587,6 +610,7 @@ func TestCartService_ForceReserveOrderIDAndSave(t *testing.T) {
 		config              *struct {
 			DefaultDeliveryCode string `inject:"config:commerce.cart.defaultDeliveryCode,optional"`
 			DeleteEmptyDelivery bool   `inject:"config:commerce.cart.deleteEmptyDelivery,optional"`
+			CartCachePrefix     string `inject:"config:commerce.cart.cartCachePrefix,optional"`
 		}
 		DeliveryInfoBuilder cartDomain.DeliveryInfoBuilder
 		CartCache           cartApplication.CartCache
@@ -630,6 +654,9 @@ func TestCartService_ForceReserveOrderIDAndSave(t *testing.T) {
 						}{
 							CartCache: new(MockCartWithItemCacheWithAdditionalData),
 						},
+						&struct {
+							CartCachePrefix string `inject:"config:commerce.cart.cartCachePrefix,optional"`
+						}{},
 					)
 					return result
 				}(),
@@ -640,6 +667,7 @@ func TestCartService_ForceReserveOrderIDAndSave(t *testing.T) {
 				config: &struct {
 					DefaultDeliveryCode string `inject:"config:commerce.cart.defaultDeliveryCode,optional"`
 					DeleteEmptyDelivery bool   `inject:"config:commerce.cart.deleteEmptyDelivery,optional"`
+					CartCachePrefix     string `inject:"config:commerce.cart.cartCachePrefix,optional"`
 				}{
 					DefaultDeliveryCode: "default_delivery_code",
 					DeleteEmptyDelivery: false,
@@ -681,6 +709,9 @@ func TestCartService_ForceReserveOrderIDAndSave(t *testing.T) {
 						}{
 							CartCache: new(MockCartWithItemCache),
 						},
+						&struct {
+							CartCachePrefix string `inject:"config:commerce.cart.cartCachePrefix,optional"`
+						}{},
 					)
 					return result
 				}(),
@@ -691,9 +722,11 @@ func TestCartService_ForceReserveOrderIDAndSave(t *testing.T) {
 				config: &struct {
 					DefaultDeliveryCode string `inject:"config:commerce.cart.defaultDeliveryCode,optional"`
 					DeleteEmptyDelivery bool   `inject:"config:commerce.cart.deleteEmptyDelivery,optional"`
+					CartCachePrefix     string `inject:"config:commerce.cart.cartCachePrefix,optional"`
 				}{
 					DefaultDeliveryCode: "default_delivery_code",
 					DeleteEmptyDelivery: false,
+					CartCachePrefix:     "",
 				},
 				DeliveryInfoBuilder: new(MockDeliveryInfoBuilder),
 				CartCache:           new(MockCartWithItemCache),
@@ -970,6 +1003,9 @@ func TestCartService_CartInEvent(t *testing.T) {
 			}{
 				CartCache: new(MockCartWithItemCacheWithAdditionalData),
 			},
+			&struct {
+				CartCachePrefix string `inject:"config:commerce.cart.cartCachePrefix,optional"`
+			}{},
 		)
 		return result
 	}()
@@ -981,6 +1017,7 @@ func TestCartService_CartInEvent(t *testing.T) {
 	config := &struct {
 		DefaultDeliveryCode string `inject:"config:commerce.cart.defaultDeliveryCode,optional"`
 		DeleteEmptyDelivery bool   `inject:"config:commerce.cart.deleteEmptyDelivery,optional"`
+		CartCachePrefix     string `inject:"config:commerce.cart.cartCachePrefix,optional"`
 	}{
 		DefaultDeliveryCode: "default_delivery_code",
 		DeleteEmptyDelivery: false,

--- a/cart/application/eventHandling.go
+++ b/cart/application/eventHandling.go
@@ -6,13 +6,14 @@ import (
 
 	"flamingo.me/flamingo/v3/framework/web"
 
-	cartDomain "flamingo.me/flamingo-commerce/v3/cart/domain/cart"
 	"flamingo.me/flamingo/v3/core/oauth/domain"
 	"flamingo.me/flamingo/v3/framework/flamingo"
+
+	cartDomain "flamingo.me/flamingo-commerce/v3/cart/domain/cart"
 )
 
 type (
-	//EventReceiver - handles events from other packages
+	// EventReceiver - handles events from other packages
 	EventReceiver struct {
 		logger              flamingo.Logger
 		cartService         *CartService
@@ -38,15 +39,15 @@ func (e *EventReceiver) Inject(
 	}
 }
 
-//Notify should get called by flamingo Eventlogic
+// Notify should get called by flamingo Eventlogic
 func (e *EventReceiver) Notify(ctx context.Context, event flamingo.Event) {
 	switch currentEvent := event.(type) {
-	//Handle Logout
+	// Handle Logout
 	case *domain.LogoutEvent:
 		if e.cartCache != nil {
 			e.cartCache.DeleteAll(ctx, currentEvent.Session)
 		}
-	//Handle LoginEvent and Merge Cart
+	// Handle LoginEvent and Merge Cart
 	case *domain.LoginEvent:
 		web.RunWithDetachedContext(ctx, func(ctx context.Context) {
 			if currentEvent == nil {

--- a/checkout/domain/placeorder/states/complete_cart_test.go
+++ b/checkout/domain/placeorder/states/complete_cart_test.go
@@ -170,6 +170,7 @@ func TestCompleteCart_Run(t *testing.T) {
 				new(flamingo.NullLogger),
 				nil,
 				nil,
+				nil,
 			)
 			cartService := &cartApplication.CartService{}
 			cartService.Inject(
@@ -274,6 +275,7 @@ func TestCompleteCart_Rollback(t *testing.T) {
 					return us
 				}(),
 				new(flamingo.NullLogger),
+				nil,
 				nil,
 				nil,
 			)

--- a/checkout/domain/placeorder/states/validate_cart_test.go
+++ b/checkout/domain/placeorder/states/validate_cart_test.go
@@ -105,6 +105,7 @@ func TestValidateCart_Run(t *testing.T) {
 		new(flamingo.NullLogger),
 		nil,
 		nil,
+		nil,
 	)
 
 	for _, tt := range tests {


### PR DESCRIPTION
Currently, it is possible to have multiple carts. This pull requests adds a configuration option to have multiple cart session caches by adding a prefix. This should be non-breaking, because the configuration is optional and uses the constants if no option is set.