### PR TITLE
price: Convert all prices to payable when marshalling to JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@
 * Add mockery mocks for both `Customer` / `CustomerIdentityService` for easier testing
 * Add `State` field to customer address to be closer to cart address type, expose via GraphQL
 
+**price**
+* When marshalling `domain.Price` to JSON the amount is rounded.
 
 ## v3.4.0
 **cart**

--- a/cart/domain/cart/paymentselection_test.go
+++ b/cart/domain/cart/paymentselection_test.go
@@ -54,7 +54,7 @@ func TestPaymentSplit_MarshalJSON(t *testing.T) {
 	tests := []struct {
 		name    string
 		split   cart.PaymentSplit
-		want    []byte
+		want    string
 		wantErr bool
 	}{
 		{
@@ -77,7 +77,7 @@ func TestPaymentSplit_MarshalJSON(t *testing.T) {
 				result[secondQualifier] = charge
 				return result
 			}(),
-			want:    []byte("{\"m1-t1-\":{\"Price\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Value\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Type\":\"t1\",\"Reference\":\"\"},\"m2-t1-r2\":{\"Price\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Value\":{\"Amount\":\"0\",\"Currency\":\"\"},\"Type\":\"t1\",\"Reference\":\"\"}}"),
+			want:    `{"m1-t1-":{"Price":{"Amount":"0.00","Currency":""},"Value":{"Amount":"0.00","Currency":""},"Type":"t1","Reference":""},"m2-t1-r2":{"Price":{"Amount":"0.00","Currency":""},"Value":{"Amount":"0.00","Currency":""},"Type":"t1","Reference":""}}`,
 			wantErr: false,
 		},
 		{
@@ -99,7 +99,7 @@ func TestPaymentSplit_MarshalJSON(t *testing.T) {
 				result[secondQualifier] = charge
 				return result
 			}(),
-			want:    nil,
+			want:    "",
 			wantErr: true,
 		},
 	}
@@ -110,9 +110,7 @@ func TestPaymentSplit_MarshalJSON(t *testing.T) {
 				t.Errorf("PaymentSplit.MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("PaymentSplit.MarshalJSON() = %v, want %v", string(got), string(tt.want))
-			}
+			assert.Equal(t, tt.want, string(got))
 		})
 	}
 }

--- a/price/domain/price.go
+++ b/price/domain/price.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"math"
 	"math/big"
+	"strconv"
 	"strings"
 )
 
@@ -459,23 +460,29 @@ func SumAll(prices ...Price) (Price, error) {
 	return result, nil
 }
 
-// MarshalJSON - implements interface required by json marshal
+// MarshalJSON implements interface required by json marshal
 func (p Price) MarshalJSON() (data []byte, err error) {
-	pn := priceEncodeAble{
-		Amount:   p.amount,
+	type priceJSON struct {
+		Amount   string
+		Currency string
+	}
+
+	pn := priceJSON{
+		Amount:   strconv.FormatFloat(p.GetPayable().FloatAmount(), 'f', 2, 64),
 		Currency: p.currency,
 	}
+
 	r, e := json.Marshal(&pn)
 	return r, e
 }
 
-// MarshalBinary - implements interface required by gob
+// MarshalBinary implements interface required by gob
 func (p Price) MarshalBinary() (data []byte, err error) {
 	return json.Marshal(p)
 }
 
-// UnmarshalBinary - implements interface required by gob.
-// UnmarshalBinary - modifies the receiver so it must take a pointer receiver!
+// UnmarshalBinary implements interface required by gob.
+// Modifies the receiver so it must take a pointer receiver!
 func (p *Price) UnmarshalBinary(data []byte) error {
 	var pe priceEncodeAble
 	err := json.Unmarshal(data, &pe)


### PR DESCRIPTION
Currently, all our web APIs expose the prices not rounded, this leads to rounding implementations in the consumer. To avoid this we round all prices by default when requested as JSON.