### PR TITLE
feat(checkout/orderservice): Introduce flag to skip cart validation during place order

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -31,6 +31,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: 'v1.55'
+          version: 'v1.59'
           args: $(rev=${{ env.REV }}; if [[ $rev != '' ]]; then echo --new-from-rev=$rev; fi)
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,23 +3,11 @@ run:
   concurrency: 4
   timeout: 5m
   tests: true
-  # vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
-  skip-dirs-use-default: true
   modules-download-mode: readonly
   allow-parallel-runners: false
-  go: '1.21'
 
 # output configuration options
 output:
-  # Format: colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
-  #
-  # Multiple can be specified by separating them by comma, output can be provided
-  # for each of them by separating format name and path by colon symbol.
-  # Output path can be either `stdout`, `stderr` or path to the file to write to.
-  # Example: "checkstyle:report.json,colored-line-number"
-  #
-  # Default: colored-line-number
-  format: colored-line-number
   print-issued-lines: true
   print-linter-name: true
   uniq-by-line: true
@@ -44,9 +32,9 @@ linters:
     - gocognit
     - goconst
     - gocritic
-    - goerr113
+    - err113
     - gofmt
-    - gomnd
+    - mnd
     - gomoddirectives
     - gosec
     - gosimple
@@ -94,7 +82,7 @@ issues:
         - wrapcheck
 
 linters-settings:
-  gomnd:
+  mnd:
     ignored-functions:
       - context.WithTimeout
   nolintlint:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## v3.12.0 [upcoming]
+**checkout**
+* add config `commerce.checkout.orderService.skipCartValidation` to disable cart validation that happens right before placing an order in the OrderService
 
 ## v3.11.0
 

--- a/checkout/application/orderService.go
+++ b/checkout/application/orderService.go
@@ -32,6 +32,9 @@ type (
 		deliveryInfoBuilder    cart.DeliveryInfoBuilder
 		webCartPaymentGateways map[string]interfaces.WebCartPaymentGateway
 		decoratedCartFactory   *decorator.DecoratedCartFactory
+
+		// configs
+		validateCartBeforePlacingOrder bool
 	}
 
 	// PlaceOrderInfo struct defines the data of payments on placed orders
@@ -122,14 +125,22 @@ func (os *OrderService) Inject(
 	DeliveryInfoBuilder cart.DeliveryInfoBuilder,
 	webCartPaymentGatewayProvider interfaces.WebCartPaymentGatewayProvider,
 	decoratedCartFactory *decorator.DecoratedCartFactory,
-
-) {
+	cfg *struct {
+		ValidateCartBeforePlacing bool `inject:"config:commerce.checkout.placeorder.validateCartBeforePlacing"`
+	},
+) *OrderService {
 	os.logger = logger.WithField(flamingo.LogKeyCategory, "checkout.OrderService").WithField(flamingo.LogKeyModule, "checkout")
 	os.cartService = CartService
 	os.cartReceiverService = CartReceiverService
 	os.webCartPaymentGateways = webCartPaymentGatewayProvider()
 	os.deliveryInfoBuilder = DeliveryInfoBuilder
 	os.decoratedCartFactory = decoratedCartFactory
+
+	if cfg != nil {
+		os.validateCartBeforePlacingOrder = cfg.ValidateCartBeforePlacing
+	}
+
+	return os
 }
 
 // GetPaymentGateway tries to get the supplied payment gateway by code from the registered payment gateways
