### PR TITLE
product: partially revert attribute Values() func to be non breaking

### DIFF
--- a/product/domain/productBasics.go
+++ b/product/domain/productBasics.go
@@ -268,8 +268,6 @@ func (at Attribute) Values() []string {
 		for _, entry := range list {
 			result = append(result, strings.Trim(fmt.Sprintf("%v", entry), " "))
 		}
-	} else {
-		result = append(result, at.Value())
 	}
 	return result
 }

--- a/product/domain/productBasics_test.go
+++ b/product/domain/productBasics_test.go
@@ -80,8 +80,7 @@ func TestAttributeValues(t *testing.T) {
 	a := Attribute{RawValue: "some string"}
 	result := a.Values()
 	assert.IsType(t, []string{}, result)
-	assert.Len(t, result, 1)
-	assert.Equal(t, "some string", result[0])
+	assert.Len(t, result, 0)
 
 	var rawValue []interface{}
 	for _, val := range []string{"some", "  string    "} {


### PR DESCRIPTION
Due to a previous PR(#236) a breaking change was introduced when handling the Values() func. This reverts the breaking part and keeps the trimming that was introduced on purpose.