### PR TITLE
Add Reason to qty adjustment result

### DIFF
--- a/cart/interfaces/templatefunctions/getItemAdjustment.go
+++ b/cart/interfaces/templatefunctions/getItemAdjustment.go
@@ -28,6 +28,7 @@ type (
 		DeliveryCode string
 		PrevQty      int
 		CurrQty      int
+		Reason       string
 	}
 )
 
@@ -47,6 +48,7 @@ func (gdm *GetQuantityAdjustmentDeletedItemsMessages) Func(ctx context.Context) 
 							DeliveryCode: a.DeliveryCode,
 							PrevQty:      a.NewQty - a.RestrictionResult.RemainingDifference,
 							CurrQty:      a.NewQty,
+							Reason:       a.RestrictionResult.RestrictorName,
 						})
 					}
 				}
@@ -71,6 +73,7 @@ func (gum *GetQuantityAdjustmentUpdatedItemsMessage) Func(ctx context.Context) i
 							DeliveryCode: a.DeliveryCode,
 							PrevQty:      a.NewQty - a.RestrictionResult.RemainingDifference,
 							CurrQty:      a.NewQty,
+							Reason:       a.RestrictionResult.RestrictorName,
 						}
 					}
 				}

--- a/cart/interfaces/templatefunctions/getItemAdjustment_test.go
+++ b/cart/interfaces/templatefunctions/getItemAdjustment_test.go
@@ -63,6 +63,7 @@ func TestGetQuantityAdjustmentDeletedItemsMessages_Func(t *testing.T) {
 							WasDeleted:   true,
 							RestrictionResult: &validation.RestrictionResult{
 								RemainingDifference: -2,
+								RestrictorName:      "restrictor",
 							},
 							NewQty: 0,
 						},
@@ -79,6 +80,7 @@ func TestGetQuantityAdjustmentDeletedItemsMessages_Func(t *testing.T) {
 					DeliveryCode: "deliveryCode",
 					PrevQty:      2,
 					CurrQty:      0,
+					Reason:       "restrictor",
 				},
 			},
 		},
@@ -96,6 +98,7 @@ func TestGetQuantityAdjustmentDeletedItemsMessages_Func(t *testing.T) {
 							WasDeleted:   false,
 							RestrictionResult: &validation.RestrictionResult{
 								RemainingDifference: -2,
+								RestrictorName:      "restrictor-A",
 							},
 							NewQty: 1,
 						},
@@ -107,6 +110,7 @@ func TestGetQuantityAdjustmentDeletedItemsMessages_Func(t *testing.T) {
 							WasDeleted:   true,
 							RestrictionResult: &validation.RestrictionResult{
 								RemainingDifference: -4,
+								RestrictorName:      "restrictor-B",
 							},
 							NewQty: 0,
 						},
@@ -123,6 +127,7 @@ func TestGetQuantityAdjustmentDeletedItemsMessages_Func(t *testing.T) {
 					DeliveryCode: "deliveryCode-B",
 					PrevQty:      4,
 					CurrQty:      0,
+					Reason:       "restrictor-B",
 				},
 			},
 		},
@@ -214,6 +219,7 @@ func TestGetQuantityAdjustmentUpdatedItemsMessage_Func(t *testing.T) {
 								IsRestricted:        true,
 								MaxAllowed:          1,
 								RemainingDifference: -2,
+								RestrictorName:      "restrictor",
 							},
 							NewQty: 1,
 						},
@@ -234,6 +240,7 @@ func TestGetQuantityAdjustmentUpdatedItemsMessage_Func(t *testing.T) {
 				DeliveryCode: "deliveryCode",
 				PrevQty:      3,
 				CurrQty:      1,
+				Reason:       "restrictor",
 			},
 		},
 	}


### PR DESCRIPTION
At the moment a frontend can not determine the reason why an item in the cart was deleted/had its quantity adjusted.