### PR TITLE
chore(bundles): Require explicit qty amounts when it comes to bundle choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * **Breaking**(In case you have implemented a custom cart service): Extend the cart service interface with `UpdateItemBundleConfig` to allow updating bundles that have already been placed inside the cart.
 * GraphQL:
   * Add new mutation `Commerce_Cart_UpdateItemBundleConfig` to update bundle configs for existing cart items
+  * **Breaking** Make the qty in the `Commerce_Cart_ChoiceConfigurationInput` type mandatory, previously 1 was taken as a default
 
 **checkout**
 * initialize place order metrics with 0 on application start to follow prometheus best practices
@@ -19,6 +20,7 @@
 **product**
 * GraphQL:
   * Expose Active Option (product+qty) for bundle products
+  * **Breaking** Make the qty in the `Commerce_Product_ChoiceConfigurationInput` type mandatory, previously it was 0 which lead to taking the minimum required qty of that choice
 
 ## v3.8.0
 

--- a/cart/interfaces/graphql/dto/dto.go
+++ b/cart/interfaces/graphql/dto/dto.go
@@ -75,7 +75,7 @@ type (
 		Identifier             string
 		MarketplaceCode        string
 		VariantMarketplaceCode *string
-		Qty                    *int
+		Qty                    int
 	}
 )
 
@@ -84,19 +84,15 @@ func MapBundleConfigToDomain(graphqlBundleConfig []ChoiceConfiguration) productD
 
 	for _, configuration := range graphqlBundleConfig {
 		variantMarketplaceCode := ""
-		quantity := 1
 
 		if configuration.VariantMarketplaceCode != nil {
 			variantMarketplaceCode = *configuration.VariantMarketplaceCode
-		}
-		if configuration.Qty != nil {
-			quantity = *configuration.Qty
 		}
 
 		cartBundleConfiguration[productDomain.Identifier(configuration.Identifier)] = productDomain.ChoiceConfiguration{
 			MarketplaceCode:        configuration.MarketplaceCode,
 			VariantMarketplaceCode: variantMarketplaceCode,
-			Qty:                    quantity,
+			Qty:                    configuration.Qty,
 		}
 	}
 

--- a/cart/interfaces/graphql/schema.graphql
+++ b/cart/interfaces/graphql/schema.graphql
@@ -480,7 +480,7 @@ input Commerce_Cart_ChoiceConfigurationInput {
     identifier: String!
     marketplaceCode: String!
     variantMarketplaceCode: String
-    qty: Int
+    qty: Int!
 }
 
 extend type Mutation {

--- a/product/interfaces/graphql/product/dto/productdto.go
+++ b/product/interfaces/graphql/product/dto/productdto.go
@@ -97,7 +97,7 @@ type (
 		Identifier             string
 		MarketplaceCode        string
 		VariantMarketplaceCode *string
-		Qty                    *int
+		Qty                    int
 	}
 
 	// VariantSelection contains information about all possible variant selections

--- a/product/interfaces/graphql/resolver.go
+++ b/product/interfaces/graphql/resolver.go
@@ -82,19 +82,15 @@ func mapToDomain(dtoChoices []*productDto.ChoiceConfiguration) domain.BundleConf
 		}
 
 		variantMarketplaceCode := ""
-		quantity := 0
 
 		if choice.VariantMarketplaceCode != nil {
 			variantMarketplaceCode = *choice.VariantMarketplaceCode
-		}
-		if choice.Qty != nil {
-			quantity = *choice.Qty
 		}
 
 		domainConfiguration[domain.Identifier(choice.Identifier)] = domain.ChoiceConfiguration{
 			MarketplaceCode:        choice.MarketplaceCode,
 			VariantMarketplaceCode: variantMarketplaceCode,
-			Qty:                    quantity,
+			Qty:                    choice.Qty,
 		}
 	}
 

