### PR TITLE
docs(sourcing): fix grammar and spelling across sourcing module

### DIFF
--- a/sourcing/Readme.md
+++ b/sourcing/Readme.md
@@ -1,40 +1,40 @@
 # Sourcing Package
 
-## What do we mean by sourcing
+## What do we mean by sourcing?
 
-Sourcing is about finding the "best" possible location,
-where a product or an ordered item should be fulfilled from.
-A sourcing logic is therefore also used to allocate your ordered items to the best source locations.
+Sourcing is about finding the "best" possible location
+from which a product or an ordered item should be fulfilled.
+Sourcing logic is therefore also used to allocate ordered items to the best source locations.
 
-Different things can play a role while figuring out the correct source location(s):
+Different factors can play a role when determining the correct source location(s):
 
 - available stock (or replenished stock)
-- cost of delivery (e.g. pick warehouses close to delivery location)
+- cost of delivery (e.g. picking warehouses close to the delivery location)
 - synergies regarding the complete order  
-  (e.g. source the order from a warehouse where most of the items are available)
-- delivery time (if time is more important than cost -
-  then picking the source location that can deliver the fastest)
-...
+  (e.g. sourcing the order from a warehouse where most of the items are available)
+- delivery time (if time is more important than cost,
+  pick the source location that can deliver the fastest)
+- ...
 
-## Typical Use cases in e-commerce
+## Typical use cases in e-commerce
 
-For your shop it is helpful to have access to the Sourcing logic for advanced use cases like:
+For your shop, it is helpful to have access to the sourcing logic for advanced use cases such as:
 
 - On PDP:
-  - you might restrict the allowed qty based on available source qty (e.g. QtyRestrictor that access Sourcing logic)
+  - you might restrict the allowed qty based on the available source qty (e.g. a QtyRestrictor that accesses the sourcing logic)
   - you might want to indicate delivery times based on source locations
 
-- During Checkout or Place Order you can access the item allocation for:
+- During checkout or place order you can access the item allocation to:
   - make sure that a cart can always be sourced (e.g. as part of your CartValidator)
-  - you might want to show potential packages and delivery time
-  - you want to make sure that only carts can be placed that can be Sourced completly
-  - you might want to attach the source locations for every item to your backend system (e.g. access the Sourcng logic in your PlaceOrder Adapter)
+  - show potential packages and delivery times
+  - make sure that only carts which can be sourced completely are allowed to be placed
+  - attach the source locations for every item to your backend system (e.g. by accessing the sourcing logic in your PlaceOrder adapter)
 
 ## About this package
 
-Provides Port for Sourcing logic, that can be implemented according to your project needs.
+Provides a port for sourcing logic that can be implemented according to your project's needs.
 
-The main Port is the "SourcingService" interface that you can provide a custom adapter and have all possible freedom to design your sourcing logic.
+The main port is the `SourcingService` interface, for which you can provide a custom adapter, giving you full freedom to design your sourcing logic.
 
 ### Configurations
 
@@ -47,13 +47,13 @@ The main Port is the "SourcingService" interface that you can provide a custom a
 
 ### DefaultSourcingService
 
-The package also offers a "DefaultSourcingService" that does sourcing based on two inputs:
+The package also offers a `DefaultSourcingService` that performs sourcing based on two inputs:
 
-1. The theoretical available or possible sourcelocations for a given delivery
-2. The available stock for a specific sourcelocations
+1. The theoretically available or possible source locations for a given delivery
+2. The available stock for specific source locations
 
-For this two inputs the DefaultSourcingService offers also Ports where you can provide individual adapters.
-Based on this the DefaultSourcingService fetches the possible sourcelocations and will source items based on the available stock on that locations (starting from the first sourcelocation retrieved).
+For these two inputs, the `DefaultSourcingService` also offers ports where you can provide individual adapters.
+Based on this, the `DefaultSourcingService` fetches the possible source locations and sources items based on the available stock at those locations (starting from the first source location retrieved).
 
 ### Fake SourcingService
 
@@ -65,7 +65,7 @@ commerce:
       enable: true
 ```
 
-When enabled overrides other fake services and user should provide fake data json by
+When enabled, it overrides other fake services, and the user has to provide a fake data JSON file via:
 ```yaml
 commerce:
   sourcing:

--- a/sourcing/application/service.go
+++ b/sourcing/application/service.go
@@ -21,7 +21,7 @@ type (
 		GetAvailableSources(ctx context.Context, session *web.Session, product productDomain.BasicProduct, deliveryCode string) (domain.AvailableSourcesPerProduct, error)
 	}
 
