### PR TITLE
checkout: reserve a new order id if early place order has payment issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 **checkout**
 * Introducing Flamingo events on final states of the place order process
 * Introduce a max ttl for the checkout state machine to avoid polluting the redis with stale checkout processes, defaults to 2h
+* Checkout controller: force new order id reservation if an early place happened and there was a payment issue
 * API
   * In case of an invalid cart during place order process we now expose the cart validation result, affected endpoints:
     ```

--- a/checkout/interfaces/controller/checkoutcontroller.go
+++ b/checkout/interfaces/controller/checkoutcontroller.go
@@ -610,6 +610,8 @@ func (cc *CheckoutController) PaymentAction(ctx context.Context, r *web.Request)
 
 			decoratedCart = cc.decoratedCartFactory.Create(ctx, *restoredCart)
 			cc.orderService.ClearLastPlacedOrder(ctx)
+
+			_, _ = cc.applicationCartService.ForceReserveOrderIDAndSave(ctx, r.Session())
 		}
 
 		return cc.redirectToCheckoutFormWithErrors(ctx, r, err)
@@ -663,6 +665,7 @@ func (cc *CheckoutController) PaymentAction(ctx context.Context, r *web.Request)
 			}
 
 			cc.orderService.ClearLastPlacedOrder(ctx)
+			_, _ = cc.applicationCartService.ForceReserveOrderIDAndSave(ctx, r.Session())
 		}
 
 		// mark payment selection as new payment to allow the user to retry
@@ -700,6 +703,7 @@ func (cc *CheckoutController) PaymentAction(ctx context.Context, r *web.Request)
 			}
 
 			cc.orderService.ClearLastPlacedOrder(ctx)
+			_, _ = cc.applicationCartService.ForceReserveOrderIDAndSave(ctx, r.Session())
 		}
 
 		// mark payment selection as new payment to allow the user to retry


### PR DESCRIPTION
If the payment provider enforces an early place order and the payment is then aborted we never renew the order id.