### PR TITLE
cart: Trying to fix race on in memory cart storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## v3.4.0 [upcoming]
 **cart**
 * Added desired time to DeliveryForm
+* InMemoryCartStorage: initialize lock and storage already in Inject() to avoid potential race conditions  
 * GraphQL
   * Updated schema and resolver regarding desired time
 

--- a/cart/application/cartService_test.go
+++ b/cart/application/cartService_test.go
@@ -735,6 +735,8 @@ func (m *MockGuestCartServiceWithModifyBehaviour) GetModifyBehaviour(context.Con
 	cob := &infrastructure.DefaultCartBehaviour{}
 
 	storage := &infrastructure.InMemoryCartStorage{}
+	storage.Inject()
+
 	cart := cartDomain.Cart{
 		ID: "mock_guest_cart",
 		Deliveries: []cartDomain.Delivery{

--- a/cart/infrastructure/defaultCartBehaviour_test.go
+++ b/cart/infrastructure/defaultCartBehaviour_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestInMemoryBehaviour_CleanCart(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		want       *domaincart.Cart
@@ -33,7 +34,7 @@ func TestInMemoryBehaviour_CleanCart(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cob := &DefaultCartBehaviour{}
 			cob.Inject(
-				&InMemoryCartStorage{},
+				newInMemoryStorage(),
 				nil,
 				flamingo.NullLogger{},
 				func() *domaincart.ItemBuilder {
@@ -81,7 +82,7 @@ func TestInMemoryBehaviour_CleanCart(t *testing.T) {
 }
 
 func TestInMemoryBehaviour_CleanDelivery(t *testing.T) {
-
+	t.Parallel()
 	type args struct {
 		cart         *domaincart.Cart
 		deliveryCode string
@@ -160,7 +161,7 @@ func TestInMemoryBehaviour_CleanDelivery(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cob := &DefaultCartBehaviour{}
 			cob.Inject(
-				&InMemoryCartStorage{},
+				newInMemoryStorage(),
 				nil,
 				flamingo.NullLogger{},
 				func() *domaincart.ItemBuilder {
@@ -196,6 +197,7 @@ func TestInMemoryBehaviour_CleanDelivery(t *testing.T) {
 }
 
 func TestInMemoryBehaviour_ApplyVoucher(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		cart        *domaincart.Cart
 		voucherCode string
@@ -235,7 +237,7 @@ func TestInMemoryBehaviour_ApplyVoucher(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cob := &DefaultCartBehaviour{}
 			cob.Inject(
-				&InMemoryCartStorage{},
+				newInMemoryStorage(),
 				nil,
 				flamingo.NullLogger{},
 				nil,
@@ -258,6 +260,7 @@ func TestInMemoryBehaviour_ApplyVoucher(t *testing.T) {
 }
 
 func TestInMemoryBehaviour_RemoveVoucher(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		ctx                context.Context
 		cart               *domaincart.Cart
@@ -323,7 +326,7 @@ func TestInMemoryBehaviour_RemoveVoucher(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cob := &DefaultCartBehaviour{}
 			cob.Inject(
-				&InMemoryCartStorage{},
+				newInMemoryStorage(),
 				nil,
 				flamingo.NullLogger{},
 				func() *domaincart.ItemBuilder {
@@ -354,6 +357,7 @@ func TestInMemoryBehaviour_RemoveVoucher(t *testing.T) {
 }
 
 func TestInMemoryBehaviour_ApplyGiftCard(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		cart         *domaincart.Cart
 		giftCardCode string
@@ -395,7 +399,7 @@ func TestInMemoryBehaviour_ApplyGiftCard(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cob := &DefaultCartBehaviour{}
 			cob.Inject(
-				&InMemoryCartStorage{},
+				newInMemoryStorage(),
 				nil,
 				flamingo.NullLogger{},
 				nil,
@@ -418,6 +422,7 @@ func TestInMemoryBehaviour_ApplyGiftCard(t *testing.T) {
 }
 
 func TestInMemoryBehaviour_RemoveGiftCard(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		cart         *domaincart.Cart
 		giftCardCode string
@@ -463,7 +468,7 @@ func TestInMemoryBehaviour_RemoveGiftCard(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cob := &DefaultCartBehaviour{}
 			cob.Inject(
-				&InMemoryCartStorage{},
+				newInMemoryStorage(),
 				nil,
 				flamingo.NullLogger{},
 				nil,
@@ -486,10 +491,11 @@ func TestInMemoryBehaviour_RemoveGiftCard(t *testing.T) {
 }
 
 func TestInMemoryBehaviour_Complete(t *testing.T) {
+	t.Parallel()
 	t.Run("happy path", func(t *testing.T) {
 		cob := &DefaultCartBehaviour{}
 		cob.Inject(
-			&InMemoryCartStorage{},
+			newInMemoryStorage(),
 			nil,
 			flamingo.NullLogger{},
 			nil,
@@ -512,10 +518,11 @@ func TestInMemoryBehaviour_Complete(t *testing.T) {
 }
 
 func TestInMemoryBehaviour_Restore(t *testing.T) {
+	t.Parallel()
 	t.Run("happy path", func(t *testing.T) {
 		cob := &DefaultCartBehaviour{}
 		cob.Inject(
-			&InMemoryCartStorage{},
+			newInMemoryStorage(),
 			nil,
 			flamingo.NullLogger{},
 			nil,
@@ -533,4 +540,11 @@ func TestInMemoryBehaviour_Restore(t *testing.T) {
 		_, err = cob.GetCart(context.Background(), got.ID)
 		assert.Nil(t, err)
 	})
+}
+
+func newInMemoryStorage() *InMemoryCartStorage {
+	result := &InMemoryCartStorage{}
+	result.Inject()
+
+	return result
 }

--- a/cart/infrastructure/inMemoryStorage.go
+++ b/cart/infrastructure/inMemoryStorage.go
@@ -18,18 +18,20 @@ type (
 
 var _ CartStorage = &InMemoryCartStorage{}
 
-func (s *InMemoryCartStorage) init() {
-	if s.guestCarts == nil {
-		s.guestCarts = make(map[string]*domaincart.Cart)
-		s.locker = &sync.Mutex{}
-	}
+// Inject dependencies and prepare storage
+// Important: InMemoryStorage MUST be bound AsEagerSingleton, Inject MUST be called in tests to behave as expected
+func (s *InMemoryCartStorage) Inject() *InMemoryCartStorage {
+	s.locker = &sync.Mutex{}
+	s.guestCarts = make(map[string]*domaincart.Cart)
+
+	return s
 }
 
 // HasCart checks if the cart storage has a cart with a given id
 func (s *InMemoryCartStorage) HasCart(_ context.Context, id string) bool {
-	s.init()
 	s.locker.Lock()
 	defer s.locker.Unlock()
+
 	if _, ok := s.guestCarts[id]; ok {
 		return true
 	}
@@ -38,9 +40,9 @@ func (s *InMemoryCartStorage) HasCart(_ context.Context, id string) bool {
 
 // GetCart returns a cart with the given id from the cart storage
 func (s *InMemoryCartStorage) GetCart(_ context.Context, id string) (*domaincart.Cart, error) {
-	s.init()
 	s.locker.Lock()
 	defer s.locker.Unlock()
+
 	if cart, ok := s.guestCarts[id]; ok {
 		return cart, nil
 	}
@@ -49,18 +51,18 @@ func (s *InMemoryCartStorage) GetCart(_ context.Context, id string) (*domaincart
 
 // StoreCart stores a cart in the storage
 func (s *InMemoryCartStorage) StoreCart(_ context.Context, cart *domaincart.Cart) error {
-	s.init()
 	s.locker.Lock()
 	defer s.locker.Unlock()
+
 	s.guestCarts[cart.ID] = cart
 	return nil
 }
 
 // RemoveCart from storage
 func (s *InMemoryCartStorage) RemoveCart(_ context.Context, cart *domaincart.Cart) error {
-	s.init()
 	s.locker.Lock()
 	defer s.locker.Unlock()
+
 	delete(s.guestCarts, cart.ID)
 	return nil
 }


### PR DESCRIPTION
The init func of InMemoryCartStorage is intended to init the storage if required as well as the sync.Locker to prevent concurrent operations on the storage. 

This handling does not solve the concurrent calls, as "it is already too late", a locking must be done before the first access to the storage map is done. 

The refactored implementation uses Inject to ensure that storage and Locker have been initialized to correctly lock on each receiver. 