@@ -180,13 +191,15 @@ func (os *OrderService) placeOrder(ctx context.Context, session *web.Session, de
 	ctx, span := trace.StartSpan(ctx, "checkout/OrderService/placeOrder")
 	defer span.End()
 
-	validationResult := os.cartService.ValidateCart(ctx, session, decoratedCart)
-	if !validationResult.IsValid() {
-		// record cartValidationFailCount metric
-		stats.Record(ctx, cartValidationFailCount.M(1))
-		os.logger.WithContext(ctx).Warn("Try to place an invalid cart")
+	if os.validateCartBeforePlacingOrder {
+		validationResult := os.cartService.ValidateCart(ctx, session, decoratedCart)
+		if !validationResult.IsValid() {
+			// record cartValidationFailCount metric
+			stats.Record(ctx, cartValidationFailCount.M(1))
+			os.logger.WithContext(ctx).Warn("Try to place an invalid cart")
 
-		return nil, errors.New("cart is invalid")
+			return nil, errors.New("cart is invalid")
+		}
 	}
 
 	placedOrderInfos, err := os.cartService.PlaceOrderWithCart(ctx, session, &decoratedCart.Cart, &payment)
@@ -372,13 +385,15 @@ func (os *OrderService) placeOrderWithPaymentProcessing(ctx context.Context, dec
 		return nil, errors.New("no payment gateway selected")
 	}
 
-	validationResult := os.cartService.ValidateCart(ctx, session, decoratedCart)
-	if !validationResult.IsValid() {
-		// record cartValidationFailCount metric
-		stats.Record(ctx, cartValidationFailCount.M(1))
-		os.logger.WithContext(ctx).Warn("Try to place an invalid cart")
+	if os.validateCartBeforePlacingOrder {
+		validationResult := os.cartService.ValidateCart(ctx, session, decoratedCart)
+		if !validationResult.IsValid() {
+			// record cartValidationFailCount metric
+			stats.Record(ctx, cartValidationFailCount.M(1))
+			os.logger.WithContext(ctx).Warn("Try to place an invalid cart")
 
-		return nil, errors.New("cart is invalid")
+			return nil, errors.New("cart is invalid")
+		}
 	}
 
 	gateway, err := os.GetPaymentGateway(ctx, decoratedCart.Cart.PaymentSelection.Gateway())

--- a/checkout/application/orderService.go
+++ b/checkout/application/orderService.go
@@ -194,7 +194,7 @@ func (os *OrderService) placeOrder(ctx context.Context, session *web.Session, de
 	ctx, span := trace.StartSpan(ctx, "checkout/OrderService/placeOrder")
 	defer span.End()
 
-	if os.skipCartValidation {
+	if !os.skipCartValidation {
 		validationResult := os.cartService.ValidateCart(ctx, session, decoratedCart)
 		if !validationResult.IsValid() {
 			// record cartValidationFailCount metric
@@ -388,7 +388,7 @@ func (os *OrderService) placeOrderWithPaymentProcessing(ctx context.Context, dec
 		return nil, errors.New("no payment gateway selected")
 	}
 
-	if os.skipCartValidation {
+	if !os.skipCartValidation {
 		validationResult := os.cartService.ValidateCart(ctx, session, decoratedCart)
 		if !validationResult.IsValid() {
 			// record cartValidationFailCount metric

--- a/checkout/application/orderService.go
+++ b/checkout/application/orderService.go
@@ -65,6 +65,9 @@ const (
 )
 
 var (
+	// ErrCartValidationFailed is returned if the cart you are trying to place is invalid
+	ErrCartValidationFailed = errors.New("cart is invalid")
+
 	// cartValidationFailCount counts validation failures on carts
 	cartValidationFailCount = stats.Int64("flamingo-commerce/checkout/orders/cart_validation_failed", "Count of failures while validating carts", stats.UnitDimensionless)
 
@@ -198,7 +201,7 @@ func (os *OrderService) placeOrder(ctx context.Context, session *web.Session, de
 			stats.Record(ctx, cartValidationFailCount.M(1))
 			os.logger.WithContext(ctx).Warn("Try to place an invalid cart")
 
-			return nil, errors.New("cart is invalid")
+			return nil, ErrCartValidationFailed
 		}
 	}
 
@@ -392,7 +395,7 @@ func (os *OrderService) placeOrderWithPaymentProcessing(ctx context.Context, dec
 			stats.Record(ctx, cartValidationFailCount.M(1))
 			os.logger.WithContext(ctx).Warn("Try to place an invalid cart")
 
-			return nil, errors.New("cart is invalid")
+			return nil, ErrCartValidationFailed
 		}
 	}
 

--- a/checkout/application/orderService_test.go
+++ b/checkout/application/orderService_test.go
@@ -48,7 +48,7 @@ func TestOrderService_LastPlacedOrder(t *testing.T) {
 
 			os := &application.OrderService{}
 
-			os.Inject(flamingo.NullLogger{}, nil, nil, nil, fakeGatewayProvider, nil)
+			os.Inject(flamingo.NullLogger{}, nil, nil, nil, fakeGatewayProvider, nil, nil)
 
 			got, err := os.LastPlacedOrder(tt.args.ctx)
 			if (err != nil) != tt.wantErr {
@@ -69,7 +69,7 @@ func TestOrderService_ClearLastPlacedOrder(t *testing.T) {
 
 	os := &application.OrderService{}
 
-	os.Inject(flamingo.NullLogger{}, nil, nil, nil, fakeGatewayProvider, nil)
+	os.Inject(flamingo.NullLogger{}, nil, nil, nil, fakeGatewayProvider, nil, nil)
 
 	want := &application.PlaceOrderInfo{
 		PaymentInfos: nil,

--- a/checkout/module.go
+++ b/checkout/module.go
@@ -121,6 +121,7 @@ commerce: checkout: {
 	redirectToCartOnInvalidCart?:     bool
 	privacyPolicyRequired?:           bool
 	placeorder: {
+		validateCartBeforePlacing: bool | *true
 		lock: {
 			type: *"memory" | "redis"
 			if type == "redis" {

--- a/checkout/module.go
+++ b/checkout/module.go
@@ -120,8 +120,10 @@ commerce: checkout: {
 	showEmptyCartPageIfNoItems?:      bool
 	redirectToCartOnInvalidCart?:     bool
 	privacyPolicyRequired?:           bool
+	orderService:{
+		skipCartValidation: bool | *false
+	}
 	placeorder: {
-		validateCartBeforePlacing: bool | *true
 		lock: {
 			type: *"memory" | "redis"
 			if type == "redis" {


### PR DESCRIPTION
In case you are using the place order state machine, cart is already validated in the dedicated ValidatCart state. So no need to additionally validate it during PlaceOrder state.