### PR TITLE
product: Add feature to the product fakeservice to use json files as the source.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@
     * `Commerce_Product` has been restructured and now has three subtypes: `Commerce_Product_SimpleProduct`, `Commerce_Product_ConfigurableProduct`, `Commerce_Product_ActiveVariantProduct`
     * Product variant data, that has previously been buried in `Commerce_ConfigurableProduct.variants`, has been mapped to the toplevel of each product and can be accessed directly.
     * Both `ActiveVariantProduct` and `ConfigurableProduct` provide a new property named `variationSelections` which exposes a list of possible attribute combinations for the configurable.
-* fake: The product fake search service is now able to return products with an active variant via `fake_configurable_with_active_variant`. Variation attributes have been changed to only include `color` and `size`.
+* FakeService
+    * The product fake search service is now able to return products with an active variant via `fake_configurable_with_active_variant`. Variation attributes have been changed to only include `color` and `size`.
+    * Added configuration option `jsonTestDataFolder` to use json files as fake products. You can find an example product under: `test/integrationtest/projecttest/tests/graphql/testdata/products/json_simple.json`
 * Expose `VariantVariationAttributesSorting` on `domain.ConfigurableProductWithActiveVariant`
 
 **checkout**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * FakeService
     * The product fake search service is now able to return products with an active variant via `fake_configurable_with_active_variant`. Variation attributes have been changed to only include `color` and `size`.
     * Added configuration option `jsonTestDataFolder` to use json files as fake products. You can find an example product under: `test/integrationtest/projecttest/tests/graphql/testdata/products/json_simple.json`
+    * Added fakservice documentation to the product module.  
 * Expose `VariantVariationAttributesSorting` on `domain.ConfigurableProductWithActiveVariant`
 
 **checkout**

