### PR TITLE
price: format price using configured precision

### DIFF
--- a/price/application/service.go
+++ b/price/application/service.go
@@ -44,6 +44,10 @@ func (s *Service) FormatPrice(price domain.Price) string {
 		Symbol:    currency,
 		Precision: 2,
 	}
+	precision, ok := configForCurrency["precision"].(float64)
+	if ok {
+		ac.Precision = int(precision)
+	}
 	decimal, ok := configForCurrency["decimal"].(string)
 	if ok {
 		ac.Decimal = decimal

--- a/price/application/service_test.go
+++ b/price/application/service_test.go
@@ -36,7 +36,16 @@ func TestService_FormatPrice(t *testing.T) {
 			Config config.Map `inject:"config:locale.accounting"`
 		}{
 			Config: config.Map{
+				"JPY": config.Map{
+					"precision":  0.0,
+					"decimal":    "",
+					"thousand":   ",",
+					"formatLong": "%s %s",
+					"formatZero": "%s%v",
+					"format":     "%s%v",
+				},
 				"default": config.Map{
+					"precision":  2.0,
 					"decimal":    ".",
 					"thousand":   ",",
 					"formatLong": "%s %s",
@@ -50,4 +59,8 @@ func TestService_FormatPrice(t *testing.T) {
 	price := priceDomain.NewFromFloat(-161.92, "USD")
 	formatted := service.FormatPrice(price)
 	assert.Equal(t, "-USD161.92", formatted)
+
+	price = priceDomain.NewFromFloat(-161.92, "JPY")
+	formatted = service.FormatPrice(price)
+	assert.Equal(t, "-JPY162", formatted)
 }


### PR DESCRIPTION
The underlying library used for formatting prices already supports different precisions for different currencies.
Default will still be precision 2, but can now be overwritten.