### PR TITLE
product: Override existing bindings for fake services

### DIFF
--- a/product/module.go
+++ b/product/module.go
@@ -48,8 +48,8 @@ func (m *Module) Configure(injector *dingo.Injector) {
 
 	injector.BindMulti(new(graphql.Service)).To(new(productgraphql.Service))
 	if m.fakeService {
-		injector.Bind((*domain.ProductService)(nil)).To(fake.ProductService{}).In(dingo.ChildSingleton)
-		injector.Bind((*domain.SearchService)(nil)).To(fake.SearchService{}).In(dingo.ChildSingleton)
+		injector.Override((*domain.ProductService)(nil), "").To(fake.ProductService{}).In(dingo.ChildSingleton)
+		injector.Override((*domain.SearchService)(nil), "").To(fake.SearchService{}).In(dingo.ChildSingleton)
 	}
 
 }


### PR DESCRIPTION
Use override binding when fake services are active to enforce those.