### PR TITLE
fix(cart): only apply guest cart payment selection after coupons/discounts and if customer cart is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
         | SumGrandTotalWithGiftCards()      | GrandTotalWithGiftCards         |
         | -                                 | GrandTotalNetWithGiftCards      |
 * Dispatch a `PreCartMergeEvent` before and a `PostCartMergeEvent` after merging a guest and customer cart when logging in
+* Update payment selection on cart merge with the guest carts' payment selection after applying coupons and giftcards and only if customer cart has no items
 * Add possibility to have additional data in `AddToCartNotAllowed` error
 
 **checkout**

--- a/cart/application/eventHandling.go
+++ b/cart/application/eventHandling.go
@@ -126,12 +126,6 @@ func (e *EventReceiver) Notify(ctx context.Context, event flamingo.Event) {
 					e.logger.WithContext(ctx).Error("WebLoginEvent - customerCart UpdatePurchaser error", err)
 				}
 			}
-			if customerCart.PaymentSelection == nil && guestCart.PaymentSelection != nil {
-				err := e.cartService.UpdatePaymentSelection(ctx, session, guestCart.PaymentSelection)
-				if err != nil {
-					e.logger.WithContext(ctx).Error("WebLoginEvent - customerCart UpdatePaymentSelection error", err)
-				}
-			}
 			if guestCart.HasAppliedCouponCode() {
 				for _, code := range guestCart.AppliedCouponCodes {
 					customerCart, err = e.cartService.ApplyVoucher(ctx, session, code.Code)
@@ -146,6 +140,12 @@ func (e *EventReceiver) Notify(ctx context.Context, event flamingo.Event) {
 					if err != nil {
 						e.logger.WithContext(ctx).Error("WebLoginEvent - customerCart ApplyGiftCard has error", code.Code, err)
 					}
+				}
+			}
+			if customerCart.PaymentSelection == nil && guestCart.PaymentSelection != nil && customerCart.ItemCount() == 0 {
+				err := e.cartService.UpdatePaymentSelection(ctx, session, guestCart.PaymentSelection)
+				if err != nil {
+					e.logger.WithContext(ctx).Error("WebLoginEvent - customerCart UpdatePaymentSelection error", err)
 				}
 			}
 


### PR DESCRIPTION
If the customer cart already has some items attempting to apply the guest carts payment selection will most likely log an error since the merged carts GrandTotal will not match the payment selection total.
Similarly, coupons and giftcards may affect the GrandTotal and should be applied before updating the payment selection.