### PR TITLE
Allow updating of bundle configuration of cart items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Add to cart of bundle products now only fails for missing required bundle choices. As prior passing all choices with qty of zero have been required. Now optional choices with qty of zero can be omitted.
 
 **cart**
-* Allow updating of bundle configuration of cart items
+* Allow updating of the bundle configuration of a cart item
 
 ## v3.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 **product**
 * Add to cart of bundle products now only fails for missing required bundle choices. As prior passing all choices with qty of zero have been required. Now optional choices with qty of zero can be omitted.
 
+**cart**
+* Allow updating of bundle configuration of cart items
+
 ## v3.8.0
 
 **sourcing**

--- a/cart/domain/cart/cartServicePorts.go
+++ b/cart/domain/cart/cartServicePorts.go
@@ -107,6 +107,8 @@ type (
 		AdditionalData map[string]string
 		// Mandatory field: ItemID is only for identifying the item.
 		ItemID string
+		// BundleConfiguration which needs to be updated
+		BundleConfiguration productDomain.BundleConfiguration
 	}
 
 	// DeliveryInfoUpdateCommand defines the update item command

--- a/cart/infrastructure/defaultCartBehaviour.go
+++ b/cart/infrastructure/defaultCartBehaviour.go
@@ -271,11 +271,6 @@ func (cob *DefaultCartBehaviour) updateItem(ctx context.Context, cart *domaincar
 		if itemUpdateCommand.BundleConfiguration != nil {
 			itemDelivery.Cartitems[index].BundleConfig = itemUpdateCommand.BundleConfiguration
 		}
-
-		// remove bundle configuration if not provided
-		if itemDelivery.Cartitems[index].BundleConfig != nil && itemUpdateCommand.BundleConfiguration == nil {
-			itemDelivery.Cartitems[index].BundleConfig = nil
-		}
 	}
 
 	// update the delivery with the new info

--- a/cart/infrastructure/defaultCartBehaviour.go
+++ b/cart/infrastructure/defaultCartBehaviour.go
@@ -266,6 +266,16 @@ func (cob *DefaultCartBehaviour) updateItem(ctx context.Context, cart *domaincar
 
 			itemDelivery.Cartitems[index].RowTaxes[0].Amount = taxAmount
 		}
+
+		// update bundle configuration if provided
+		if itemUpdateCommand.BundleConfiguration != nil {
+			itemDelivery.Cartitems[index].BundleConfig = itemUpdateCommand.BundleConfiguration
+		}
+
+		// remove bundle configuration if not provided
+		if itemDelivery.Cartitems[index].BundleConfig != nil && itemUpdateCommand.BundleConfiguration == nil {
+			itemDelivery.Cartitems[index].BundleConfig = nil
+		}
 	}
 
 	// update the delivery with the new info
