### PR TITLE
feat(cart): add support for AdditionalData on CartItem level for the defaultCartBehaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@
 * GraphQL:
   * Aggregate many input values to `Commerce_Cart_AddToCart` mutation in `Commerce_Cart_AddToCartInput`
   * Add support for bundle and configurable products in `Commerce_Cart_AddToCart` mutation
-
+* Added support for AdditionalData on CartItem Level for the defaultCartBehaviour.
 
 **checkout**
 * Add possibility to have additional data in `PaymentFlowActionTriggerClientSDK`

--- a/cart/infrastructure/defaultCartBehaviour.go
+++ b/cart/infrastructure/defaultCartBehaviour.go
@@ -237,6 +237,9 @@ func (cob *DefaultCartBehaviour) updateItem(ctx context.Context, cart *domaincar
 					itemDelivery.Cartitems[k].RowTaxes[0].Amount = taxAmount
 				}
 
+				if itemUpdateCommand.AdditionalData != nil {
+					itemDelivery.Cartitems[k].AdditionalData = itemUpdateCommand.AdditionalData
+				}
 			}
 
 			if itemUpdateCommand.SourceID != nil {


### PR DESCRIPTION
Currently `updateItem` on the `defaultCartBehavior` (Memory Cart) is lacking support for setting the AdditionalData. This PR is adding AdditionalData from the Update command to the item.