### PR TITLE
cart: Adjust log level if cache entry not found for DeleteCartInCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   * Cart item validation now requires the decorated cart to be passed to assure that validators don't rely on a cart from any other source (e.g. session)
   * Session added as parameter to interface method `MaxQuantityRestrictor.Restrict`
   * Session added as parameter to `RestrictionService.RestrictQty`
+  * Changed no cache entry found error for cartCache `Invalidate`, `Delete` and `DeleteAll` to `ErrNoCacheEntry`
 * Switch module config to CUE
 * GraphQL
   * Add new mutation to set / update one or multiple delivery addresses `Commerce_Cart_UpdateDeliveryAddresses`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
     * type `Commerce_Charge` is now `Commerce_Price_Charge`
     * type `Commerce_ChargeQualifier` is now `Commerce_Price_ChargeQualifier`
     * input `Commerce_ChargeQualifierInput` is now `Commerce_Price_ChargeQualifierInput`
+* Adjusted log level for cache entry not found error when trying to delete the cached cart   
 
 **customer**
 * **Breaking**: renamed `GetId` to `GetID` in `domain.Customer` interface
@@ -50,7 +51,7 @@
   * In case of a payment error the checkout controller will now redirect to the checkout/review action instead of just rendering the matching template on the current route.
   * Same applies in case of an error during place order, the checkout controller will now redirect to the checkout step.
   * In both cases the error will be stored as a flash message in the session before redirecting, the target action will then receive it and pass it to the template view data. 
-    
+ 
 **search**
 * Switch module config to CUE
 * Update `pagination` module configuration. Use `commerce.pagination` namespace for configuration now.

--- a/cart/application/cartCache.go
+++ b/cart/application/cartCache.go
@@ -57,7 +57,7 @@ var (
 	_ CartCache = (*CartSessionCache)(nil)
 	// ErrCacheIsInvalid sets generalized invalid Cache Error
 	ErrCacheIsInvalid = errors.New("cache is invalid")
-	// ErrNoCacheEntry - used if cahce is not found
+	// ErrNoCacheEntry - used if cache is not found
 	ErrNoCacheEntry = errors.New("cache entry not found")
 )
 
@@ -196,7 +196,7 @@ func (cs *CartSessionCache) Invalidate(ctx context.Context, session *web.Session
 		}
 	}
 
-	return errors.New("not found for invalidate")
+	return ErrNoCacheEntry
 }
 
 // Delete a Cache entry
@@ -208,7 +208,7 @@ func (cs *CartSessionCache) Delete(ctx context.Context, session *web.Session, id
 		return nil
 	}
 
-	return errors.New("not found for delete")
+	return ErrNoCacheEntry
 }
 
 // DeleteAll empties the Cache
@@ -228,5 +228,5 @@ func (cs *CartSessionCache) DeleteAll(ctx context.Context, session *web.Session)
 		return nil
 	}
 
-	return errors.New("not found for delete")
+	return ErrNoCacheEntry
 }

--- a/cart/application/cartCache_test.go
+++ b/cart/application/cartCache_test.go
@@ -337,7 +337,7 @@ func TestCartSessionCache_Invalidate(t *testing.T) {
 				},
 			},
 			wantErr:               true,
-			wantMessageErr:        "not found for invalidate",
+			wantMessageErr:        "cache entry not found",
 			wantCacheEntryInvalid: false,
 		},
 		{
@@ -421,7 +421,7 @@ func TestCartSessionCache_Delete(t *testing.T) {
 				},
 			},
 			wantErr:        true,
-			wantMessageErr: "not found for delete",
+			wantMessageErr: "cache entry not found",
 		},
 		{
 			name:   "deleted correctly",
@@ -486,7 +486,7 @@ func TestCartSessionCache_DeleteAll(t *testing.T) {
 				session: web.EmptySession(),
 			},
 			wantErr:                true,
-			wantMessageErr:         "not found for delete",
+			wantMessageErr:         "cache entry not found",
 			wantSessionValuesEmpty: false,
 		},
 		{

--- a/cart/application/cartService.go
+++ b/cart/application/cartService.go
@@ -923,6 +923,10 @@ func (cs *CartService) DeleteCartInCache(ctx context.Context, session *web.Sessi
 		}
 
 		err = cs.cartCache.Delete(ctx, session, id)
+		if err == ErrNoCacheEntry {
+			cs.logger.WithContext(ctx).Info("Cart in cache not found: %v", err)
+			return
+		}
 		if err != nil {
 			cs.logger.WithContext(ctx).Error("Error while deleting cart in cache: %v", err)
 		}


### PR DESCRIPTION
During the place order process the cached cart is deleted twice (Once when completing the current cart and once when placing the cart):
https://github.com/i-love-flamingo/flamingo-commerce/blob/master/cart/application/cartService.go#L517
https://github.com/i-love-flamingo/flamingo-commerce/blob/master/cart/application/cartService.go#L1013
The second call currently logs an error because the cache entry is not found. 
Adjusted the log level for that case.