--- a/cart/domain/cart/paymentselection_test.go
+++ b/cart/domain/cart/paymentselection_test.go
@@ -135,7 +135,10 @@ func TestPaymentSplit_UnmarshalJSON(t *testing.T) {
 			want: func() cart.PaymentSplit {
 				result := cart.PaymentSplit{}
 				charge := domain.Charge{
-					Type: "t1",
+					Price:     price.NewZero(""),
+					Value:     price.NewZero(""),
+					Type:      "t1",
+					Reference: "",
 				}
 				firstQualifier := cart.SplitQualifier{
 					Method:     "m1",

--- a/price/domain/price.go
+++ b/price/domain/price.go
@@ -487,6 +487,11 @@ func (p *Price) UnmarshalBinary(data []byte) error {
 	return nil
 }
 
+// UnmarshalJSON – implements encode Unmarshaler
+func (p *Price) UnmarshalJSON(data []byte) error {
+	return p.UnmarshalBinary(data)
+}
+
 // Add - Adds the given Charge to the current Charge and returns a new Charge
 func (p Charge) Add(add Charge) (Charge, error) {
 	if p.Type != add.Type {

--- a/product/Readme.md
+++ b/product/Readme.md
@@ -157,5 +157,22 @@ will modify the result of the two lists accordingly - while
 will not.
 
 
+## FakeService
+
+With enabled fake services `domain.ProductService` and `domain.SearchService` are responding with preconfigured fake products on invocation.   
+
+````yaml
+commerce: 
+	product: 
+		fakeservice: 
+			enabled: true # boolean: enables fakservices
+			currency: *"€" | !="" # string: currency for the fakeservices
+			jsonTestDataFolder: string | *"testdata/products"
+````
+
+The configuration option `jsonTestDataFolder` tells fakeservices to look for json files with product data in the defined folder. 
+Json files represent MarketPlaceCodes with their filename and `domain.BasicProduct` within the contents.
+You can find an example product under: `test/integrationtest/projecttest/tests/graphql/testdata/products/json_simple.json`
+
 ## Dependencies:
-* search package: the product.SearchService uses the search Result and Filter objects
+* search package: the product.SearchService uses the search Result and Filter objects.

--- a/product/infrastructure/fake/helper.go
+++ b/product/infrastructure/fake/helper.go
@@ -24,6 +24,7 @@ func registerTestData(folder string) map[string]string {
 	return testDataFiles
 }
 
+//unmarshalJSONProduct
 func unmarshalJSONProduct(productRaw []byte) (domain.BasicProduct, error) {
 	product := &map[string]interface{}{}
 	err := json.Unmarshal(productRaw, product)
@@ -36,16 +37,6 @@ func unmarshalJSONProduct(productRaw []byte) (domain.BasicProduct, error) {
 
 	if !ok {
 		return nil, errors.New("Type is not specified")
-	}
-
-	if productType == domain.TypeConfigurableWithActiveVariant {
-		configurableProductWithActiveVariant := &domain.ConfigurableProductWithActiveVariant{}
-
-		err = json.Unmarshal(productRaw, configurableProductWithActiveVariant)
-
-		if err == nil {
-			return *configurableProductWithActiveVariant, nil
-		}
 	}
 
 	if productType == domain.TypeConfigurable {

--- a/product/infrastructure/fake/helper.go
+++ b/product/infrastructure/fake/helper.go
@@ -3,7 +3,6 @@ package fake
 import (
 	"encoding/json"
 	"errors"
-
 	"flamingo.me/flamingo/v3/framework/flamingo"
 
 	"flamingo.me/flamingo-commerce/v3/product/domain"
@@ -17,8 +16,10 @@ func registerTestData(folder string, logger flamingo.Logger) map[string]string {
 	testDataFiles := make(map[string]string)
 	files, err := ioutil.ReadDir(folder)
 	if err != nil {
-		logger.Error(err)
+		logger.Info(err)
+		return testDataFiles
 	}
+
 	for _, file := range files {
 		if !file.IsDir() && strings.HasSuffix(file.Name(), ".json") {
 			base := filepath.Base(file.Name())[:len(file.Name())-len(".json")]

--- a/product/infrastructure/fake/helper.go
+++ b/product/infrastructure/fake/helper.go
@@ -3,28 +3,32 @@ package fake
 import (
 	"encoding/json"
 	"errors"
+
+	"flamingo.me/flamingo/v3/framework/flamingo"
+
 	"flamingo.me/flamingo-commerce/v3/product/domain"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
 )
 
-// registerTestData
-func registerTestData(folder string) map[string]string {
+// registerTestData returns files of given folder
+func registerTestData(folder string, logger flamingo.Logger) map[string]string {
 	testDataFiles := make(map[string]string)
 	files, err := ioutil.ReadDir(folder)
-	if err == nil {
-		for _, file := range files {
-			if !file.IsDir() && strings.HasSuffix(file.Name(), ".json") {
-				base := filepath.Base(file.Name())[:len(file.Name())-5]
-				testDataFiles[base] = filepath.Join(folder, file.Name())
-			}
+	if err != nil {
+		logger.Error(err)
+	}
+	for _, file := range files {
+		if !file.IsDir() && strings.HasSuffix(file.Name(), ".json") {
+			base := filepath.Base(file.Name())[:len(file.Name())-len(".json")]
+			testDataFiles[base] = filepath.Join(folder, file.Name())
 		}
 	}
 	return testDataFiles
 }
 
-//unmarshalJSONProduct
+// unmarshalJSONProduct unmarshals product based on type
 func unmarshalJSONProduct(productRaw []byte) (domain.BasicProduct, error) {
 	product := &map[string]interface{}{}
 	err := json.Unmarshal(productRaw, product)
@@ -36,7 +40,7 @@ func unmarshalJSONProduct(productRaw []byte) (domain.BasicProduct, error) {
 	productType, ok := (*product)["Type"]
 
 	if !ok {
-		return nil, errors.New("Type is not specified")
+		return nil, errors.New("type is not specified")
 	}
 
 	if productType == domain.TypeConfigurable {

--- a/product/infrastructure/fake/helper.go
+++ b/product/infrastructure/fake/helper.go
@@ -1,0 +1,66 @@
+package fake
+
+import (
+	"encoding/json"
+	"errors"
+	"flamingo.me/flamingo-commerce/v3/product/domain"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+)
+
+// registerTestData
+func registerTestData(folder string) map[string]string {
+	testDataFiles := make(map[string]string)
+	files, err := ioutil.ReadDir(folder)
+	if err == nil {
+		for _, file := range files {
+			if !file.IsDir() && strings.HasSuffix(file.Name(), ".json") {
+				base := filepath.Base(file.Name())[:len(file.Name())-5]
+				testDataFiles[base] = filepath.Join(folder, file.Name())
+			}
+		}
+	}
+	return testDataFiles
+}
+
+func unmarshalJSONProduct(productRaw []byte) (domain.BasicProduct, error) {
+	product := &map[string]interface{}{}
+	err := json.Unmarshal(productRaw, product)
+
+	if err != nil {
+		return nil, err
+	}
+
+	productType, ok := (*product)["Type"]
+
+	if !ok {
+		return nil, errors.New("Type is not specified")
+	}
+
+	if productType == domain.TypeConfigurableWithActiveVariant {
+		configurableProductWithActiveVariant := &domain.ConfigurableProductWithActiveVariant{}
+
+		err = json.Unmarshal(productRaw, configurableProductWithActiveVariant)
+
+		if err == nil {
+			return *configurableProductWithActiveVariant, nil
+		}
+	}
+
+	if productType == domain.TypeConfigurable {
+		configurableProduct := &domain.ConfigurableProduct{}
+		err = json.Unmarshal(productRaw, configurableProduct)
+		if err == nil {
+			return *configurableProduct, nil
+		}
+	}
+
+	simpleProduct := &domain.SimpleProduct{}
+	err = json.Unmarshal(productRaw, simpleProduct)
+	if err != nil {
+		return nil, err
+	}
+
+	return *simpleProduct, nil
+}

--- a/product/infrastructure/fake/productservice.go
+++ b/product/infrastructure/fake/productservice.go
@@ -374,15 +374,10 @@ func (ps *ProductService) getProductFromJSON(code string) (domain.BasicProduct, 
 
 // jsonProductCodes returns an ordered list of the json product codes
 func (ps *ProductService) jsonProductCodes() []string {
-	productCodes := make([]string, 0, len(ps.testDataFiles))
 	keys := make([]string, 0, len(ps.testDataFiles))
 	for k := range ps.testDataFiles {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-	for _, k := range keys {
-		productCodes = append(productCodes, k)
-	}
-
-	return productCodes
+	return keys
 }

--- a/product/infrastructure/fake/productservice.go
+++ b/product/infrastructure/fake/productservice.go
@@ -165,6 +165,7 @@ func (ps *ProductService) FakeSimple(marketplaceCode string, isNew bool, isExclu
 	return product
 }
 
+//GetMarketPlaceCodes returns list of available marketplace code which are supported by this fakeservice
 func (ps *ProductService) GetMarketPlaceCodes() []string {
 	marketPlaceCodes := []string{
 		"fake_configurable",
@@ -369,7 +370,7 @@ func (ps *ProductService) getProductFromJSON(code string) (domain.BasicProduct, 
 func (ps *ProductService) jsonProductCodes() []string {
 	productCodes := make([]string, 0, len(ps.testDataFiles))
 
-	for key, _ := range ps.testDataFiles {
+	for key := range ps.testDataFiles {
 		productCodes = append(productCodes, key)
 	}
 

--- a/product/infrastructure/fake/productservice.go
+++ b/product/infrastructure/fake/productservice.go
@@ -75,16 +75,7 @@ func (ps *ProductService) Get(_ context.Context, marketplaceCode string) (domain
 		return jsonProduct, nil
 	}
 
-	marketPlaceCodes := []string{
-		"fake_configurable",
-		"fake_configurable_with_active_variant",
-		"fake_simple",
-		"fake_simple_with_fixed_price",
-		"fake_simple_out_of_stock",
-		"fake_fixed_simple_without_discounts",
-	}
-
-	marketPlaceCodes = append(marketPlaceCodes, ps.jsonProductCodes()...)
+	marketPlaceCodes := ps.GetMarketPlaceCodes()
 
 	return nil, domain.ProductNotFound{
 		MarketplaceCode: "Code " + marketplaceCode + " Not implemented in FAKE: Only following codes should be used" + strings.Join(marketPlaceCodes, ", "),
@@ -172,6 +163,19 @@ func (ps *ProductService) FakeSimple(marketplaceCode string, isNew bool, isExclu
 	}
 
 	return product
+}
+
+func (ps *ProductService) GetMarketPlaceCodes() []string {
+	marketPlaceCodes := []string{
+		"fake_configurable",
+		"fake_configurable_with_active_variant",
+		"fake_simple",
+		"fake_simple_with_fixed_price",
+		"fake_simple_out_of_stock",
+		"fake_fixed_simple_without_discounts",
+	}
+
+	return append(marketPlaceCodes, ps.jsonProductCodes()...)
 }
 
 func (ps *ProductService) getFakeConfigurable(marketplaceCode string) domain.ConfigurableProduct {

--- a/product/infrastructure/fake/searchservice.go
+++ b/product/infrastructure/fake/searchservice.go
@@ -43,7 +43,7 @@ func (s *SearchService) Search(ctx context.Context, filter ...searchDomain.Filte
 				OriginalQuery:  "",
 				Page:           1,
 				NumPages:       1,
-				NumResults:     2,
+				NumResults:     len(hits),
 				SelectedFacets: nil,
 				SortOptions:    nil,
 			},

--- a/product/infrastructure/fake/searchservice.go
+++ b/product/infrastructure/fake/searchservice.go
@@ -24,13 +24,16 @@ func (s *SearchService) Inject(
 
 //Search returns Products based on given Filters
 func (s *SearchService) Search(ctx context.Context, filter ...searchDomain.Filter) (*domain.SearchResult, error) {
-	p1, err := s.productService.Get(ctx, "fake_configurable")
-	if err != nil {
-		return nil, err
-	}
-	p2, err := s.productService.Get(ctx, "fake_simple")
-	if err != nil {
-		return nil, err
+	documents := make([]searchDomain.Document, 0)
+	hits := make([]domain.BasicProduct, 0)
+
+	for _, marketPlaceCode := range s.productService.GetMarketPlaceCodes() {
+		product, _ := s.productService.Get(ctx, marketPlaceCode)
+		if product == nil {
+			continue
+		}
+		documents = append(documents, product)
+		hits = append(hits, product)
 	}
 
 	return &domain.SearchResult{
@@ -44,7 +47,7 @@ func (s *SearchService) Search(ctx context.Context, filter ...searchDomain.Filte
 				SelectedFacets: nil,
 				SortOptions:    nil,
 			},
-			Hits:       []searchDomain.Document{p1, p2},
+			Hits:       documents,
 			Suggestion: []searchDomain.Suggestion{},
 			Facets: map[string]searchDomain.Facet{"brandCode": {
 				Type:  string(searchDomain.ListFacet),
@@ -73,7 +76,7 @@ func (s *SearchService) Search(ctx context.Context, filter ...searchDomain.Filte
 					Position: 0,
 				}},
 		},
-		Hits: []domain.BasicProduct{p1, p2},
+		Hits: hits,
 	}, nil
 
 }

--- a/product/module.go
+++ b/product/module.go
@@ -75,7 +75,8 @@ commerce: {
 		slugAttributeCode: string | *"urlSlug"
 		fakeservice: {
 			enabled: bool | *false
-			currency: *"€" | !=""  
+			currency: *"€" | !=""
+			jsonTestDataFolder: *"testdata/products" | !=""
 		}
 		api: {
 			enabled: bool | *true

--- a/product/module.go
+++ b/product/module.go
@@ -76,7 +76,7 @@ commerce: {
 		fakeservice: {
 			enabled: bool | *false
 			currency: *"€" | !=""
-			jsonTestDataFolder: *"testdata/products" | !=""
+			jsonTestDataFolder?: !=""
 		}
 		api: {
 			enabled: bool | *true

--- a/product/module.go
+++ b/product/module.go
@@ -76,7 +76,9 @@ commerce: {
 		fakeservice: {
 			enabled: bool | *false
 			currency: *"€" | !=""
-			jsonTestDataFolder?: !=""
+			if enabled {
+			  jsonTestDataFolder: string | *"testdata/products"
+			}
 		}
 		api: {
 			enabled: bool | *true

--- a/product/module.go
+++ b/product/module.go
@@ -48,8 +48,8 @@ func (m *Module) Configure(injector *dingo.Injector) {
 
 	injector.BindMulti(new(graphql.Service)).To(new(productgraphql.Service))
 	if m.fakeService {
-		injector.Bind((*domain.ProductService)(nil)).To(fake.ProductService{})
-		injector.Bind((*domain.SearchService)(nil)).To(fake.SearchService{})
+		injector.Bind((*domain.ProductService)(nil)).To(fake.ProductService{}).In(dingo.ChildSingleton)
+		injector.Bind((*domain.SearchService)(nil)).To(fake.SearchService{}).In(dingo.ChildSingleton)
 	}
 
 }

--- a/test/integrationtest/projecttest/config/config.yml
+++ b/test/integrationtest/projecttest/config/config.yml
@@ -71,6 +71,8 @@ commerce:
   product:
     fakeservice:
       enabled: true
+      jsonTestDataFolder: "graphql/testdata/products"
+
     priceIsGross: true
   customer:
     useNilCustomerAdapter: false

--- a/test/integrationtest/projecttest/tests/graphql/testdata/products/json_simple.json
+++ b/test/integrationtest/projecttest/tests/graphql/testdata/products/json_simple.json
@@ -1,0 +1,755 @@
+{
+  "Identifier": "simple",
+  "Title": "This should be the best test product",
+  "Type": "simple",
+  "Attributes": {
+    "alwaysInStock": {
+      "Code": "alwaysInStock",
+      "CodeLabel": "Always In Stock",
+      "Label": "Yes",
+      "RawValue": "true",
+      "UnitCode": ""
+    },
+    "alwaysInStock_codeLabel": {
+      "Code": "alwaysInStock_codeLabel",
+      "CodeLabel": "",
+      "Label": "Always In Stock",
+      "RawValue": "Always In Stock",
+      "UnitCode": ""
+    },
+    "loyalty": {
+      "Code": "loyalty",
+      "CodeLabel": "Loyalty earning",
+      "Label": "1000",
+      "RawValue": "1000",
+      "UnitCode": ""
+    },
+    "loyalty_codeLabel": {
+      "Code": "loyalty_codeLabel",
+      "CodeLabel": "",
+      "Label": "Loyalty earning",
+      "RawValue": "Loyalty earning",
+      "UnitCode": ""
+    },
+    "brandCode": {
+      "Code": "brandCode",
+      "CodeLabel": "Brand",
+      "Label": "johnnie-walker",
+      "RawValue": "johnnie-walker",
+      "UnitCode": ""
+    },
+    "brandCode_codeLabel": {
+      "Code": "brandCode_codeLabel",
+      "CodeLabel": "",
+      "Label": "Brand",
+      "RawValue": "Brand",
+      "UnitCode": ""
+    },
+    "brandForeignId": {
+      "Code": "brandForeignId",
+      "CodeLabel": "",
+      "Label": "johnnie-walker-en_US-online",
+      "RawValue": "johnnie-walker-en_US-online",
+      "UnitCode": ""
+    },
+    "brandName": {
+      "Code": "brandName",
+      "CodeLabel": "",
+      "Label": "JOHNNIE WALKER",
+      "RawValue": "JOHNNIE WALKER",
+      "UnitCode": ""
+    },
+    "brandToCodeMapping": {
+      "Code": "brandToCodeMapping",
+      "CodeLabel": "",
+      "Label": "JOHNNIE WALKER:johnnie-walker",
+      "RawValue": "JOHNNIE WALKER:johnnie-walker",
+      "UnitCode": ""
+    },
+    "brandToForeignIdMapping": {
+      "Code": "brandToForeignIdMapping",
+      "CodeLabel": "",
+      "Label": "JOHNNIE WALKER:johnnie-walker-en_US-online",
+      "RawValue": "JOHNNIE WALKER:johnnie-walker-en_US-online",
+      "UnitCode": ""
+    },
+    "brandType": {
+      "Code": "brandType",
+      "CodeLabel": "",
+      "Label": "default",
+      "RawValue": "default",
+      "UnitCode": ""
+    },
+    "deliveryOptions": {
+      "Code": "deliveryOptions",
+      "CodeLabel": "Delivery options",
+      "Label": "[delivery____domestichome delivery____internationalhome inflight ispu]",
+      "RawValue": [
+        "delivery____domestichome",
+        "delivery____internationalhome",
+        "inflight",
+        "ispu"
+      ],
+      "UnitCode": ""
+    },
+    "deliveryOptions_codeLabel": {
+      "Code": "deliveryOptions_codeLabel",
+      "CodeLabel": "",
+      "Label": "Delivery options",
+      "RawValue": "Delivery options",
+      "UnitCode": ""
+    },
+    "discountGroup": {
+      "Code": "discountGroup",
+      "CodeLabel": "Discount Group",
+      "Label": "Non discountable",
+      "RawValue": "0",
+      "UnitCode": ""
+    },
+    "discountGroup_codeLabel": {
+      "Code": "discountGroup_codeLabel",
+      "CodeLabel": "",
+      "Label": "Discount Group",
+      "RawValue": "Discount Group",
+      "UnitCode": ""
+    },
+    "itemType": {
+      "Code": "itemType",
+      "CodeLabel": "Item Type",
+      "Label": "IP",
+      "RawValue": "IP",
+      "UnitCode": ""
+    },
+    "itemType_codeLabel": {
+      "Code": "itemType_codeLabel",
+      "CodeLabel": "",
+      "Label": "Item Type",
+      "RawValue": "Item Type",
+      "UnitCode": ""
+    },
+    "manufacturerColor": {
+      "Code": "manufacturerColor",
+      "CodeLabel": "Manufacturer color",
+      "Label": "Manufacturer Color green",
+      "RawValue": "Manufacturer Color green",
+      "UnitCode": ""
+    },
+    "manufacturerColor_codeLabel": {
+      "Code": "manufacturerColor_codeLabel",
+      "CodeLabel": "",
+      "Label": "Manufacturer color",
+      "RawValue": "Manufacturer color",
+      "UnitCode": ""
+    },
+    "manufacturerSeriesname": {
+      "Code": "manufacturerSeriesname",
+      "CodeLabel": "Vendor style number",
+      "Label": "Product Series BEST (English)",
+      "RawValue": "Product Series BEST (English)",
+      "UnitCode": ""
+    },
+    "manufacturerSeriesname_codeLabel": {
+      "Code": "manufacturerSeriesname_codeLabel",
+      "CodeLabel": "",
+      "Label": "Vendor style number",
+      "RawValue": "Vendor style number",
+      "UnitCode": ""
+    },
+    "manufacturersData": {
+      "Code": "manufacturersData",
+      "CodeLabel": "Manufacturers data",
+      "Label": "Manufacturers Data test",
+      "RawValue": "Manufacturers Data test",
+      "UnitCode": ""
+    },
+    "manufacturersData_codeLabel": {
+      "Code": "manufacturersData_codeLabel",
+      "CodeLabel": "",
+      "Label": "Manufacturers data",
+      "RawValue": "Manufacturers data",
+      "UnitCode": ""
+    },
+    "metaDescription": {
+      "Code": "metaDescription",
+      "CodeLabel": "Meta Description",
+      "Label": "This is the meta description of the product.",
+      "RawValue": "This is the meta description of the product.",
+      "UnitCode": ""
+    },
+    "metaDescription_codeLabel": {
+      "Code": "metaDescription_codeLabel",
+      "CodeLabel": "",
+      "Label": "Meta Description",
+      "RawValue": "Meta Description",
+      "UnitCode": ""
+    },
+    "metaTitle": {
+      "Code": "metaTitle",
+      "CodeLabel": "Meta Title",
+      "Label": "This is the meta title",
+      "RawValue": "This is the meta title",
+      "UnitCode": ""
+    },
+    "metaTitle_codeLabel": {
+      "Code": "metaTitle_codeLabel",
+      "CodeLabel": "",
+      "Label": "Meta Title",
+      "RawValue": "Meta Title",
+      "UnitCode": ""
+    },
+    "netWeight": {
+      "Code": "netWeight",
+      "CodeLabel": "Net weight",
+      "Label": "99999.0000",
+      "RawValue": "99999.0000",
+      "UnitCode": "KILOGRAM"
+    },
+    "netWeight_codeLabel": {
+      "Code": "netWeight_codeLabel",
+      "CodeLabel": "",
+      "Label": "Net weight",
+      "RawValue": "Net weight",
+      "UnitCode": ""
+    },
+    "p60": {
+      "Code": "p60",
+      "CodeLabel": "P-60 Product",
+      "Label": "0",
+      "RawValue": "0",
+      "UnitCode": ""
+    },
+    "p60_codeLabel": {
+      "Code": "p60_codeLabel",
+      "CodeLabel": "",
+      "Label": "P-60 Product",
+      "RawValue": "P-60 Product",
+      "UnitCode": ""
+    },
+    "poGenerate": {
+      "Code": "poGenerate",
+      "CodeLabel": "PO Generate",
+      "Label": "Yes",
+      "RawValue": "true",
+      "UnitCode": ""
+    },
+    "poGenerate_codeLabel": {
+      "Code": "poGenerate_codeLabel",
+      "CodeLabel": "",
+      "Label": "PO Generate",
+      "RawValue": "PO Generate",
+      "UnitCode": ""
+    },
+    "pointRatio": {
+      "Code": "pointRatio",
+      "CodeLabel": "Points ratio",
+      "Label": "125.0000",
+      "RawValue": "125.0000",
+      "UnitCode": ""
+    },
+    "pointRatio_codeLabel": {
+      "Code": "pointRatio_codeLabel",
+      "CodeLabel": "",
+      "Label": "Points ratio",
+      "RawValue": "Points ratio",
+      "UnitCode": ""
+    },
+    "pointsPayment": {
+      "Code": "pointsPayment",
+      "CodeLabel": "Payment by Points",
+      "Label": "Yes",
+      "RawValue": "true",
+      "UnitCode": ""
+    },
+    "pointsPayment_codeLabel": {
+      "Code": "pointsPayment_codeLabel",
+      "CodeLabel": "",
+      "Label": "Payment by Points",
+      "RawValue": "Payment by Points",
+      "UnitCode": ""
+    },
+    "rrp": {
+      "Code": "rrp",
+      "CodeLabel": "Recommended Retail Price",
+      "Label": "95.00",
+      "RawValue": "95.00",
+      "UnitCode": ""
+    },
+    "rrp_codeLabel": {
+      "Code": "rrp_codeLabel",
+      "CodeLabel": "",
+      "Label": "Recommended Retail Price",
+      "RawValue": "Recommended Retail Price",
+      "UnitCode": ""
+    },
+    "supplierSkuCode": {
+      "Code": "supplierSkuCode",
+      "CodeLabel": "Supplier SKU Code",
+      "Label": "Maximum-features",
+      "RawValue": "Maximum-features",
+      "UnitCode": ""
+    },
+    "supplierSkuCode_codeLabel": {
+      "Code": "supplierSkuCode_codeLabel",
+      "CodeLabel": "",
+      "Label": "Supplier SKU Code",
+      "RawValue": "Supplier SKU Code",
+      "UnitCode": ""
+    },
+    "travelExclusive": {
+      "Code": "travelExclusive",
+      "CodeLabel": "Travel Exclusive Item",
+      "Label": "0",
+      "RawValue": "0",
+      "UnitCode": ""
+    },
+    "travelExclusive_codeLabel": {
+      "Code": "travelExclusive_codeLabel",
+      "CodeLabel": "",
+      "Label": "Travel Exclusive Item",
+      "RawValue": "Travel Exclusive Item",
+      "UnitCode": ""
+    },
+    "urlSlug": {
+      "Code": "urlSlug",
+      "CodeLabel": "URL slug",
+      "Label": "this-should-be-the-best-test-product",
+      "RawValue": "this-should-be-the-best-test-product",
+      "UnitCode": ""
+    },
+    "urlSlug_codeLabel": {
+      "Code": "urlSlug_codeLabel",
+      "CodeLabel": "",
+      "Label": "URL slug",
+      "RawValue": "URL slug",
+      "UnitCode": ""
+    },
+    "urlTitle": {
+      "Code": "urlTitle",
+      "CodeLabel": "URL title",
+      "Label": "This should be the best test product",
+      "RawValue": "This should be the best test product",
+      "UnitCode": ""
+    },
+    "urlTitle_codeLabel": {
+      "Code": "urlTitle_codeLabel",
+      "CodeLabel": "",
+      "Label": "URL title",
+      "RawValue": "URL title",
+      "UnitCode": ""
+    },
+    "volume": {
+      "Code": "volume",
+      "CodeLabel": "Volume",
+      "Label": "99999.9900",
+      "RawValue": "99999.9900",
+      "UnitCode": "LITER"
+    },
+    "volume_codeLabel": {
+      "Code": "volume_codeLabel",
+      "CodeLabel": "",
+      "Label": "Volume",
+      "RawValue": "Volume",
+      "UnitCode": ""
+    }
+  },
+  "ShortDescription": "This is the short description.",
+  "Description": "DO NOT CHANGE THIS PRODUCT! It is used for integration tests! This product tries to make it as easy as possible to test as much as possible with this one product. \nSo it has attributes, a long description, a special price, multiple images, belongs to multiple categories and so one. \nPlease ask your local tester if you miss something. ",
+  "Media": [
+    {
+      "Type": "image-api",
+      "MimeType": "image/jpeg",
+      "Usage": "detail",
+      "Title": "",
+      "Reference": "a/3/c/3/a3c381fcaf8f121aff8badbb1b88f3cc_best.jpg"
+    },
+    {
+      "Type": "image-api",
+      "MimeType": "image/jpeg",
+      "Usage": "gallery",
+      "Title": "",
+      "Reference": "c/c/0/8/cc08a6e84ab1caa3ad2741700a797992_OM3_800.jpg"
+    },
+    {
+      "Type": "image-api",
+      "MimeType": "image/jpeg",
+      "Usage": "gallery",
+      "Title": "",
+      "Reference": "a/3/c/3/a3c381fcaf8f121aff8badbb1b88f3cc_best.jpg"
+    },
+    {
+      "Type": "image-api",
+      "MimeType": "image/jpeg",
+      "Usage": "gallery",
+      "Title": "",
+      "Reference": "c/c/0/8/cc08a6e84ab1caa3ad2741700a797992_OM3_800.jpg"
+    },
+    {
+      "Type": "image-api",
+      "MimeType": "image/jpeg",
+      "Usage": "gallery",
+      "Title": "",
+      "Reference": "8/a/a/d/8aad6052669b5c02c1c008b645c4dec9__1000x1000__ITEM__DEFAULT__THUMB__100205AX_.jpg"
+    },
+    {
+      "Type": "image-api",
+      "MimeType": "image/jpeg",
+      "Usage": "gallery",
+      "Title": "",
+      "Reference": "7/3/2/4/7324ff69e205fc530db335c94a22edd1__1000x1000__ITEM__DEFAULT__THUMB__100261AX_.jpg"
+    },
+    {
+      "Type": "image-api",
+      "MimeType": "image/jpeg",
+      "Usage": "list",
+      "Title": "",
+      "Reference": "9/1/9/2/9192c5d2802e3e4e43cbf5cfc23c6126__1000x1000__ITEM__DEFAULT__THUMB__100017AX_.jpg"
+    },
+    {
+      "Type": "image-api",
+      "MimeType": "image/jpeg",
+      "Usage": "thumbnail",
+      "Title": "",
+      "Reference": "9/1/9/2/9192c5d2802e3e4e43cbf5cfc23c6126__1000x1000__ITEM__DEFAULT__THUMB__100017AX_.jpg"
+    }
+  ],
+  "MarketPlaceCode": "54aff082da3fe516",
+  "RetailerCode": "retailer",
+  "RetailerSku": "maximum-features",
+  "RetailerName": "Retailer Duty Free \u0026 More",
+  "CreatedAt": "2019-11-06T09:57:51-05:00",
+  "UpdatedAt": "2020-09-24T05:49:35-05:00",
+  "VisibleFrom": "0001-01-01T00:00:00Z",
+  "VisibleTo": "0001-01-01T00:00:00Z",
+  "Categories": [
+    {
+      "Code": "online_beauty",
+      "Path": "Beauty",
+      "Name": "",
+      "Parent": null
+    },
+    {
+      "Code": "online_beauty_makeup",
+      "Path": "Beauty/Makeup",
+      "Name": "",
+      "Parent": null
+    },
+    {
+      "Code": "online_beauty_skincare",
+      "Path": "Beauty/Skincare",
+      "Name": "",
+      "Parent": null
+    },
+    {
+      "Code": "online_fragrance",
+      "Path": "Fragrances",
+      "Name": "",
+      "Parent": null
+    },
+    {
+      "Code": "online_fragrance_mens",
+      "Path": "Fragrances/Men’s",
+      "Name": "",
+      "Parent": null
+    },
+    {
+      "Code": "online_fragrance_unisex",
+      "Path": "Fragrances/Unisex",
+      "Name": "",
+      "Parent": null
+    },
+    {
+      "Code": "online_fragrance_womens",
+      "Path": "Fragrances/Women’s",
+      "Name": "",
+      "Parent": null
+    },
+    {
+      "Code": "online_gadgets",
+      "Path": "Gadgets",
+      "Name": "",
+      "Parent": null
+    },
+    {
+      "Code": "online_gadgets_accessories",
+      "Path": "Gadgets/Accessories",
+      "Name": "",
+      "Parent": null
+    },
+    {
+      "Code": "online_gadgets_gifts",
+      "Path": "Gadgets/Gifts",
+      "Name": "",
+      "Parent": null
+    },
+    {
+      "Code": "online_gadgets_travelEssentials",
+      "Path": "Gadgets/Travel Essentials",
+      "Name": "",
+      "Parent": null
+    },
+    {
+      "Code": "online_jewelry",
+      "Path": "Jewelry",
+      "Name": "",
+      "Parent": null
+    },
+    {
+      "Code": "online_jewelry_costumeJewelry",
+      "Path": "Jewelry/Costume Jewelry",
+      "Name": "",
+      "Parent": null
+    },
+    {
+      "Code": "online_kidsSnacks",
+      "Path": "Kid’s \u0026 Snacks",
+      "Name": "",
+      "Parent": null
+    },
+    {
+      "Code": "online_kidsSnacks_confectionary",
+      "Path": "Kid’s \u0026 Snacks/Confectionary",
+      "Name": "",
+      "Parent": null
+    },
+    {
+      "Code": "online_kidsSnacks_toys",
+      "Path": "Kid’s \u0026 Snacks/Toys",
+      "Name": "",
+      "Parent": null
+    },
+    {
+      "Code": "online_liquors",
+      "Path": "Liquors/Spirits",
+      "Name": "",
+      "Parent": null
+    },
+    {
+      "Code": "online_liqours_spirits",
+      "Path": "Liquors",
+      "Name": "",
+      "Parent": null
+    },
+    {
+      "Code": "online_liquors_wineChampagne",
+      "Path": "Liquors/Wine \u0026 Champagne",
+      "Name": "",
+      "Parent": null
+    },
+    {
+      "Code": "online_tabacco",
+      "Path": "Tobacco",
+      "Name": "",
+      "Parent": null
+    }
+  ],
+  "MainCategory": {
+    "Code": "online_beauty",
+    "Path": "Beauty",
+    "Name": "",
+    "Parent": null
+  },
+  "CategoryToCodeMapping": [
+    "Beauty:online_beauty",
+    "Beauty/Makeup:online_beauty_makeup",
+    "Beauty/Skincare:online_beauty_skincare",
+    "Fragrances:online_fragrance",
+    "Fragrances/Men’s:online_fragrance_mens",
+    "Fragrances/Unisex:online_fragrance_unisex",
+    "Fragrances/Women’s:online_fragrance_womens",
+    "Gadgets:online_gadgets",
+    "Gadgets/Accessories:online_gadgets_accessories",
+    "Gadgets/Gifts:online_gadgets_gifts",
+    "Gadgets/Travel Essentials:online_gadgets_travelEssentials",
+    "Jewelry:online_jewelry",
+    "Jewelry/Costume Jewelry:online_jewelry_costumeJewelry",
+    "Kid’s \u0026 Snacks:online_kidsSnacks",
+    "Kid’s \u0026 Snacks/Confectionary:online_kidsSnacks_confectionary",
+    "Kid’s \u0026 Snacks/Toys:online_kidsSnacks_toys",
+    "Liquors:online_liquors",
+    "Liquors/Spirits:online_liqours_spirits",
+    "Liquors/Wine \u0026 Champagne:online_liquors_wineChampagne",
+    "Tobacco:online_tabacco"
+  ],
+  "StockLevel": "",
+  "Keywords": [],
+  "IsNew": false,
+  "IsSaleable": true,
+  "SaleableFrom": "0001-01-01T00:00:00Z",
+  "SaleableTo": "0001-01-01T00:00:00Z",
+  "ActivePrice": {
+    "Default": {
+      "Amount": "1.23456789e+06",
+      "Currency": "USD"
+    },
+    "Discounted": {
+      "Amount": "25",
+      "Currency": "USD"
+    },
+    "DiscountText": "special_price",
+    "ActiveBase": "0.0",
+    "ActiveBaseAmount": "0.0",
+    "ActiveBaseUnit": "",
+    "IsDiscounted": true,
+    "CampaignRules": [
+      "SpecialPriceRule"
+    ],
+    "DenyMoreDiscounts": false,
+    "Context": {
+      "CustomerGroup": "",
+      "ChannelCode": "",
+      "Locale": "en_US"
+    },
+    "TaxClass": "fullTax"
+  },
+  "AvailablePrices": [],
+  "LoyaltyPrices": [
+    {
+      "Type": "Loyalty",
+      "Default": {
+        "Amount": "1.54320986e+08",
+        "Currency": "Loyalty"
+      },
+      "IsDiscounted": true,
+      "Discounted": {
+        "Amount": "3124",
+        "Currency": "Loyalty"
+      },
+      "DiscountText": "special_price",
+      "MinPointsToSpent": "0",
+      "MaxPointsToSpent": null,
+      "Context": {
+        "CustomerGroup": "",
+        "ChannelCode": "",
+        "Locale": ""
+      }
+    }
+  ],
+  "LoyaltyEarnings": [
+    {
+      "Type": "Loyalty",
+      "Default": {
+        "Amount": "25",
+        "Currency": "Loyalty"
+      }
+    }
+  ],
+  "Teaser": {
+    "ShortTitle": "This should be the best test product",
+    "ShortDescription": "This is the short description.",
+    "URLSlug": "this-should-be-the-best-test-product",
+    "TeaserPrice": {
+      "Default": {
+        "Amount": "1.23456789e+06",
+        "Currency": "USD"
+      },
+      "Discounted": {
+        "Amount": "25",
+        "Currency": "USD"
+      },
+      "DiscountText": "special_price",
+      "ActiveBase": "0.0",
+      "ActiveBaseAmount": "0.0",
+      "ActiveBaseUnit": "",
+      "IsDiscounted": true,
+      "CampaignRules": [
+        "SpecialPriceRule"
+      ],
+      "DenyMoreDiscounts": false,
+      "Context": {
+        "CustomerGroup": "",
+        "ChannelCode": "",
+        "Locale": "en_US"
+      },
+      "TaxClass": "fullTax"
+    },
+    "TeaserPriceIsFromPrice": false,
+    "PreSelectedVariantSku": "",
+    "Media": [
+      {
+        "Type": "image-api",
+        "MimeType": "image/jpeg",
+        "Usage": "detail",
+        "Title": "",
+        "Reference": "a/3/c/3/a3c381fcaf8f121aff8badbb1b88f3cc_best.jpg"
+      },
+      {
+        "Type": "image-api",
+        "MimeType": "image/jpeg",
+        "Usage": "gallery",
+        "Title": "",
+        "Reference": "c/c/0/8/cc08a6e84ab1caa3ad2741700a797992_OM3_800.jpg"
+      },
+      {
+        "Type": "image-api",
+        "MimeType": "image/jpeg",
+        "Usage": "gallery",
+        "Title": "",
+        "Reference": "a/3/c/3/a3c381fcaf8f121aff8badbb1b88f3cc_best.jpg"
+      },
+      {
+        "Type": "image-api",
+        "MimeType": "image/jpeg",
+        "Usage": "gallery",
+        "Title": "",
+        "Reference": "c/c/0/8/cc08a6e84ab1caa3ad2741700a797992_OM3_800.jpg"
+      },
+      {
+        "Type": "image-api",
+        "MimeType": "image/jpeg",
+        "Usage": "gallery",
+        "Title": "",
+        "Reference": "8/a/a/d/8aad6052669b5c02c1c008b645c4dec9__1000x1000__ITEM__DEFAULT__THUMB__100205AX_.jpg"
+      },
+      {
+        "Type": "image-api",
+        "MimeType": "image/jpeg",
+        "Usage": "gallery",
+        "Title": "",
+        "Reference": "7/3/2/4/7324ff69e205fc530db335c94a22edd1__1000x1000__ITEM__DEFAULT__THUMB__100261AX_.jpg"
+      },
+      {
+        "Type": "image-api",
+        "MimeType": "image/jpeg",
+        "Usage": "list",
+        "Title": "",
+        "Reference": "9/1/9/2/9192c5d2802e3e4e43cbf5cfc23c6126__1000x1000__ITEM__DEFAULT__THUMB__100017AX_.jpg"
+      },
+      {
+        "Type": "image-api",
+        "MimeType": "image/jpeg",
+        "Usage": "thumbnail",
+        "Title": "",
+        "Reference": "9/1/9/2/9192c5d2802e3e4e43cbf5cfc23c6126__1000x1000__ITEM__DEFAULT__THUMB__100017AX_.jpg"
+      }
+    ],
+    "MarketPlaceCode": "54aff082da3fe516",
+    "TeaserAvailablePrices": [],
+    "TeaserLoyaltyPriceInfo": {
+      "Type": "Loyalty",
+      "Default": {
+        "Amount": "1.54320986e+08",
+        "Currency": "Loyalty"
+      },
+      "IsDiscounted": true,
+      "Discounted": {
+        "Amount": "3124",
+        "Currency": "Loyalty"
+      },
+      "DiscountText": "special_price",
+      "MinPointsToSpent": "0",
+      "MaxPointsToSpent": null,
+      "Context": {
+        "CustomerGroup": "",
+        "ChannelCode": "",
+        "Locale": ""
+      }
+    },
+    "TeaserLoyaltyEarningInfo": {
+      "Type": "Loyalty",
+      "Default": {
+        "Amount": "25",
+        "Currency": "Loyalty"
+      }
+    }
+  }
+}

--- a/test/integrationtest/projecttest/tests/graphql/testdata/products/json_simple.json
+++ b/test/integrationtest/projecttest/tests/graphql/testdata/products/json_simple.json
@@ -536,7 +536,7 @@
       "Parent": null
     },
     {
-      "Code": "online_tabacco",
+      "Code": "online_tobacco",
       "Path": "Tobacco",
       "Name": "",
       "Parent": null
@@ -568,7 +568,7 @@
     "Liquors:online_liquors",
     "Liquors/Spirits:online_liqours_spirits",
     "Liquors/Wine \u0026 Champagne:online_liquors_wineChampagne",
-    "Tobacco:online_tabacco"
+    "Tobacco:online_tobacco"
   ],
   "StockLevel": "",
   "Keywords": [],


### PR DESCRIPTION
Currently, fake services are very static, in case you need something special, a custom attribute, variant options, etc. developers have to either create a pull request or implement own fake service in their projects. This feature allows developers to define/extend current fake products with their own versions of it.