@@ -397,7 +407,7 @@ func (cob *DefaultCartBehaviour) buildItemForCart(ctx context.Context, addReques
 	return cob.createCartItemFromProduct(addRequest.Qty, addRequest.MarketplaceCode, addRequest.VariantMarketplaceCode, addRequest.AdditionalData, addRequest.BundleConfiguration, product)
 }
 func (cob *DefaultCartBehaviour) createCartItemFromProduct(qty int, marketplaceCode string, variantMarketPlaceCode string,
-	additonalData map[string]string, bundleConfig domain.BundleConfiguration, product domain.BasicProduct) (*domaincart.Item, error) {
+	additionalData map[string]string, bundleConfig domain.BundleConfiguration, product domain.BasicProduct) (*domaincart.Item, error) {
 	item := &domaincart.Item{
 		ID:                     strconv.Itoa(rand.Int()),
 		ExternalReference:      strconv.Itoa(rand.Int()),
@@ -405,7 +415,7 @@ func (cob *DefaultCartBehaviour) createCartItemFromProduct(qty int, marketplaceC
 		VariantMarketPlaceCode: variantMarketPlaceCode,
 		ProductName:            product.BaseData().Title,
 		Qty:                    qty,
-		AdditionalData:         additonalData,
+		AdditionalData:         additionalData,
 	}
 
 	currency := product.SaleableData().ActivePrice.GetFinalPrice().Currency()

--- a/cart/infrastructure/defaultCartBehaviour_test.go
+++ b/cart/infrastructure/defaultCartBehaviour_test.go
@@ -819,7 +819,7 @@ func TestDefaultCartBehaviour_UpdateItems(t *testing.T) {
 		assert.Empty(t, got.Deliveries[0].Cartitems[0].BundleConfig["identifier2"])
 	})
 
-	t.Run("item with bundle configuration is removed if not provided", func(t *testing.T) {
+	t.Run("bundle configuration is removed from item if not provided", func(t *testing.T) {
 		t.Parallel()
 
 		cob := &DefaultCartBehaviour{}

--- a/cart/infrastructure/defaultCartBehaviour_test.go
+++ b/cart/infrastructure/defaultCartBehaviour_test.go
@@ -818,62 +818,6 @@ func TestDefaultCartBehaviour_UpdateItems(t *testing.T) {
 		assert.Equal(t, "simple_option1", got.Deliveries[0].Cartitems[0].BundleConfig["identifier1"].MarketplaceCode)
 		assert.Empty(t, got.Deliveries[0].Cartitems[0].BundleConfig["identifier2"])
 	})
-
-	t.Run("bundle configuration is removed from item if not provided", func(t *testing.T) {
-		t.Parallel()
-
-		cob := &DefaultCartBehaviour{}
-		cob.Inject(
-			newInMemoryStorage(),
-			&fake.ProductService{},
-			flamingo.NullLogger{},
-			nil,
-			nil,
-			nil,
-		)
-
-		cart, err := cob.StoreNewCart(context.Background(), &domaincart.Cart{
-			ID: "1234",
-			Deliveries: []domaincart.Delivery{
-				{
-					DeliveryInfo: domaincart.DeliveryInfo{
-						Code: "delivery",
-					},
-					Cartitems: []domaincart.Item{
-						{
-							ID:              "abc",
-							MarketplaceCode: "fake_bundle",
-							Qty:             1,
-							BundleConfig: map[domain.Identifier]domain.ChoiceConfiguration{
-								"identifier1": {
-									MarketplaceCode: "simple_option1",
-									Qty:             1,
-								},
-								"identifier2": {
-									MarketplaceCode:        "configurable_option1",
-									VariantMarketplaceCode: "shirt-black-l",
-									Qty:                    1,
-								},
-							},
-						},
-					},
-				},
-			},
-		})
-		assert.NoError(t, err)
-
-		qty := 1
-		got, _, err := cob.UpdateItems(context.Background(), cart, []domaincart.ItemUpdateCommand{
-			{
-				ItemID: "abc",
-				Qty:    &qty,
-			},
-		})
-		assert.NoError(t, err)
-
-		assert.Equal(t, "fake_bundle", got.Deliveries[0].Cartitems[0].MarketplaceCode)
-		assert.Empty(t, got.Deliveries[0].Cartitems[0].BundleConfig)
-	})
 }
 
 func TestDefaultCartBehaviour_AddToCart(t *testing.T) {

--- a/cart/infrastructure/defaultCartBehaviour_test.go
+++ b/cart/infrastructure/defaultCartBehaviour_test.go
@@ -818,6 +818,62 @@ func TestDefaultCartBehaviour_UpdateItems(t *testing.T) {
 		assert.Equal(t, "simple_option1", got.Deliveries[0].Cartitems[0].BundleConfig["identifier1"].MarketplaceCode)
 		assert.Empty(t, got.Deliveries[0].Cartitems[0].BundleConfig["identifier2"])
 	})
+
+	t.Run("item with bundle configuration is removed if not provided", func(t *testing.T) {
+		t.Parallel()
+
+		cob := &DefaultCartBehaviour{}
+		cob.Inject(
+			newInMemoryStorage(),
+			&fake.ProductService{},
+			flamingo.NullLogger{},
+			nil,
+			nil,
+			nil,
+		)
+
+		cart, err := cob.StoreNewCart(context.Background(), &domaincart.Cart{
+			ID: "1234",
+			Deliveries: []domaincart.Delivery{
+				{
+					DeliveryInfo: domaincart.DeliveryInfo{
+						Code: "delivery",
+					},
+					Cartitems: []domaincart.Item{
+						{
+							ID:              "abc",
+							MarketplaceCode: "fake_bundle",
+							Qty:             1,
+							BundleConfig: map[domain.Identifier]domain.ChoiceConfiguration{
+								"identifier1": {
+									MarketplaceCode: "simple_option1",
+									Qty:             1,
+								},
+								"identifier2": {
+									MarketplaceCode:        "configurable_option1",
+									VariantMarketplaceCode: "shirt-black-l",
+									Qty:                    1,
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+		assert.NoError(t, err)
+
+		qty := 1
+		got, _, err := cob.UpdateItems(context.Background(), cart, []domaincart.ItemUpdateCommand{
+			{
+				ItemID: "abc",
+				Qty:    &qty,
+			},
+		})
+		assert.NoError(t, err)
+
+		assert.Equal(t, "fake_bundle", got.Deliveries[0].Cartitems[0].MarketplaceCode)
+		assert.Empty(t, got.Deliveries[0].Cartitems[0].BundleConfig)
+	})
 }
 
 func TestDefaultCartBehaviour_AddToCart(t *testing.T) {

--- a/cart/infrastructure/defaultCartBehaviour_test.go
+++ b/cart/infrastructure/defaultCartBehaviour_test.go
@@ -755,6 +755,69 @@ func TestDefaultCartBehaviour_UpdateItems(t *testing.T) {
 		assert.Equal(t, 0, len(got.Deliveries[0].Cartitems))
 		assert.Equal(t, 0.0, got.GrandTotal.FloatAmount())
 	})
+
+	t.Run("item with bundle configuration is updated", func(t *testing.T) {
+		t.Parallel()
+
+		cob := &DefaultCartBehaviour{}
+		cob.Inject(
+			newInMemoryStorage(),
+			&fake.ProductService{},
+			flamingo.NullLogger{},
+			nil,
+			nil,
+			nil,
+		)
+
+		cart, err := cob.StoreNewCart(context.Background(), &domaincart.Cart{
+			ID: "1234",
+			Deliveries: []domaincart.Delivery{
+				{
+					DeliveryInfo: domaincart.DeliveryInfo{
+						Code: "delivery",
+					},
+					Cartitems: []domaincart.Item{
+						{
+							ID:              "abc",
+							MarketplaceCode: "fake_bundle",
+							Qty:             1,
+							BundleConfig: map[domain.Identifier]domain.ChoiceConfiguration{
+								"identifier1": {
+									MarketplaceCode: "simple_option1",
+									Qty:             1,
+								},
+								"identifier2": {
+									MarketplaceCode:        "configurable_option1",
+									VariantMarketplaceCode: "shirt-black-l",
+									Qty:                    1,
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+		assert.NoError(t, err)
+
+		qty := 1
+		got, _, err := cob.UpdateItems(context.Background(), cart, []domaincart.ItemUpdateCommand{
+			{
+				ItemID: "abc",
+				Qty:    &qty,
+				BundleConfiguration: domain.BundleConfiguration{
+					"identifier1": {
+						MarketplaceCode: "simple_option1",
+						Qty:             1,
+					},
+				},
+			},
+		})
+		assert.NoError(t, err)
+
+		assert.Equal(t, "fake_bundle", got.Deliveries[0].Cartitems[0].MarketplaceCode)
+		assert.Equal(t, "simple_option1", got.Deliveries[0].Cartitems[0].BundleConfig["identifier1"].MarketplaceCode)
+		assert.Empty(t, got.Deliveries[0].Cartitems[0].BundleConfig["identifier2"])
+	})
 }
 
 func TestDefaultCartBehaviour_AddToCart(t *testing.T) {


### PR DESCRIPTION
Currently, it's impossible to update a product's bundle configuration in the cart (cart item).

This pull request:

* adds `BundleConfiguration` to the `ItemUpdateCommand`
* implements updating of the cart item in the `DefaultCartBehavior`