### PR TITLE
chore: Replace github.com/pkg/errors with Go core error package

### DIFF
--- a/cart/application/cartCache.go
+++ b/cart/application/cartCache.go
@@ -3,6 +3,7 @@ package application
 import (
 	"context"
 	"encoding/gob"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -13,7 +14,6 @@ import (
 	"flamingo.me/flamingo/v3/core/auth"
 	"flamingo.me/flamingo/v3/framework/flamingo"
 	"flamingo.me/flamingo/v3/framework/web"
-	"github.com/pkg/errors"
 )
 
 //go:generate go run github.com/vektra/mockery/v2@v2.43.2 --name CartCache --case snake

--- a/cart/application/cartReceiver_test.go
+++ b/cart/application/cartReceiver_test.go
@@ -2,6 +2,7 @@ package application_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -10,7 +11,6 @@ import (
 	authMock "flamingo.me/flamingo/v3/core/auth/mock"
 	"flamingo.me/flamingo/v3/framework/flamingo"
 	"flamingo.me/flamingo/v3/framework/web"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/cart/application/cartService.go
+++ b/cart/application/cartService.go
@@ -3,12 +3,12 @@ package application
 import (
 	"context"
 	"encoding/gob"
+	"errors"
 	"fmt"
 
 	"go.opencensus.io/trace"
 
 	"flamingo.me/flamingo/v3/core/auth"
-	"github.com/pkg/errors"
 
 	"flamingo.me/flamingo/v3/framework/flamingo"
 	"flamingo.me/flamingo/v3/framework/web"
@@ -582,7 +582,7 @@ func (cs *CartService) DeleteItem(ctx context.Context, session *web.Session, ite
 	if err != nil {
 		cs.handleCartNotFound(session, err)
 		if !errors.Is(err, context.Canceled) {
-			cs.logger.WithContext(ctx).WithField(flamingo.LogKeySubCategory, "DeleteItem").Error(errors.Wrap(err, "Trying to delete SKU :"+item.MarketplaceCode))
+			cs.logger.WithContext(ctx).WithField(flamingo.LogKeySubCategory, "DeleteItem").Error(fmt.Errorf("trying to delete SKU %q: %w", item.MarketplaceCode, err))
 		}
 		return err
 	}

--- a/cart/domain/cart/cart.go
+++ b/cart/domain/cart/cart.go
@@ -275,7 +275,7 @@ func (c Cart) GetDeliveryByItemID(itemID string) (*Delivery, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("delivery not found for %q", itemID) //nolint:err113 //not worth introducing a dedicated error
+	return nil, fmt.Errorf("%w for %q", ErrDeliveryCodeNotFound, itemID)
 }
 
 // GetByItemID gets an item by its id
@@ -288,7 +288,7 @@ func (c Cart) GetByItemID(itemID string) (*Item, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("itemId %q in cart does not exist", itemID) //nolint:err113 //not worth introducing a dedicated error
+	return nil, fmt.Errorf("%w for itemID %q", ErrItemNotFound, itemID)
 }
 
 // GetTotalQty for the product in the cart
@@ -314,7 +314,7 @@ func (c Cart) GetByExternalReference(ref string) (*Item, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("cant find item with external reference %q", ref) //nolint:err113 //not worth introducing a dedicated error
+	return nil, fmt.Errorf("%w for external reference %q", ErrItemNotFound, ref)
 }
 
 // ItemCount returns amount of cart items in the current cart

--- a/cart/domain/cart/cart.go
+++ b/cart/domain/cart/cart.go
@@ -3,10 +3,9 @@ package cart
 import (
 	"bytes"
 	"encoding/gob"
+	"errors"
 	"fmt"
 	"math/big"
-
-	"github.com/pkg/errors"
 
 	"flamingo.me/flamingo/v3/framework/web"
 
@@ -276,7 +275,7 @@ func (c Cart) GetDeliveryByItemID(itemID string) (*Delivery, error) {
 		}
 	}
 
-	return nil, errors.Errorf("delivery not found for %q", itemID)
+	return nil, fmt.Errorf("delivery not found for %q", itemID) //nolint:err113 //not worth introducing a dedicated error
 }
 
 // GetByItemID gets an item by its id
@@ -289,7 +288,7 @@ func (c Cart) GetByItemID(itemID string) (*Item, error) {
 		}
 	}
 
-	return nil, errors.Errorf("itemId %q in cart does not exist", itemID)
+	return nil, fmt.Errorf("itemId %q in cart does not exist", itemID) //nolint:err113 //not worth introducing a dedicated error
 }
 
 // GetTotalQty for the product in the cart
@@ -315,7 +314,7 @@ func (c Cart) GetByExternalReference(ref string) (*Item, error) {
 		}
 	}
 
