### PR TITLE
feat(checkout/placeorder): Make canceling orders in rollback configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 
 **checkout**
 * Add possibility to have additional data in `PaymentFlowActionTriggerClientSDK`
+* Breaking: Disable auto canceling of orders during place order rollback, to restore old behaviour set `commerce.checkout.placeorder.states.placeorder.cancelOrdersDuringRollback: true`
 
 **product**
 * Introduce `Labels()` function on `Attribute` to handle translations for attributes with multiple values, will fallback to `Values()` function if not translated.

--- a/checkout/domain/placeorder/states/place_order.go
+++ b/checkout/domain/placeorder/states/place_order.go
@@ -18,10 +18,11 @@ import (
 type (
 	// PlaceOrder state
 	PlaceOrder struct {
-		orderService         *application.OrderService
-		cartService          *cartApplication.CartService
-		cartDecoratorFactory *decorator.DecoratedCartFactory
-		paymentService       *paymentApplication.PaymentService
+		orderService               *application.OrderService
+		cartService                *cartApplication.CartService
+		cartDecoratorFactory       *decorator.DecoratedCartFactory
+		paymentService             *paymentApplication.PaymentService
+		cancelOrdersDuringRollback bool
 	}
 
 	// PlaceOrderRollbackData needed for rollbacks
@@ -42,11 +43,18 @@ func (po *PlaceOrder) Inject(
 	cartService *cartApplication.CartService,
 	cartDecoratorFactory *decorator.DecoratedCartFactory,
 	paymentService *paymentApplication.PaymentService,
+	cfg *struct {
+		cancelOrdersDuringRollback bool `inject:"config:commerce.checkout.placeorder.states.placeorder.cancelOrdersDuringRollback"`
+	},
 ) *PlaceOrder {
 	po.orderService = orderService
 	po.cartService = cartService
 	po.cartDecoratorFactory = cartDecoratorFactory
 	po.paymentService = paymentService
+
+	if cfg != nil {
+		po.cancelOrdersDuringRollback = cfg.cancelOrdersDuringRollback
+	}
 
 	return po
 }
@@ -106,6 +114,10 @@ func (po PlaceOrder) Rollback(ctx context.Context, data process.RollbackData) er
 	rollbackData, ok := data.(PlaceOrderRollbackData)
 	if !ok {
 		return fmt.Errorf("rollback data not of expected type 'PlaceOrderRollbackData', but %T", rollbackData)
+	}
+
+	if !po.cancelOrdersDuringRollback {
+		return nil
 	}
 
 	err := po.orderService.CancelOrderWithoutRestore(ctx, web.SessionFromContext(ctx), &rollbackData.OrderInfos)

--- a/checkout/module.go
+++ b/checkout/module.go
@@ -106,6 +106,7 @@ func (m *Module) Configure(injector *dingo.Injector) {
 
 // CueConfig definition
 func (m *Module) CueConfig() string {
+	// language=cue
 	return `
 commerce: checkout: {
 	Redis :: {
@@ -136,6 +137,11 @@ commerce: checkout: {
 			type: *"memory" | "redis"
 			if type == "redis" {
 				redis: Redis
+			}
+		}
+		states: {
+			placeorder: {
+				cancelOrdersDuringRollback: bool | *false		
 			}
 		}
 	}


### PR DESCRIPTION
In case of an error, for example, during the payment process, it is often not desirable to cancel the order but to leave it in the state with open payment. Otherwise, it could appear that the user has deliberately canceled the order. 

This MR changes the default behavior and makes it optionally possible to cancel the order by configuration.