--- a/product/interfaces/graphql/schema.graphql
+++ b/product/interfaces/graphql/schema.graphql
@@ -332,8 +332,7 @@ input Commerce_Product_ChoiceConfigurationInput {
     identifier: String!
     marketplaceCode: String!
     variantMarketplaceCode: String
-    "Optional quantity, if none provided the minimum will be used."
-    qty: Int
+    qty: Int!
 }
 
 extend type Query {

--- a/test/integrationtest/projecttest/graphql/generated.go
+++ b/test/integrationtest/projecttest/graphql/generated.go
@@ -37773,7 +37773,7 @@ func (ec *executionContext) unmarshalInputCommerce_Cart_ChoiceConfigurationInput
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("qty"))
-			data, err := ec.unmarshalOInt2ᚖint(ctx, v)
+			data, err := ec.unmarshalNInt2int(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -38064,7 +38064,7 @@ func (ec *executionContext) unmarshalInputCommerce_Product_ChoiceConfigurationIn
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("qty"))
-			data, err := ec.unmarshalOInt2ᚖint(ctx, v)
+			data, err := ec.unmarshalNInt2int(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -49852,22 +49852,6 @@ func (ec *executionContext) unmarshalOInt2int(ctx context.Context, v interface{}
 
 func (ec *executionContext) marshalOInt2int(ctx context.Context, sel ast.SelectionSet, v int) graphql.Marshaler {
 	res := graphql.MarshalInt(v)
-	return res
-}
-
-func (ec *executionContext) unmarshalOInt2ᚖint(ctx context.Context, v interface{}) (*int, error) {
-	if v == nil {
-		return nil, nil
-	}
-	res, err := graphql.UnmarshalInt(v)
-	return &res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalOInt2ᚖint(ctx context.Context, sel ast.SelectionSet, v *int) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	res := graphql.MarshalInt(*v)
 	return res
 }
 

--- a/test/integrationtest/projecttest/graphql/schema/flamingo.me_flamingo-commerce_v3_cart_interfaces_graphql-Service.graphql
+++ b/test/integrationtest/projecttest/graphql/schema/flamingo.me_flamingo-commerce_v3_cart_interfaces_graphql-Service.graphql
@@ -480,7 +480,7 @@ input Commerce_Cart_ChoiceConfigurationInput {
     identifier: String!
     marketplaceCode: String!
     variantMarketplaceCode: String
-    qty: Int
+    qty: Int!
 }
 
 extend type Mutation {

--- a/test/integrationtest/projecttest/graphql/schema/flamingo.me_flamingo-commerce_v3_product_interfaces_graphql-Service.graphql
+++ b/test/integrationtest/projecttest/graphql/schema/flamingo.me_flamingo-commerce_v3_product_interfaces_graphql-Service.graphql
@@ -332,8 +332,7 @@ input Commerce_Product_ChoiceConfigurationInput {
     identifier: String!
     marketplaceCode: String!
     variantMarketplaceCode: String
-    "Optional quantity, if none provided the minimum will be used."
-    qty: Int
+    qty: Int!
 }
 
 extend type Query {

--- a/test/integrationtest/projecttest/tests/graphql/testdata/commerce_cart_AddBundleToCart.graphql
+++ b/test/integrationtest/projecttest/tests/graphql/testdata/commerce_cart_AddBundleToCart.graphql
@@ -8,10 +8,12 @@ mutation {
                 identifier: "###IDENTIFIER1###"
                 marketplaceCode: "###MARKETPLACE_CODE1###"
                 variantMarketplaceCode: "###VARIANT_MARKETPLACE_CODE1###"
+                qty: 1
             },{
                 identifier: "###IDENTIFIER2###"
                 marketplaceCode: "###MARKETPLACE_CODE2###"
                 variantMarketplaceCode: "###VARIANT_MARKETPLACE_CODE2###"
+                qty: 1
             }]
         }
     ) {

--- a/test/integrationtest/projecttest/tests/graphql/testdata/commerce_cart_AddBundleToCart_Update_Qty_Helper.graphql
+++ b/test/integrationtest/projecttest/tests/graphql/testdata/commerce_cart_AddBundleToCart_Update_Qty_Helper.graphql
@@ -8,10 +8,12 @@ mutation {
           identifier: "###IDENTIFIER1###"
           marketplaceCode: "###MARKETPLACE_CODE1###"
           variantMarketplaceCode: "###VARIANT_MARKETPLACE_CODE1###"
+          qty: 1
         },{
           identifier: "###IDENTIFIER2###"
           marketplaceCode: "###MARKETPLACE_CODE2###"
           variantMarketplaceCode: "###VARIANT_MARKETPLACE_CODE2###"
+          qty: 1
         }]
       }
     ) {


### PR DESCRIPTION
Falling back to minimum values or 1 was a bad design choice. The consumer of graphql should clearly state with what amount a bundle choice should be added to the cart / fetched from the product service