### PR TITLE
Rename GitHub Action workflow and update badges in readme

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Go
+name: Tests
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch

--- a/Readme.md
+++ b/Readme.md
@@ -2,6 +2,7 @@
 # Flamingo Commerce
 [![Go Report Card](https://goreportcard.com/badge/github.com/i-love-flamingo/flamingo-commerce)](https://goreportcard.com/report/github.com/i-love-flamingo/flamingo-commerce)
 [![Build Status](https://travis-ci.com/i-love-flamingo/flamingo-commerce.svg?branch=master)](https://travis-ci.com/i-love-flamingo/flamingo-commerce?branch=master)
+[![Tests](https://github.com/i-love-flamingo/flamingo-commerce/workflows/Tests/badge.svg?branch=master)](https://github.com/i-love-flamingo/flamingo-commerce/actions?query=branch%3Amaster+workflow%3ATests)
 [![Release](https://img.shields.io/github/release/i-love-flamingo/flamingo-commerce?style=flat-square)](https://github.com/i-love-flamingo/flamingo-commerce/releases)
 
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 
 # Flamingo Commerce
 [![Go Report Card](https://goreportcard.com/badge/github.com/i-love-flamingo/flamingo-commerce)](https://goreportcard.com/report/github.com/i-love-flamingo/flamingo-commerce)
-[![Build Status](https://travis-ci.org/i-love-flamingo/flamingo-commerce.svg?branch=master)](https://travis-ci.org/i-love-flamingo/flamingo-commerce?branch=master)
+[![Build Status](https://travis-ci.com/i-love-flamingo/flamingo-commerce.svg?branch=master)](https://travis-ci.com/i-love-flamingo/flamingo-commerce?branch=master)
 [![Release](https://img.shields.io/github/release/i-love-flamingo/flamingo-commerce?style=flat-square)](https://github.com/i-love-flamingo/flamingo-commerce/releases)
 
 


### PR DESCRIPTION
After switching from travis-ci.org to travis-ci.com we should use the proper URLs for badges.
Also, the newly added GitHub Actions come with badges