-	// Service to access the sourcing based on current cart
+	// Service provides access to sourcing based on the current cart
 	Service struct {
 		logger              flamingo.Logger
 		sourcingService     domain.SourcingService
@@ -50,10 +50,10 @@ func (s *Service) Inject(
 	return s
 }
 
-// GetAvailableSourcesDeductedByCurrentCart fetches available sources minus those already allocated to the cart
+// GetAvailableSourcesDeductedByCurrentCart fetches the available sources minus those already allocated to the cart.
 func (s *Service) GetAvailableSourcesDeductedByCurrentCart(ctx context.Context, session *web.Session, product productDomain.BasicProduct, deliveryCode string) (domain.AvailableSourcesPerProduct, error) {
 	if product == nil {
-		s.logger.WithContext(ctx).Error("No product given for GetAvailableSourcesDeductedByCurrentCart")
+		s.logger.WithContext(ctx).Error("no product given for GetAvailableSourcesDeductedByCurrentCart")
 		return nil, errors.New("no product given for GetAvailableSourcesDeductedByCurrentCart")
 	}
 
@@ -65,10 +65,10 @@ func (s *Service) GetAvailableSourcesDeductedByCurrentCart(ctx context.Context, 
 	return s.sourcingService.GetAvailableSources(ctx, product, deliveryInfo, decoratedCart)
 }
 
-// GetAvailableSources without evaluating current cart items
+// GetAvailableSources returns the available sources without evaluating current cart items.
 func (s *Service) GetAvailableSources(ctx context.Context, session *web.Session, product productDomain.BasicProduct, deliveryCode string) (domain.AvailableSourcesPerProduct, error) {
 	if product == nil {
-		s.logger.WithContext(ctx).Error("No product given for GetAvailableSources")
+		s.logger.WithContext(ctx).Error("no product given for GetAvailableSources")
 		return nil, errors.New("no product given for GetAvailableSources")
 	}
 

--- a/sourcing/domain/fake/sourcing_service.go
+++ b/sourcing/domain/fake/sourcing_service.go
@@ -31,7 +31,7 @@ func (s *SourcingService) Inject(
 	},
 ) {
 	if cfg.FakeSourceData == "" {
-		panic("fake sourcing service enabled but jsonPath was not set")
+		panic("fake sourcing service is enabled but jsonPath is not set")
 	}
 
 	fileBytes, err := os.ReadFile(cfg.FakeSourceData)

--- a/sourcing/domain/fake/sourcing_service_test.go
+++ b/sourcing/domain/fake/sourcing_service_test.go
@@ -87,7 +87,7 @@ func TestSourcingService_AllocateItems(t *testing.T) {
 		assert.Equal(t, expectedItemAllocations, resultAllocations)
 	})
 
-	t.Run("empty result when there are no item ids", func(t *testing.T) {
+	t.Run("empty result when there are no item IDs", func(t *testing.T) {
 		t.Parallel()
 
 		service := &fake.SourcingService{}
@@ -167,7 +167,7 @@ func TestSourcingService_GetAvailableSources(t *testing.T) {
 		assert.Equal(t, expectedSources, resultSources)
 	})
 
-	t.Run("success when product id was not found but delivery code correct", func(t *testing.T) {
+	t.Run("success when product id is not found but delivery code is correct", func(t *testing.T) {
 		t.Parallel()
 
 		service := &fake.SourcingService{}

--- a/sourcing/domain/restrictor/restrictor.go
+++ b/sourcing/domain/restrictor/restrictor.go
@@ -16,7 +16,7 @@ import (
 )
 
 type (
-	// Restrictor restricts qty based on available stock
+	// Restrictor restricts quantity based on available stock
 	Restrictor struct {
 		logger          flamingo.Logger
 		sourcingService application.SourcingApplication
@@ -36,12 +36,12 @@ func (r *Restrictor) Inject(
 	return r
 }
 
-// Name returns the code of the restrictor
+// Name returns the name of the restrictor.
 func (r *Restrictor) Name() string {
 	return "SourceAvailableRestrictor"
 }
 
-// Restrict qty based on product data
+// Restrict limits the quantity based on the product's available sources.
 func (r *Restrictor) Restrict(ctx context.Context, session *web.Session, product productDomain.BasicProduct, _ *cart.Cart, deliveryCode string) *validation.RestrictionResult {
 	ctx, span := trace.StartSpan(ctx, "sourcing/restrictors/SourceAvailableRestrictor")
 	defer span.End()

--- a/sourcing/domain/restrictor/restrictor_test.go
+++ b/sourcing/domain/restrictor/restrictor_test.go
@@ -43,7 +43,8 @@ func TestRestrictor_Restrict(t *testing.T) {
 
 	fixtureCart := &cart.Cart{}
 
-	t.Run("error handing on error fetching available sources", func(t *testing.T) {
+	t.Run("error handling on error fetching available sources", func(t *testing.T) {
+		t.Parallel()
 		want := &validation.RestrictionResult{
 			IsRestricted:        false,
 			MaxAllowed:          0,

--- a/sourcing/domain/service.go
+++ b/sourcing/domain/service.go
@@ -18,51 +18,53 @@ const MaxSourceQty = math.MaxInt64
 type (
 	// SourcingService describes the main port used by the sourcing logic.
 	SourcingService interface {
-		// AllocateItems returns Sources for the given item in the given cart
-		// e.g. use this during place order to know
-		// throws ErrInsufficientSourceQty if not enough stock is available for the number of items in the cart
-		// throws ErrNoSourceAvailable if no source is available at all for one of the items
-		// throws ErrNeedMoreDetailsSourceCannotBeDetected if information on the cart (or delivery is missing)
+		// AllocateItems returns sources for the given items in the given cart.
+		// E.g. use this when placing an order to determine where items are sourced from.
+		// Returns ErrInsufficientSourceQty if not enough stock is available for the number of items in the cart.
+		// Returns ErrNoSourceAvailable if no source is available at all for one of the items.
+		// Returns ErrNeedMoreDetailsSourceCannotBeDetected if information on the cart or delivery is missing.
 		AllocateItems(ctx context.Context, decoratedCart *decorator.DecoratedCart) (ItemAllocations, error)
 
-		// GetAvailableSources returns possible Sources for the product and the desired delivery.
-		// Optionally, the existing cart can be passed so that existing items in the cart can be evaluated also (e.g. deduct stock)
-		// e.g., use this before a product should be placed in the cart to know if and from where an item can be sourced
-		// throws ErrNeedMoreDetailsSourceCannotBeDetected
-		// throws ErrNoSourceAvailable if no source is available for the product and the given delivery
+		// GetAvailableSources returns possible sources for the product and the desired delivery.
+		// Optionally, the existing cart can be passed so that items already in the cart are also taken into account (e.g. to deduct stock).
+		// E.g. use this before placing a product in the cart to know whether and from where an item can be sourced.
+		// Returns ErrNeedMoreDetailsSourceCannotBeDetected if information on the cart or delivery is missing.
+		// Returns ErrNoSourceAvailable if no source is available for the product and the given delivery.
 		GetAvailableSources(ctx context.Context, product domain.BasicProduct, deliveryInfo *cartDomain.DeliveryInfo, decoratedCart *decorator.DecoratedCart) (AvailableSourcesPerProduct, error)
 	}
 
-	// ItemID string alias
+	// ItemID is a string alias identifying a cart item.
 	ItemID string
 
-	// ItemAllocations represents the allocated Qtys per itemID
+	// ItemAllocations represents the allocated qtys per ItemID.
 	ItemAllocations map[ItemID]ItemAllocation
 
-	// ItemAllocation info
+	// ItemAllocation holds allocation information for a cart item.
 	ItemAllocation struct {
 		AllocatedQtys map[ProductID]AllocatedQtys
 		Error         error
 	}
 
+	// ProductID is a string alias identifying a product.
 	ProductID string
 
+	// AvailableSourcesPerProduct maps a product to its available sources.
 	AvailableSourcesPerProduct map[ProductID]AvailableSources
 
-	// AllocatedQtys represents the allocated Qty per source
+	// AllocatedQtys represents the allocated qty per source.
 	AllocatedQtys map[Source]int
 
-	// Source descriptor for a single location
+	// Source is the descriptor for a single location.
 	Source struct {
-		// LocationCode identifies the warehouse or stock location
+		// LocationCode identifies the warehouse or stock location.
 		LocationCode string
-		// ExternalLocationCode identifies the source location in an external system
+		// ExternalLocationCode identifies the source location in an external system.
 		ExternalLocationCode string
 		// SuppliedBy identifies the location that supplies this stock location.
 		SuppliedBy string
 	}
 
-	// AvailableSources is the result value object containing the available Qty per Source
+	// AvailableSources is the result value object containing the available qty per Source.
 	AvailableSources map[Source]int
 
 	// DefaultSourcingService provides a default implementation of the SourcingService interface.
@@ -87,31 +89,31 @@ type (
 var (
 	_ SourcingService = new(DefaultSourcingService)
 
-	// ErrInsufficientSourceQty - use to indicate that the requested qty exceeds the available qty
+	// ErrInsufficientSourceQty indicates that the requested qty exceeds the available qty.
 	ErrInsufficientSourceQty = errors.New("available Source Qty insufficient")
 
-	// ErrNoSourceAvailable - use to indicate that no source for an item is available at all
+	// ErrNoSourceAvailable indicates that no source is available for an item.
 	ErrNoSourceAvailable = errors.New("no Available Source Qty")
 
-	// ErrNeedMoreDetailsSourceCannotBeDetected - use to indicate that information is missing to determine a source
+	// ErrNeedMoreDetailsSourceCannotBeDetected indicates that information is missing to determine a source.
 	ErrNeedMoreDetailsSourceCannotBeDetected = errors.New("source cannot be detected")
 
-	// ErrUnsupportedProductType return when the service does not support a product type
+	// ErrUnsupportedProductType is returned when the service does not support a product type.
 	ErrUnsupportedProductType = errors.New("unsupported product type")
 
-	// ErrEmptyProductIdentifier return when product id is missing
+	// ErrEmptyProductIdentifier is returned when the product ID is missing.
 	ErrEmptyProductIdentifier = errors.New("product identifier is empty")
 
-	// ErrProductIsNil returned when nil product is received
-	ErrProductIsNil = errors.New("received product in nil")
+	// ErrProductIsNil is returned when a nil product is received.
+	ErrProductIsNil = errors.New("received product is nil")
 
-	// ErrStockProviderNotFound returned stock provider is nil
+	// ErrStockProviderNotFound is returned when the stock provider is nil.
 	ErrStockProviderNotFound = errors.New("no Stock Provider bound")
 
-	// ErrSourceProviderNotFound returned source provider is nil
+	// ErrSourceProviderNotFound is returned when the source provider is nil.
 	ErrSourceProviderNotFound = errors.New("no Source Provider bound")
 
-	// ErrCartNotProvided cart not provided
+	// ErrCartNotProvided is returned when the cart is not provided.
 	ErrCartNotProvided = errors.New("cart not provided")
 )
 
@@ -133,7 +135,7 @@ func (d *DefaultSourcingService) Inject(
 	return d
 }
 
-// GetAvailableSources - see description in Interface
+// GetAvailableSources - see description in the interface
 //
 //nolint:cyclop // more readable this way
 func (d *DefaultSourcingService) GetAvailableSources(ctx context.Context, product domain.BasicProduct, deliveryInfo *cartDomain.DeliveryInfo, decoratedCart *decorator.DecoratedCart) (AvailableSourcesPerProduct, error) {
@@ -203,7 +205,7 @@ func (d *DefaultSourcingService) getAvailableSourcesForASingleProduct(ctx contex
 		}
 	}
 
-	// if a cart is given, we need to deduct the possible allocated items in the cart
+	// if a cart is given, we need to deduct the items already allocated in the cart
 	if decoratedCart != nil {
 		allocatedSources, err := d.AllocateItems(ctx, decoratedCart)
 		if err != nil {
@@ -264,7 +266,7 @@ func getItemIdsWithProduct(dc *decorator.DecoratedCart, product domain.BasicProd
 	return result
 }
 
-// AllocateItems - see description in Interface
+// AllocateItems - see description in the interface
 func (d *DefaultSourcingService) AllocateItems(ctx context.Context, decoratedCart *decorator.DecoratedCart) (ItemAllocations, error) {
 	if err := d.checkConfiguration(); err != nil {
 		return nil, err
@@ -427,7 +429,7 @@ func (d *DefaultSourcingService) allocateFromSources(
 		stockToAllocate := min(qtyToAllocate-allocatedQty, sourceStock)
 		productSourcestock[productID][source] -= stockToAllocate
 		allocatedQty += stockToAllocate
-		allocatedQtys[source] = stockToAllocate // Added this line to update the allocatedQtys map
+		allocatedQtys[source] = stockToAllocate
 	}
 
 	return allocatedQty
@@ -452,11 +454,11 @@ func (d *DefaultSourcingService) getSourceStock(
 	return remainingSourcestock[product.GetIdentifier()][source], nil
 }
 
-// QtySum returns the sum of all sourced items
+// QtySum returns the sum of all sourced items.
 func (s AvailableSources) QtySum() int {
 	qty := 0
 	for _, sqty := range s {
-		// check against max int 32 to avoid overflowing int
+		// check against max int32 to avoid overflowing int
 		if sqty == MaxSourceQty || qty > math.MaxInt32 {
 			return MaxSourceQty
 		}
@@ -466,7 +468,7 @@ func (s AvailableSources) QtySum() int {
 	return qty
 }
 
-// Reduce returns new AvailableSources reduced by the given AvailableSources
+// Reduce returns a new AvailableSources reduced by the given AllocatedQtys.
 func (s AvailableSources) Reduce(reducedBy AllocatedQtys) AvailableSources {
 	newAvailableSources := make(AvailableSources)
 	for source, availableQty := range s {
@@ -492,6 +494,7 @@ func formatSources(sources []Source) string {
 	return checkedSources
 }
 
+// FindSourcesWithLeastAvailableQty returns the AvailableSources whose qty sum is the lowest across all products.
 func (as AvailableSourcesPerProduct) FindSourcesWithLeastAvailableQty() AvailableSources {
 	var minAvailableSources AvailableSources
 

--- a/sourcing/domain/service_test.go
+++ b/sourcing/domain/service_test.go
@@ -65,7 +65,8 @@ func TestDefaultSourcingService_GetAvailableSources(t *testing.T) {
 		assert.EqualError(t, err, "no Stock Provider bound", "received error if stock provider is not set")
 	})
 
-	t.Run("error handing on error fetching available sources", func(t *testing.T) {
+	t.Run("error handling on error fetching available sources", func(t *testing.T) {
+		t.Parallel()
 		sourcingService := domain.DefaultSourcingService{}
 		sourcingService.Inject(flamingo.NullLogger{}, &struct {
 			AvailableSourcesProvider domain.AvailableSourcesProvider `inject:",optional"`
@@ -163,7 +164,7 @@ func TestDefaultSourcingService_GetAvailableSources(t *testing.T) {
 		assert.ErrorIs(t, err, domain.ErrNoSourceAvailable)
 	})
 
-	t.Run("get sources for bundle product, cart is nil, sources shouldn't be allocated", func(t *testing.T) {
+	t.Run("get sources for bundle product, cart is nil, sources should not be allocated", func(t *testing.T) {
 		t.Parallel()
 
 		simpleInBundle1 := productDomain.SimpleProduct{Identifier: "product1"}
@@ -211,7 +212,7 @@ func TestDefaultSourcingService_GetAvailableSources(t *testing.T) {
 		assert.Equal(t, 5, availableSources[domain.ProductID(simpleInBundle2.GetIdentifier())].QtySum())
 	})
 
-	t.Run("get sources for simple product, cart is nil, sources shouldn't be allocated", func(t *testing.T) {
+	t.Run("get sources for simple product, cart is nil, sources should not be allocated", func(t *testing.T) {
 		t.Parallel()
 
 		simpleProduct := productDomain.SimpleProduct{
@@ -559,7 +560,7 @@ func TestDefaultSourcingService_AllocateItems(t *testing.T) {
 			itemAllocation[domain.ItemID("item2")].AllocatedQtys[domain.ProductID(simple2.GetIdentifier())][source1])
 	})
 
-	t.Run("if too many products are allocated to a bundle, they won't be available for the next item", func(t *testing.T) {
+	t.Run("if too many products are allocated to a bundle, they will not be available for the next item", func(t *testing.T) {
 		t.Parallel()
 
 		simpleInBundle1 := productDomain.SimpleProduct{Identifier: "product1"}
@@ -629,7 +630,7 @@ func TestDefaultSourcingService_AllocateItems(t *testing.T) {
 			itemAllocation[domain.ItemID("item1")].AllocatedQtys["product2"][source1])
 	})
 
-	t.Run("if an item from a bundle is purchased separately and insufficient quantity remains, it won't be available for the bundle", func(t *testing.T) {
+	t.Run("if an item from a bundle is purchased separately and insufficient quantity remains, it will not be available for the bundle", func(t *testing.T) {
 		t.Parallel()
 
 		simpleInBundle1 := productDomain.SimpleProduct{Identifier: "product1"}

--- a/sourcing/module.go
+++ b/sourcing/module.go
@@ -13,7 +13,7 @@ import (
 )
 
 type (
-	// Module registers sourcing module
+	// Module registers the sourcing module
 	Module struct {
 		useDefaultSourcingService bool
 		enableQtyRestrictor       bool
@@ -54,7 +54,7 @@ func (m *Module) Configure(injector *dingo.Injector) {
 	injector.Bind(new(application.SourcingApplication)).To(application.Service{})
 }
 
-// Depends on other modules
+// Depends declares the modules this module depends on.
 func (m *Module) Depends() []dingo.Module {
 	return []dingo.Module{
 		new(cart.Module),


### PR DESCRIPTION
This PR contains edits to the spelling or wording in the comments of the sourcing package