### PR TITLE
checkout: Generate a new idempotency key after cart restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 * fake: The product fake search service is now able to return products with an active variant via `fake_configurable_with_active_variant`. Variation attributes have been changed to only include `color` and `size`.
 * Expose `VariantVariationAttributesSorting` on `domain.ConfigurableProductWithActiveVariant`
 
+**checkout**
+* Checkout Controller, update handling of aborted/canceled payments:
+  * Cancel the order / restore the cart before generating the new idempotency key of the payment selection
+
 ## v3.3.0
 **product**
 * Switch module config to CUE

--- a/checkout/interfaces/controller/checkoutcontroller.go
+++ b/checkout/interfaces/controller/checkoutcontroller.go
@@ -644,17 +644,6 @@ func (cc *CheckoutController) PaymentAction(ctx context.Context, r *web.Request)
 		// payment is done and confirmed, place order
 		return cc.responder.RouteRedirect("checkout.placeorder", nil)
 	case paymentDomain.PaymentFlowStatusAborted:
-		// mark payment selection as new payment to allow the user to retry
-		newPaymentSelection, err := decoratedCart.Cart.PaymentSelection.GenerateNewIdempotencyKey()
-		if err != nil {
-			cc.logger.WithContext(ctx).Error("cart.checkoutcontroller.paymentaction: Error during GenerateNewIdempotencyKey:", err)
-		} else {
-			err = cc.applicationCartService.UpdatePaymentSelection(ctx, session, newPaymentSelection)
-			if err != nil {
-				cc.logger.WithContext(ctx).Error("cart.checkoutcontroller.paymentaction: Error during UpdatePaymentSelection:", err)
-			}
-		}
-
 		// payment was aborted by user, redirect to checkout so a new payment can be started
 		if cc.orderService.HasLastPlacedOrder(ctx) {
 			infos, err := cc.orderService.LastPlacedOrder(ctx)
@@ -676,12 +665,6 @@ func (cc *CheckoutController) PaymentAction(ctx context.Context, r *web.Request)
 			cc.orderService.ClearLastPlacedOrder(ctx)
 		}
 
-		if cc.showReviewStepAfterPaymentError && !cc.skipReviewAction {
-			return cc.responder.RouteRedirect("checkout.review", nil)
-		}
-
-		return cc.responder.RouteRedirect("checkout", nil)
-	case paymentDomain.PaymentFlowStatusFailed, paymentDomain.PaymentFlowStatusCancelled:
 		// mark payment selection as new payment to allow the user to retry
 		newPaymentSelection, err := decoratedCart.Cart.PaymentSelection.GenerateNewIdempotencyKey()
 		if err != nil {
@@ -693,6 +676,12 @@ func (cc *CheckoutController) PaymentAction(ctx context.Context, r *web.Request)
 			}
 		}
 
+		if cc.showReviewStepAfterPaymentError && !cc.skipReviewAction {
+			return cc.responder.RouteRedirect("checkout.review", nil)
+		}
+
+		return cc.responder.RouteRedirect("checkout", nil)
+	case paymentDomain.PaymentFlowStatusFailed, paymentDomain.PaymentFlowStatusCancelled:
 		// payment failed or is cancelled by payment provider, redirect back to checkout
 		if cc.orderService.HasLastPlacedOrder(ctx) {
 			infos, err := cc.orderService.LastPlacedOrder(ctx)
@@ -727,6 +716,17 @@ func (cc *CheckoutController) PaymentAction(ctx context.Context, r *web.Request)
 					ErrorCode:    paymentDomain.PaymentErrorCodeFailed,
 					ErrorMessage: paymentDomain.PaymentErrorCodeFailed,
 				}
+			}
+		}
+
+		// mark payment selection as new payment to allow the user to retry
+		newPaymentSelection, err := decoratedCart.Cart.PaymentSelection.GenerateNewIdempotencyKey()
+		if err != nil {
+			cc.logger.WithContext(ctx).Error("cart.checkoutcontroller.paymentaction: Error during GenerateNewIdempotencyKey:", err)
+		} else {
+			err = cc.applicationCartService.UpdatePaymentSelection(ctx, session, newPaymentSelection)
+			if err != nil {
+				cc.logger.WithContext(ctx).Error("cart.checkoutcontroller.paymentaction: Error during UpdatePaymentSelection:", err)
 			}
 		}
 


### PR DESCRIPTION
When a payment is aborted/canceled the checkout controller regenerates a new idempotency key. If an early place happened the cart at this stage is potentially not accessible any more. We therefore need to first cancel the order / restore the cart before setting the new PaymentSelection / Idempotency Key.

This PR changes the orders of the calls.