### PR TITLE
sourcing: Add deliveryInfo to interface StockProvider GetStock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@
     * The product fake search service returns no products if it is queried with `no-results`
 * Expose `VariantVariationAttributesSorting` on `domain.ConfigurableProductWithActiveVariant`
 
+**sourcing**
+* **Breaking**
+  * Optional pointer `DeliveryInfo` added as parameter to `StockProvider.GetStock`
+
+
 ## v3.3.0
 **product**
 * Switch module config to CUE

--- a/sourcing/domain/service.go
+++ b/sourcing/domain/service.go
@@ -72,7 +72,7 @@ type (
 
 	// StockProvider interface for DefaultSourcingService
 	StockProvider interface {
-		GetStock(ctx context.Context, product domain.BasicProduct, source Source) (int, error)
+		GetStock(ctx context.Context, product domain.BasicProduct, source Source, deliveryInfo *cartDomain.DeliveryInfo) (int, error)
 	}
 )
 
@@ -121,7 +121,7 @@ func (d *DefaultSourcingService) GetAvailableSources(ctx context.Context, produc
 	var lastStockError error
 	availableSources := AvailableSources{}
 	for _, source := range sources {
-		qty, err := d.stockProvider.GetStock(ctx, product, source)
+		qty, err := d.stockProvider.GetStock(ctx, product, source, deliveryInfo)
 		if err != nil {
 			d.logger.Error(err)
 			lastStockError = err
@@ -249,7 +249,7 @@ func (d *DefaultSourcingService) allocateItem(ctx context.Context, productSource
 	for _, source := range sources {
 		// if we have no stock given for source and productid we fetch it initially
 		if _, exists := remainingSourcestock[productID][source]; !exists {
-			sourceStock, err := d.stockProvider.GetStock(ctx, decoratedItem.Product, source)
+			sourceStock, err := d.stockProvider.GetStock(ctx, decoratedItem.Product, source, &deliveryInfo)
 			if err != nil {
 				d.logger.Error(err)
 				continue

--- a/sourcing/domain/service_test.go
+++ b/sourcing/domain/service_test.go
@@ -41,11 +41,11 @@ func (a availableSourcesProviderMock) GetPossibleSources(_ context.Context, _ pr
 	return a.Sources, a.Error
 }
 
-func (s stockProviderMock) GetStock(_ context.Context, _ productDomain.BasicProduct, _ domain.Source) (int, error) {
+func (s stockProviderMock) GetStock(_ context.Context, _ productDomain.BasicProduct, _ domain.Source, _ *cart.DeliveryInfo) (int, error) {
 	return s.Qty, s.Error
 }
 
-func (s stockBySourceAndProductProviderMock) GetStock(_ context.Context, product productDomain.BasicProduct, source domain.Source) (int, error) {
+func (s stockBySourceAndProductProviderMock) GetStock(_ context.Context, product productDomain.BasicProduct, source domain.Source, _ *cart.DeliveryInfo) (int, error) {
 	return s.Qty[source.LocationCode][product.GetIdentifier()], s.Error
 }
 


### PR DESCRIPTION
Implementing StockProviders require the deliveryInfo for specific stock checks.