-	return nil, errors.Errorf("uitemID %v in cart not existing", ref)
+	return nil, fmt.Errorf("cant find item with external reference %q", ref) //nolint:err113 //not worth introducing a dedicated error
 }
 
 // ItemCount returns amount of cart items in the current cart

--- a/cart/domain/cart/cartServicePorts.go
+++ b/cart/domain/cart/cartServicePorts.go
@@ -118,11 +118,11 @@ type (
 
 var (
 	// ErrCartNotFound is used if a cart was not found
-	ErrCartNotFound = errors.New("Cart not found")
+	ErrCartNotFound = errors.New("cart not found")
 	// ErrItemNotFound is used if a item on cart was not found
-	ErrItemNotFound = errors.New("Item not found")
+	ErrItemNotFound = errors.New("item not found")
 	// ErrDeliveryCodeNotFound is used if a delivery was not found
-	ErrDeliveryCodeNotFound = errors.New("Delivery not found")
+	ErrDeliveryCodeNotFound = errors.New("delivery not found")
 )
 
 // CreateDeliveryInfoUpdateCommand - factory to get the update command based on the given deliveryInfos (which might come from cart)

--- a/cart/domain/cart/cartServicePorts.go
+++ b/cart/domain/cart/cartServicePorts.go
@@ -10,13 +10,11 @@ package cart
 import (
 	"context"
 	"encoding/json"
-
-	"flamingo.me/flamingo/v3/core/auth"
-	"flamingo.me/flamingo/v3/framework/flamingo"
-
-	"github.com/pkg/errors"
+	"errors"
 
 	productDomain "flamingo.me/flamingo-commerce/v3/product/domain"
+	"flamingo.me/flamingo/v3/core/auth"
+	"flamingo.me/flamingo/v3/framework/flamingo"
 )
 
 type (

--- a/cart/infrastructure/defaultCartBehaviour.go
+++ b/cart/infrastructure/defaultCartBehaviour.go
@@ -2,6 +2,7 @@ package infrastructure
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"math/rand"
@@ -10,7 +11,6 @@ import (
 	"go.opencensus.io/trace"
 
 	"flamingo.me/flamingo/v3/framework/flamingo"
-	"github.com/pkg/errors"
 
 	domaincart "flamingo.me/flamingo-commerce/v3/cart/domain/cart"
 	"flamingo.me/flamingo-commerce/v3/cart/domain/decorator"
@@ -552,7 +552,7 @@ func (cob *DefaultCartBehaviour) CleanDelivery(ctx context.Context, cart *domain
 
 	// create delivery if it does not yet exist
 	if !newCart.HasDeliveryForCode(deliveryCode) {
-		return nil, nil, errors.Errorf("DefaultCartBehaviour: delivery %s not found", deliveryCode)
+		return nil, nil, fmt.Errorf("DefaultCartBehaviour: delivery %s not found", deliveryCode) //nolint:err113 //not worth introducing a dedicated error
 	}
 
 	var position int

--- a/cart/infrastructure/defaultCartBehaviour.go
+++ b/cart/infrastructure/defaultCartBehaviour.go
@@ -552,7 +552,7 @@ func (cob *DefaultCartBehaviour) CleanDelivery(ctx context.Context, cart *domain
 
 	// create delivery if it does not yet exist
 	if !newCart.HasDeliveryForCode(deliveryCode) {
-		return nil, nil, fmt.Errorf("DefaultCartBehaviour: delivery %s not found", deliveryCode) //nolint:err113 //not worth introducing a dedicated error
+		return nil, nil, fmt.Errorf("DefaultCartBehaviour: %w with code %q", domaincart.ErrDeliveryCodeNotFound, deliveryCode)
 	}
 
 	var position int

--- a/cart/infrastructure/defaultCartBehaviour_test.go
+++ b/cart/infrastructure/defaultCartBehaviour_test.go
@@ -132,7 +132,8 @@ func TestDefaultCartBehaviour_CleanDelivery(t *testing.T) {
 		assert.NoError(t, err)
 
 		got, _, err := cob.CleanDelivery(context.Background(), cart, "dev-3")
-		assert.EqualError(t, err, "DefaultCartBehaviour: delivery dev-3 not found")
+		assert.ErrorIs(t, err, domaincart.ErrDeliveryCodeNotFound)
+		assert.ErrorContains(t, err, "dev-3")
 		assert.Nil(t, got)
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/leekchan/accounting v0.3.1
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0
 	github.com/stvp/tempredis v0.0.0-20231107154819-8a695b693b9c
@@ -123,6 +122,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/openzipkin/zipkin-go v0.4.3 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect

--- a/product/domain/productService.go
+++ b/product/domain/productService.go
@@ -24,7 +24,7 @@ type (
 
 	// SearchService is a typed search for products
 	SearchService interface {
-		//Search returns Products based on given Filters
+		// Search returns Products based on given Filters
 		Search(ctx context.Context, filter ...searchDomain.Filter) (*SearchResult, error)
 		// SearchBy returns Products prefiltered by the given attribute (also based on additional given Filters)
 		// e.g. SearchBy(ctx,"brandCode","apple")
@@ -36,6 +36,8 @@ type (
 		MarketplaceCode string
 	}
 )
+
+var _ error = ProductNotFound{}
 
 // Error implements the error interface
 func (err ProductNotFound) Error() string {

--- a/product/interfaces/controller/controller.go
+++ b/product/interfaces/controller/controller.go
@@ -2,10 +2,10 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"net/url"
 
 	"flamingo.me/flamingo/v3/framework/web"
-	"github.com/pkg/errors"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
@@ -189,13 +189,11 @@ func (vc *View) Get(c context.Context, r *web.Request) web.Result {
 
 	// catch error
 	if err != nil {
-		switch errors.Cause(err).(type) {
-		case domain.ProductNotFound:
+		if errors.As(err, &domain.ProductNotFound{}) {
 			return vc.Responder.NotFound(err)
-
-		default:
-			return vc.Responder.ServerError(err)
 		}
+
+		return vc.Responder.ServerError(err)
 	}
 
 	var viewData productViewData

--- a/w3cdatalayer/application/factory.go
+++ b/w3cdatalayer/application/factory.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha512"
 	"encoding/base64"
 	"encoding/hex"
+	"fmt"
 	"net/url"
 	"regexp"
 	"strconv"
@@ -14,7 +15,6 @@ import (
 	"flamingo.me/flamingo/v3/core/auth"
 	"flamingo.me/flamingo/v3/framework/flamingo"
 	"flamingo.me/flamingo/v3/framework/web"
-	"github.com/pkg/errors"
 	"go.opencensus.io/tag"
 
 	"flamingo.me/flamingo-commerce/v3/cart/domain/decorator"
@@ -128,7 +128,7 @@ func (s Factory) BuildForCurrentRequest(ctx context.Context, request *web.Reques
 
 	baseURL, err := s.router.Absolute(request, request.Request().URL.Path, nil)
 	if err != nil {
-		s.logger.Warn(errors.Wrap(err, "cannot build absolute url"))
+		s.logger.Warn(fmt.Errorf("cannot build absolute url: %w", err))
 		baseURL = new(url.URL)
 	}
 	layer.Page = &domain.Page{

--- a/w3cdatalayer/application/service.go
+++ b/w3cdatalayer/application/service.go
@@ -2,6 +2,7 @@ package application
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"flamingo.me/flamingo-commerce/v3/cart/domain/decorator"
@@ -11,7 +12,6 @@ import (
 	"flamingo.me/flamingo/v3/framework/flamingo"
 	"flamingo.me/flamingo/v3/framework/web"
 	"flamingo.me/pugtemplate/pugjs"
-	"github.com/pkg/errors"
 )
 
 type (


### PR DESCRIPTION
The topic was started in 2021 (see #334) and is now actually in a mergeable state.. 🎉  