### PR TITLE
cart: Reverse the order of split items discount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 * API
   * **Breaking**: Update `DELETE /api/v1/cart` to actually clean the whole cart not only removing the cart items (introduces new route for the previous behaviour, see below)
   * Add new endpoint `DELETE /api/v1/cart/deliveries/items` to be able to remove all cart items from all deliveries but keeping delivery info and other cart data untouched
-* Add new method `SumShippingGrossWithDiscounts` to the cart domain which returns gross shipping costs for the cart
+* Add new method `SumShippingGrossWithDiscounts` to the cart domain which returns gross shipping costs for the cart 
+* When using the `ItemSplitter` to split items in items with single qty (`SplitInSingleQtyItems`) the split discounts are reversed to make splitting the row total stable.
 * `CartService`
   * Add `UpdateAdditionalData` to be able to set additional data to cart
   * Add `UpdateDeliveryAdditionalData` to be able to set additional data to the delivery info

--- a/cart/domain/cart/delivery_test.go
+++ b/cart/domain/cart/delivery_test.go
@@ -14,9 +14,9 @@ func TestDeliveryInfo_TotalCalculations(t *testing.T) {
 	df := DeliveryBuilder{}
 	df.SetDeliveryCode("test")
 
-	//Add item with 4,1 $ - 10 Qty and Tax of 7
+	// Add item with 4,1 $ - 10 Qty and Tax of 7
 	itemf := ItemBuilder{}
-	//Set net price 410
+	// Set net price 410
 	itemf.SetSinglePriceNet(
 		priceDomain.NewFromInt(410, 100, "$"),
 	).SetQty(10).AddTaxInfo(
@@ -34,8 +34,8 @@ func TestDeliveryInfo_TotalCalculations(t *testing.T) {
 	assert.Equal(t, priceDomain.NewFromInt(4387, 100, "$"), item.RowPriceGross, "item1 gross price wrong")
 	df.AddItem(*item)
 
-	//Add item with 10 $ - 5 Qty / Discount of 25 (505) and Tax of 7
-	//Set net price 410
+	// Add item with 10 $ - 5 Qty / Discount of 25 (505) and Tax of 7
+	// Set net price 410
 	itemf.SetSinglePriceNet(
 		priceDomain.NewFromInt(1000, 100, "$"),
 	).SetQty(5).AddTaxInfo(
@@ -53,42 +53,47 @@ func TestDeliveryInfo_TotalCalculations(t *testing.T) {
 	if item2 == nil {
 		t.Fatal("item2 is nil but no error?")
 	}
-	//item2 gros should be tax = (5 * 10) - discount (25) * 0.07 = 1,75
-	assert.Equal(t, priceDomain.NewFromInt(5175, 100, "$"), item2.RowPriceGross, "item2 gross price wrong")
+	// item2 gros should be tax = (5 * 10) - discount (25) * 0.07 = 1,75
+	assert.Equal(
+		t,
+		priceDomain.NewFromInt(5175, 100, "$").FloatAmount(),
+		item2.RowPriceGross.FloatAmount(),
+		"item2 gross price wrong",
+	)
 	df.AddItem(*item2)
 
-	//Check totals
+	// Check totals
 	d, err := df.Build()
 	assert.NoError(t, err)
 
-	//SubTotalGross - need to be 5175 + 4387
+	// SubTotalGross - need to be 5175 + 4387
 	assertPricesWithLikelyEqual(t, priceDomain.NewFromInt(9562, 100, "$"), d.SubTotalGross(), "SubTotalGross result should match 95,62")
 
-	//assert.Equal(t, priceDomain.NewFromInt(9562, 100, "$"), d.SubTotalGross(), fmt.Sprintf("SubTotalGross result should match 95,62 but is %f", d.SubTotalGross().FloatAmount()))
+	// assert.Equal(t, priceDomain.NewFromInt(9562, 100, "$"), d.SubTotalGross(), fmt.Sprintf("SubTotalGross result should match 95,62 but is %f", d.SubTotalGross().FloatAmount()))
 
-	//SubTotalGross - need to be 4100 + 5000
+	// SubTotalGross - need to be 4100 + 5000
 	assert.True(t, priceDomain.NewFromInt(9100, 100, "$").Equal(d.SubTotalNet()), "SubTotalNet wrong")
 
-	//SumTotalTaxAmount is the difference
+	// SumTotalTaxAmount is the difference
 	assert.True(t, priceDomain.NewFromInt(462, 100, "$").Equal(d.SumTotalTaxAmount()), fmt.Sprintf("result wrong %f", d.SumTotalTaxAmount().FloatAmount()))
 
-	//SumTotalDiscountAmount
+	// SumTotalDiscountAmount
 	assert.True(t, priceDomain.NewFromInt(-2500, 100, "$").Equal(d.SumTotalDiscountAmount()), "SumTotalDiscountAmount")
 
-	//SubTotalNetWithDiscounts
+	// SubTotalNetWithDiscounts
 	assert.True(t, priceDomain.NewFromInt(9100-2500, 100, "$").Equal(d.SubTotalNetWithDiscounts()), fmt.Sprintf("SubTotalNetWithDiscounts result wrong %f", d.SubTotalNetWithDiscounts().FloatAmount()))
 
-	//SubTotalGrossWithDiscounts
+	// SubTotalGrossWithDiscounts
 	assertPricesWithLikelyEqual(t, priceDomain.NewFromInt(9562-2500, 100, "$"), d.SubTotalGrossWithDiscounts(), "SubTotalGrossWithDiscount")
 
-	//Taxes check
+	// Taxes check
 	taxes := d.SumRowTaxes()
 	assert.Equal(t, 1, len(taxes), "expected one merged tax")
 	assertPricesWithLikelyEqual(t, priceDomain.NewFromInt(462, 100, "$"), taxes.TotalAmount(), "taxes check wrong")
 
 }
 
-//assertPricesWithLikelyEqual - helper
+// assertPricesWithLikelyEqual - helper
 func assertPricesWithLikelyEqual(t *testing.T, p1 priceDomain.Price, p2 priceDomain.Price, msg string) {
 	t.Helper()
 	assert.True(t, p1.LikelyEqual(p2), fmt.Sprintf("%v (%f != %f)", msg, p1.FloatAmount(), p2.FloatAmount()))


### PR DESCRIPTION
The split adds the moving cents to the first ones, resulting in
having the smallest prices at the end but since discounts are
negative, we need to reverse it to ensure that a split of the row
totals has the rounding cents at the same positions