### PR TITLE
Add to cart of bundle products fails for missing of none required bundle choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v3.8.1 [upcoming]
 
 **product**
-* Add to cart of bundle products now only fails for missing required bundle choices. As prior passing all choices with qty of zero has been required. Now optional choices with qty of zero can be omitted.
+* Add to cart of bundle products now only fails for missing required bundle choices. As prior passing all choices with qty of zero hav been required. Now optional choices with qty of zero can be omitted.
 
 ## v3.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v3.8.1 [upcoming]
 
+**product**
+* Add to cart of bundle products now only fails for missing required bundle choices. As prior passing all choices with qty of zero has been required. Now optional choices with qty of zero can be omitted.
+
 ## v3.8.0
 
 **sourcing**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v3.8.1 [upcoming]
 
 **product**
-* Add to cart of bundle products now only fails for missing required bundle choices. As prior passing all choices with qty of zero hav been required. Now optional choices with qty of zero can be omitted.
+* Add to cart of bundle products now only fails for missing required bundle choices. As prior passing all choices with qty of zero have been required. Now optional choices with qty of zero can be omitted.
 
 ## v3.8.0
 

--- a/product/domain/productTypeBundle.go
+++ b/product/domain/productTypeBundle.go
@@ -128,7 +128,7 @@ func (b BundleProduct) GetBundleProductWithActiveChoices(bundleConfiguration Bun
 			bundleProductWithActiveChoices.ActiveChoices[Identifier(choice.Identifier)] = activeChoice
 		}
 
-		if _, ok := bundleProductWithActiveChoices.ActiveChoices[Identifier(choice.Identifier)]; !ok {
+		if _, ok := bundleProductWithActiveChoices.ActiveChoices[Identifier(choice.Identifier)]; !ok && choice.Required {
 			return BundleProductWithActiveChoices{}, ErrMarketplaceCodeDoNotExists
 		}
 	}

--- a/product/domain/productTypeBundle_test.go
+++ b/product/domain/productTypeBundle_test.go
@@ -108,6 +108,39 @@ func TestGetBundleProductWithActiveChoices(t *testing.T) {
 		assert.Equal(t, domain.ErrRequiredChoicesAreNotSelected, err)
 	})
 
+	t.Run("returns no error for missing none required bundle configuration choices", func(t *testing.T) {
+		b := domain.BundleProduct{
+			Choices: []domain.Choice{
+				{
+					Identifier: "A",
+					Options: []domain.Option{{
+						Product: domain.SimpleProduct{BasicProductData: domain.BasicProductData{MarketPlaceCode: "A"}},
+						MinQty:  1,
+						MaxQty:  2,
+					}},
+					Required: true,
+				},
+				{
+					Identifier: "B",
+					Options: []domain.Option{{
+						Product: domain.SimpleProduct{BasicProductData: domain.BasicProductData{MarketPlaceCode: "B"}},
+						MinQty:  0,
+						MaxQty:  1,
+					}},
+					Required: false,
+				},
+			},
+		}
+
+		bc := domain.BundleConfiguration{
+			"A": {MarketplaceCode: "A", Qty: 2, VariantMarketplaceCode: ""},
+		}
+
+		_, err := b.GetBundleProductWithActiveChoices(bc)
+
+		assert.NoError(t, err)
+	})
+
 	t.Run("error when variant not found", func(t *testing.T) {
 		bundleProduct := domain.BundleProduct{
 			Choices: []domain.Choice{


### PR DESCRIPTION
As prior passing all choices with qty of zero have been required. Now optional choices with qty of zero can be omitted.