### PR TITLE
fix(sourcing): use correct error to generate the message

### DIFF
--- a/sourcing/domain/service.go
+++ b/sourcing/domain/service.go
@@ -219,7 +219,7 @@ func (d *DefaultSourcingService) getAvailableSourcesForASingleProduct(ctx contex
 
 	if len(availableSources) == 0 {
 		if lastStockError != nil {
-			errString := err.Error()
+			errString := lastStockError.Error()
 			return availableSources, fmt.Errorf("%w with error: %s", ErrNoSourceAvailable, errString)
 		}
 		return availableSources, fmt.Errorf("%w %s", ErrNoSourceAvailable, formatSources(sources))


### PR DESCRIPTION
The err from above can be nil here