### PR TITLE
Add cancellation reason support for checkout and payment workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 
 **checkout**
 * Added support for login, password and tls to the redis client
+* Enhanced the cancellation flow with detailed reasons threading through the place-order process
+* GraphQL: Added an optional `reason` argument to the `Commerce_Checkout_CancelPlaceOrder` mutation
+
+**payment**
+* **Breaking:** `WebCartPaymentGateway.CancelOrderPayment` now requires a `CancellationReason` argument. Added the `CancellationReason` type to the domain.
 
 **search**
 * Added `FacetMapper` interface and `BindMulti` registry to allow custom facet types in GraphQL. Built-in facet types (ListFacet, TreeFacet, RangeFacet) are now registered as mappers.

--- a/checkout/application/placeorder/commands.go
+++ b/checkout/application/placeorder/commands.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 
 	cartDomain "flamingo.me/flamingo-commerce/v3/cart/domain/cart"
+	paymentdomain "flamingo.me/flamingo-commerce/v3/payment/domain"
 )
 
 type (
@@ -19,5 +20,6 @@ type (
 
 	// CancelPlaceOrderCommand cancels current running process
 	CancelPlaceOrderCommand struct {
+		Reason paymentdomain.CancellationReason
 	}
 )

--- a/checkout/application/placeorder/coordinator.go
+++ b/checkout/application/placeorder/coordinator.go
@@ -280,8 +280,7 @@ func (c *Coordinator) Cancel(ctx context.Context, reason paymentdomain.Cancellat
 			return
 		}
 
-		p.SetCancelReason(reason)
-		p.Failed(ctx, process.CanceledByCustomerReason{})
+		p.Failed(ctx, process.CanceledByCustomerReason{PaymentCancellationReason: reason})
 		err = c.storeProcessContext(ctx, p.Context())
 		if err != nil {
 			returnErr = err

--- a/checkout/application/placeorder/coordinator.go
+++ b/checkout/application/placeorder/coordinator.go
@@ -19,6 +19,7 @@ import (
 
 	"flamingo.me/flamingo-commerce/v3/cart/application"
 	"flamingo.me/flamingo-commerce/v3/checkout/domain/placeorder/process"
+	paymentdomain "flamingo.me/flamingo-commerce/v3/payment/domain"
 
 	cartDomain "flamingo.me/flamingo-commerce/v3/cart/domain/cart"
 )
@@ -230,7 +231,7 @@ func (c *Coordinator) LastProcess(ctx context.Context) (*process.Process, error)
 
 // Cancel the process if it exists (blocking)
 // be aware that all rollback callbacks are executed
-func (c *Coordinator) Cancel(ctx context.Context) error {
+func (c *Coordinator) Cancel(ctx context.Context, reason paymentdomain.CancellationReason) error {
 	ctx, span := trace.StartSpan(ctx, "checkout/Coordinator/Cancel")
 	defer span.End()
 
@@ -279,6 +280,7 @@ func (c *Coordinator) Cancel(ctx context.Context) error {
 			return
 		}
 
+		p.SetCancelReason(reason)
 		p.Failed(ctx, process.CanceledByCustomerReason{})
 		err = c.storeProcessContext(ctx, p.Context())
 		if err != nil {

--- a/checkout/application/placeorder/handler.go
+++ b/checkout/application/placeorder/handler.go
@@ -87,9 +87,9 @@ func (h *Handler) HasUnfinishedProcess(ctx context.Context) (bool, error) {
 }
 
 // CancelPlaceOrder handles order cancellation, is blocking
-func (h *Handler) CancelPlaceOrder(ctx context.Context, _ CancelPlaceOrderCommand) error {
+func (h *Handler) CancelPlaceOrder(ctx context.Context, cmd CancelPlaceOrderCommand) error {
 	ctx, span := trace.StartSpan(ctx, "checkout/Handler/CancelPlaceOrder")
 	defer span.End()
 
-	return h.coordinator.Cancel(ctx)
+	return h.coordinator.Cancel(ctx, cmd.Reason)
 }

--- a/checkout/application/placeorder/validate_payment.go
+++ b/checkout/application/placeorder/validate_payment.go
@@ -113,7 +113,7 @@ func PaymentValidator(ctx context.Context, p *process.Process, paymentService *a
 		}
 	case paymentDomain.PaymentFlowStatusAborted:
 		return process.RunResult{
-			Failed: process.PaymentCanceledByCustomerReason{},
+			Failed: process.PaymentCanceledByCustomerReason{PaymentCancellationReason: paymentDomain.CancellationReasonAbortedByCustomer},
 		}
 	case paymentDomain.PaymentFlowWaitingForCustomer:
 		// payment pending, waiting for customer doing async stuff like finishing is payment in mobile app

--- a/checkout/application/placeorder/validate_payment_test.go
+++ b/checkout/application/placeorder/validate_payment_test.go
@@ -6,6 +6,11 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	cartDomain "flamingo.me/flamingo-commerce/v3/cart/domain/cart"
 	"flamingo.me/flamingo-commerce/v3/checkout/application/placeorder"
 	"flamingo.me/flamingo-commerce/v3/checkout/domain/placeorder/process"
@@ -15,10 +20,6 @@ import (
 	"flamingo.me/flamingo-commerce/v3/payment/interfaces"
 	"flamingo.me/flamingo-commerce/v3/payment/interfaces/mocks"
 	price "flamingo.me/flamingo-commerce/v3/price/domain"
-	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 func provideProcessFactory(t *testing.T) *process.Factory {
@@ -365,7 +366,7 @@ func TestPaymentValidator(t *testing.T) {
 				},
 			},
 			want: want{
-				runResult: process.RunResult{Failed: process.PaymentCanceledByCustomerReason{}},
+				runResult: process.RunResult{Failed: process.PaymentCanceledByCustomerReason{PaymentCancellationReason: domain.CancellationReasonAbortedByCustomer}},
 				state:     states.New{}.Name(),
 			},
 		},

--- a/checkout/domain/placeorder/process/cancellation_reason_context.go
+++ b/checkout/domain/placeorder/process/cancellation_reason_context.go
@@ -1,0 +1,30 @@
+package process
+
+import (
+	"context"
+
+	paymentdomain "flamingo.me/flamingo-commerce/v3/payment/domain"
+)
+
+type cancellationReasonContextKey struct{}
+
+// SetCancelReason stores the cancellation reason on the process context.
+// MUST be called before Process.Failed so rollback can read it.
+func (p *Process) SetCancelReason(reason paymentdomain.CancellationReason) {
+	p.context.CancelReason = reason
+}
+
+// ContextWithCancellationReason returns a context carrying the cancellation
+// reason for the single rollback -> state.Rollback hop.
+func ContextWithCancellationReason(ctx context.Context, reason paymentdomain.CancellationReason) context.Context {
+	return context.WithValue(ctx, cancellationReasonContextKey{}, reason)
+}
+
+// CancellationReasonFromContext reads the reason placed by
+// ContextWithCancellationReason; missing / wrong type defaults to Unspecified.
+func CancellationReasonFromContext(ctx context.Context) paymentdomain.CancellationReason {
+	if reason, ok := ctx.Value(cancellationReasonContextKey{}).(paymentdomain.CancellationReason); ok {
+		return reason
+	}
+	return paymentdomain.CancellationReasonUnspecified
+}

--- a/checkout/domain/placeorder/process/cancellation_reason_context.go
+++ b/checkout/domain/placeorder/process/cancellation_reason_context.go
@@ -8,12 +8,6 @@ import (
 
 type cancellationReasonContextKey struct{}
 
-// SetCancelReason stores the cancellation reason on the process context.
-// MUST be called before Process.Failed so rollback can read it.
-func (p *Process) SetCancelReason(reason paymentdomain.CancellationReason) {
-	p.context.CancelReason = reason
-}
-
 // ContextWithCancellationReason returns a context carrying the cancellation
 // reason for the single rollback -> state.Rollback hop.
 func ContextWithCancellationReason(ctx context.Context, reason paymentdomain.CancellationReason) context.Context {

--- a/checkout/domain/placeorder/process/cancellation_reason_context.go
+++ b/checkout/domain/placeorder/process/cancellation_reason_context.go
@@ -26,5 +26,6 @@ func CancellationReasonFromContext(ctx context.Context) paymentdomain.Cancellati
 	if reason, ok := ctx.Value(cancellationReasonContextKey{}).(paymentdomain.CancellationReason); ok {
 		return reason
 	}
+
 	return paymentdomain.CancellationReasonUnspecified
 }

--- a/checkout/domain/placeorder/process/cancellation_reason_context_test.go
+++ b/checkout/domain/placeorder/process/cancellation_reason_context_test.go
@@ -92,7 +92,7 @@ func (stubFinalState) Run(context.Context, *process.Process) process.RunResult {
 func (stubFinalState) IsFinal() bool                                        { return true }
 func (stubFinalState) Rollback(context.Context, process.RollbackData) error { return nil }
 
-func TestProcess_SetCancelReason_FlowsToRollback(t *testing.T) {
+func TestProcess_FailedWithReason_FlowsToRollback(t *testing.T) {
 	t.Parallel()
 
 	rec := &recordingState{}
@@ -121,12 +121,11 @@ func TestProcess_SetCancelReason_FlowsToRollback(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// This mirrors exactly what Coordinator.Cancel does (Task A4): set the
-	// reason, then trigger rollback via Failed.
-	p.SetCancelReason(paymentdomain.CancellationReasonAbortedByCustomer)
-	p.Failed(context.Background(), process.CanceledByCustomerReason{})
+	// This mirrors exactly what Coordinator.Cancel does: pass the reason via Failed.
+	p.Failed(context.Background(), process.CanceledByCustomerReason{PaymentCancellationReason: paymentdomain.CancellationReasonAbortedByCustomer})
 
 	assert.True(t, rec.rolledBack)
 	assert.Equal(t, paymentdomain.CancellationReasonAbortedByCustomer, rec.gotReason)
 	assert.Equal(t, paymentdomain.CancellationReasonAbortedByCustomer, p.Context().CancelReason)
+	assert.Equal(t, paymentdomain.CancellationReasonAbortedByCustomer, p.Context().FailedReason.(process.CanceledByCustomerReason).PaymentCancellationReason)
 }

--- a/checkout/domain/placeorder/process/cancellation_reason_context_test.go
+++ b/checkout/domain/placeorder/process/cancellation_reason_context_test.go
@@ -1,0 +1,117 @@
+package process_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/gob"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"flamingo.me/flamingo/v3/framework/flamingo"
+
+	"flamingo.me/flamingo-commerce/v3/checkout/domain/placeorder/process"
+	paymentdomain "flamingo.me/flamingo-commerce/v3/payment/domain"
+)
+
+func TestCancellationReasonContext_RoundTrip(t *testing.T) {
+	t.Run("absent key defaults to Unspecified", func(t *testing.T) {
+		got := process.CancellationReasonFromContext(context.Background())
+		assert.Equal(t, paymentdomain.CancellationReasonUnspecified, got)
+	})
+
+	t.Run("value round-trips", func(t *testing.T) {
+		ctx := process.ContextWithCancellationReason(context.Background(), paymentdomain.CancellationReasonAbortedByCustomer)
+		got := process.CancellationReasonFromContext(ctx)
+		assert.Equal(t, paymentdomain.CancellationReasonAbortedByCustomer, got)
+	})
+}
+
+func TestProcessContext_GobRoundTrip(t *testing.T) {
+	t.Run("with CancelReason set", func(t *testing.T) {
+		in := process.Context{UUID: "abc", CancelReason: paymentdomain.CancellationReasonAbortedByCustomer}
+
+		var buf bytes.Buffer
+		require.NoError(t, gob.NewEncoder(&buf).Encode(in))
+
+		var out process.Context
+		require.NoError(t, gob.NewDecoder(&buf).Decode(&out))
+		assert.Equal(t, paymentdomain.CancellationReasonAbortedByCustomer, out.CancelReason)
+	})
+
+	t.Run("legacy bytes without reason decode to Unspecified", func(t *testing.T) {
+		in := process.Context{UUID: "abc"} // CancelReason left zero
+
+		var buf bytes.Buffer
+		require.NoError(t, gob.NewEncoder(&buf).Encode(in))
+
+		var out process.Context
+		require.NoError(t, gob.NewDecoder(&buf).Decode(&out))
+		assert.Equal(t, paymentdomain.CancellationReasonUnspecified, out.CancelReason)
+	})
+}
+
+// recordingState captures the reason it sees during rollback.
+type recordingState struct {
+	gotReason  paymentdomain.CancellationReason
+	rolledBack bool
+}
+
+func (s *recordingState) Name() string { return "recording" }
+func (s *recordingState) Run(context.Context, *process.Process) process.RunResult {
+	return process.RunResult{}
+}
+func (s *recordingState) IsFinal() bool { return false }
+func (s *recordingState) Rollback(ctx context.Context, _ process.RollbackData) error {
+	s.gotReason = process.CancellationReasonFromContext(ctx)
+	s.rolledBack = true
+	return nil
+}
+
+// stubFinalState is a minimal failed state so Process.Failed can switch to it.
+type stubFinalState struct{}
+
+func (stubFinalState) Name() string { return "Failed" }
+func (stubFinalState) Run(context.Context, *process.Process) process.RunResult {
+	return process.RunResult{}
+}
+func (stubFinalState) IsFinal() bool                                        { return true }
+func (stubFinalState) Rollback(context.Context, process.RollbackData) error { return nil }
+
+func TestProcess_SetCancelReason_FlowsToRollback(t *testing.T) {
+	rec := &recordingState{}
+
+	factory := &process.Factory{}
+	factory.Inject(
+		func() *process.Process {
+			return (&process.Process{}).Inject(
+				map[string]process.State{"recording": rec, "Failed": stubFinalState{}},
+				flamingo.NullLogger{},
+				nil,
+			)
+		},
+		&struct {
+			StartState  process.State `inject:"startState"`
+			FailedState process.State `inject:"failedState"`
+		}{
+			StartState:  rec,
+			FailedState: stubFinalState{},
+		},
+	)
+
+	p, err := factory.NewFromProcessContext(process.Context{
+		CurrentStateName:   "recording",
+		RollbackReferences: []process.RollbackReference{{StateName: "recording"}},
+	})
+	require.NoError(t, err)
+
+	// This mirrors exactly what Coordinator.Cancel does (Task A4): set the
+	// reason, then trigger rollback via Failed.
+	p.SetCancelReason(paymentdomain.CancellationReasonAbortedByCustomer)
+	p.Failed(context.Background(), process.CanceledByCustomerReason{})
+
+	assert.True(t, rec.rolledBack)
+	assert.Equal(t, paymentdomain.CancellationReasonAbortedByCustomer, rec.gotReason)
+	assert.Equal(t, paymentdomain.CancellationReasonAbortedByCustomer, p.Context().CancelReason)
+}

--- a/checkout/domain/placeorder/process/cancellation_reason_context_test.go
+++ b/checkout/domain/placeorder/process/cancellation_reason_context_test.go
@@ -16,12 +16,18 @@ import (
 )
 
 func TestCancellationReasonContext_RoundTrip(t *testing.T) {
+	t.Parallel()
+
 	t.Run("absent key defaults to Unspecified", func(t *testing.T) {
+		t.Parallel()
+
 		got := process.CancellationReasonFromContext(context.Background())
 		assert.Equal(t, paymentdomain.CancellationReasonUnspecified, got)
 	})
 
 	t.Run("value round-trips", func(t *testing.T) {
+		t.Parallel()
+
 		ctx := process.ContextWithCancellationReason(context.Background(), paymentdomain.CancellationReasonAbortedByCustomer)
 		got := process.CancellationReasonFromContext(ctx)
 		assert.Equal(t, paymentdomain.CancellationReasonAbortedByCustomer, got)
@@ -29,7 +35,11 @@ func TestCancellationReasonContext_RoundTrip(t *testing.T) {
 }
 
 func TestProcessContext_GobRoundTrip(t *testing.T) {
+	t.Parallel()
+
 	t.Run("with CancelReason set", func(t *testing.T) {
+		t.Parallel()
+
 		in := process.Context{UUID: "abc", CancelReason: paymentdomain.CancellationReasonAbortedByCustomer}
 
 		var buf bytes.Buffer
@@ -41,6 +51,8 @@ func TestProcessContext_GobRoundTrip(t *testing.T) {
 	})
 
 	t.Run("legacy bytes without reason decode to Unspecified", func(t *testing.T) {
+		t.Parallel()
+
 		in := process.Context{UUID: "abc"} // CancelReason left zero
 
 		var buf bytes.Buffer
@@ -66,6 +78,7 @@ func (s *recordingState) IsFinal() bool { return false }
 func (s *recordingState) Rollback(ctx context.Context, _ process.RollbackData) error {
 	s.gotReason = process.CancellationReasonFromContext(ctx)
 	s.rolledBack = true
+
 	return nil
 }
 
@@ -80,6 +93,8 @@ func (stubFinalState) IsFinal() bool                                        { re
 func (stubFinalState) Rollback(context.Context, process.RollbackData) error { return nil }
 
 func TestProcess_SetCancelReason_FlowsToRollback(t *testing.T) {
+	t.Parallel()
+
 	rec := &recordingState{}
 
 	factory := &process.Factory{}

--- a/checkout/domain/placeorder/process/context.go
+++ b/checkout/domain/placeorder/process/context.go
@@ -6,6 +6,7 @@ import (
 
 	"flamingo.me/flamingo-commerce/v3/cart/domain/cart"
 	"flamingo.me/flamingo-commerce/v3/checkout/application"
+	paymentdomain "flamingo.me/flamingo-commerce/v3/payment/domain"
 )
 
 type (
@@ -19,6 +20,7 @@ type (
 		ReturnURL          *url.URL
 		RollbackReferences []RollbackReference
 		FailedReason       FailedReason
+		CancelReason       paymentdomain.CancellationReason
 	}
 	// StateData holding state relevant data
 	StateData interface{}

--- a/checkout/domain/placeorder/process/process.go
+++ b/checkout/domain/placeorder/process/process.go
@@ -19,6 +19,7 @@ import (
 	"flamingo.me/flamingo-commerce/v3/cart/domain/cart"
 	"flamingo.me/flamingo-commerce/v3/cart/domain/validation"
 	"flamingo.me/flamingo-commerce/v3/checkout/application"
+	paymentdomain "flamingo.me/flamingo-commerce/v3/payment/domain"
 )
 
 type (
@@ -50,7 +51,7 @@ type (
 	// RollbackData needed for rollback of a state
 	RollbackData interface{}
 
-	// FailedReason gives a human readable reason for a state failure
+	// FailedReason gives a human-readable reason for a state failure
 	FailedReason interface {
 		Reason() string
 	}
@@ -60,16 +61,20 @@ type (
 		Error string
 	}
 
-	// CanceledByCustomerReason is used when customer cancels order
-	CanceledByCustomerReason struct{}
+	// CanceledByCustomerReason is used when a customer cancels an order
+	CanceledByCustomerReason struct {
+		PaymentCancellationReason paymentdomain.CancellationReason
+	}
 
 	// PaymentErrorOccurredReason is used for errors during payment
 	PaymentErrorOccurredReason struct {
 		Error string
 	}
 
-	// PaymentCanceledByCustomerReason is used to signal that payment was canceled by customer
-	PaymentCanceledByCustomerReason struct{}
+	// PaymentCanceledByCustomerReason is used to signal that a payment was canceled by a customer
+	PaymentCanceledByCustomerReason struct {
+		PaymentCancellationReason paymentdomain.CancellationReason
+	}
 
 	// CartValidationErrorReason contains the ValidationResult
 	CartValidationErrorReason struct {
@@ -116,9 +121,19 @@ func (e PaymentCanceledByCustomerReason) Reason() string {
 	return "Payment canceled by customer"
 }
 
+// CancellationReason returns the payment cancellation reason
+func (e PaymentCanceledByCustomerReason) CancellationReason() paymentdomain.CancellationReason {
+	return e.PaymentCancellationReason
+}
+
 // Reason for the error occurred
 func (e CanceledByCustomerReason) Reason() string {
 	return "Place order canceled by customer"
+}
+
+// CancellationReason returns the payment cancellation reason
+func (e CanceledByCustomerReason) CancellationReason() paymentdomain.CancellationReason {
+	return e.PaymentCancellationReason
 }
 
 // Reason for failing
@@ -269,6 +284,12 @@ func (p *Process) UpdateOrderInfo(info *application.PlaceOrderInfo) {
 
 // Failed performs all collected rollbacks and switches to FailedState
 func (p *Process) Failed(ctx context.Context, reason FailedReason) {
+	if r, ok := reason.(interface {
+		CancellationReason() paymentdomain.CancellationReason
+	}); ok {
+		p.context.CancelReason = r.CancellationReason()
+	}
+
 	err := p.rollback(ctx)
 	if err != nil {
 		p.logger.WithContext(ctx).Error("fatal rollback error: ", err)

--- a/checkout/domain/placeorder/process/process.go
+++ b/checkout/domain/placeorder/process/process.go
@@ -223,6 +223,8 @@ func (p *Process) CurrentState() (State, error) {
 }
 
 func (p *Process) rollback(ctx context.Context) error {
+	ctx = ContextWithCancellationReason(ctx, p.context.CancelReason)
+
 	for i := len(p.context.RollbackReferences) - 1; i >= 0; i-- {
 		rollbackRef := p.context.RollbackReferences[i]
 		state, ok := p.allStates[rollbackRef.StateName]

--- a/checkout/domain/placeorder/states/create_payment.go
+++ b/checkout/domain/placeorder/states/create_payment.go
@@ -97,6 +97,8 @@ func (c CreatePayment) Rollback(ctx context.Context, data process.RollbackData) 
 		return err
 	}
 
+	reason := process.CancellationReasonFromContext(ctx)
+
 	err = paymentGateway.CancelOrderPayment(
 		ctx,
 		&placeorder.Payment{
@@ -104,6 +106,7 @@ func (c CreatePayment) Rollback(ctx context.Context, data process.RollbackData) 
 			PaymentID:          rollbackData.PaymentID,
 			RawTransactionData: rollbackData.RawTransactionData,
 		},
+		reason,
 	)
 	if err != nil {
 		return err

--- a/checkout/domain/placeorder/states/create_payment_test.go
+++ b/checkout/domain/placeorder/states/create_payment_test.go
@@ -164,6 +164,8 @@ func TestCreatePayment_IsFinal(t *testing.T) {
 
 func TestCreatePayment_Rollback(t *testing.T) {
 	t.Run("happy path forwards reason from context", func(t *testing.T) {
+		t.Parallel()
+
 		state := states.CreatePayment{}
 
 		payment := &placeorder.Payment{
@@ -193,6 +195,8 @@ func TestCreatePayment_Rollback(t *testing.T) {
 	})
 
 	t.Run("defaults to Unspecified when ctx has no reason", func(t *testing.T) {
+		t.Parallel()
+
 		state := states.CreatePayment{}
 
 		payment := &placeorder.Payment{

--- a/checkout/domain/placeorder/states/create_payment_test.go
+++ b/checkout/domain/placeorder/states/create_payment_test.go
@@ -163,10 +163,8 @@ func TestCreatePayment_IsFinal(t *testing.T) {
 }
 
 func TestCreatePayment_Rollback(t *testing.T) {
-	t.Run("happy path", func(t *testing.T) {
+	t.Run("happy path forwards reason from context", func(t *testing.T) {
 		state := states.CreatePayment{}
-
-		var data interface{}
 
 		payment := &placeorder.Payment{
 			Gateway:            "test",
@@ -175,14 +173,43 @@ func TestCreatePayment_Rollback(t *testing.T) {
 			PaymentID:          "1234",
 		}
 
-		data = states.CreatePaymentRollbackData{
+		data := states.CreatePaymentRollbackData{
 			Gateway:            payment.Gateway,
 			PaymentID:          payment.PaymentID,
 			RawTransactionData: payment.RawTransactionData,
 		}
 
 		gateway := mocks.NewWebCartPaymentGateway(t)
-		gateway.EXPECT().CancelOrderPayment(mock.Anything, payment).Return(nil).Once()
+		gateway.EXPECT().
+			CancelOrderPayment(mock.Anything, payment, domain.CancellationReasonAbortedByCustomer).
+			Return(nil).Once()
+		paymentService := paymentServiceHelper(t, gateway)
+		state.Inject(paymentService)
+
+		ctx := process.ContextWithCancellationReason(context.Background(), domain.CancellationReasonAbortedByCustomer)
+		result := state.Rollback(ctx, data)
+		assert.Nil(t, result)
+		gateway.AssertExpectations(t)
+	})
+
+	t.Run("defaults to Unspecified when ctx has no reason", func(t *testing.T) {
+		state := states.CreatePayment{}
+
+		payment := &placeorder.Payment{
+			Gateway:            "test",
+			RawTransactionData: &rawTransactionData{},
+			PaymentID:          "1234",
+		}
+		data := states.CreatePaymentRollbackData{
+			Gateway:            payment.Gateway,
+			PaymentID:          payment.PaymentID,
+			RawTransactionData: payment.RawTransactionData,
+		}
+
+		gateway := mocks.NewWebCartPaymentGateway(t)
+		gateway.EXPECT().
+			CancelOrderPayment(mock.Anything, payment, domain.CancellationReasonUnspecified).
+			Return(nil).Once()
 		paymentService := paymentServiceHelper(t, gateway)
 		state.Inject(paymentService)
 
@@ -235,7 +262,9 @@ func TestCreatePayment_Rollback(t *testing.T) {
 
 		expectedError := errors.New("generic payment error")
 		gateway := mocks.NewWebCartPaymentGateway(t)
-		gateway.EXPECT().CancelOrderPayment(mock.Anything, payment).Return(expectedError).Once()
+		gateway.EXPECT().
+			CancelOrderPayment(mock.Anything, payment, domain.CancellationReasonUnspecified).
+			Return(expectedError).Once()
 		paymentService := paymentServiceHelper(t, gateway)
 		state.Inject(paymentService)
 		assert.EqualError(t, state.Rollback(context.Background(), data), expectedError.Error())

--- a/checkout/interfaces/graphql/dto/cancellation_reason.go
+++ b/checkout/interfaces/graphql/dto/cancellation_reason.go
@@ -1,0 +1,31 @@
+package dto
+
+import (
+	paymentdomain "flamingo.me/flamingo-commerce/v3/payment/domain"
+)
+
+// PaymentCancellationReason is the GraphQL-facing string enum for the optional
+// cancel-mutation reason argument. Values mirror the proto enum.
+type PaymentCancellationReason string
+
+const (
+	// PaymentCancellationReasonUnspecified is the default / legacy value.
+	PaymentCancellationReasonUnspecified PaymentCancellationReason = "UNSPECIFIED"
+	// PaymentCancellationReasonAbortedByCustomer marks an explicit customer abort.
+	PaymentCancellationReasonAbortedByCustomer PaymentCancellationReason = "ABORTED_BY_CUSTOMER"
+)
+
+// MapPaymentCancellationReason maps the optional GraphQL reason to the domain
+// enum; nil / UNSPECIFIED / unknown all resolve to Unspecified.
+func MapPaymentCancellationReason(r *PaymentCancellationReason) paymentdomain.CancellationReason {
+	if r == nil {
+		return paymentdomain.CancellationReasonUnspecified
+	}
+
+	switch *r {
+	case PaymentCancellationReasonAbortedByCustomer:
+		return paymentdomain.CancellationReasonAbortedByCustomer
+	default:
+		return paymentdomain.CancellationReasonUnspecified
+	}
+}

--- a/checkout/interfaces/graphql/dto/cancellation_reason.go
+++ b/checkout/interfaces/graphql/dto/cancellation_reason.go
@@ -23,6 +23,8 @@ func MapPaymentCancellationReason(r *PaymentCancellationReason) paymentdomain.Ca
 	}
 
 	switch *r {
+	case PaymentCancellationReasonUnspecified:
+		return paymentdomain.CancellationReasonUnspecified
 	case PaymentCancellationReasonAbortedByCustomer:
 		return paymentdomain.CancellationReasonAbortedByCustomer
 	default:

--- a/checkout/interfaces/graphql/dto/cancellation_reason_test.go
+++ b/checkout/interfaces/graphql/dto/cancellation_reason_test.go
@@ -1,0 +1,21 @@
+package dto_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"flamingo.me/flamingo-commerce/v3/checkout/interfaces/graphql/dto"
+	paymentdomain "flamingo.me/flamingo-commerce/v3/payment/domain"
+)
+
+func TestMapPaymentCancellationReason(t *testing.T) {
+	aborted := dto.PaymentCancellationReasonAbortedByCustomer
+	unspecified := dto.PaymentCancellationReasonUnspecified
+	unknown := dto.PaymentCancellationReason("SOMETHING_ELSE")
+
+	assert.Equal(t, paymentdomain.CancellationReasonUnspecified, dto.MapPaymentCancellationReason(nil))
+	assert.Equal(t, paymentdomain.CancellationReasonUnspecified, dto.MapPaymentCancellationReason(&unspecified))
+	assert.Equal(t, paymentdomain.CancellationReasonAbortedByCustomer, dto.MapPaymentCancellationReason(&aborted))
+	assert.Equal(t, paymentdomain.CancellationReasonUnspecified, dto.MapPaymentCancellationReason(&unknown))
+}

--- a/checkout/interfaces/graphql/dto/cancellation_reason_test.go
+++ b/checkout/interfaces/graphql/dto/cancellation_reason_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestMapPaymentCancellationReason(t *testing.T) {
+	t.Parallel()
+
 	aborted := dto.PaymentCancellationReasonAbortedByCustomer
 	unspecified := dto.PaymentCancellationReasonUnspecified
 	unknown := dto.PaymentCancellationReason("SOMETHING_ELSE")

--- a/checkout/interfaces/graphql/mutationresolver.go
+++ b/checkout/interfaces/graphql/mutationresolver.go
@@ -109,8 +109,10 @@ func (r *CommerceCheckoutMutationResolver) CommerceCheckoutStartPlaceOrder(ctx c
 }
 
 // CommerceCheckoutCancelPlaceOrder cancels a running place order
-func (r *CommerceCheckoutMutationResolver) CommerceCheckoutCancelPlaceOrder(ctx context.Context) (bool, error) {
-	err := r.placeorderHandler.CancelPlaceOrder(ctx, placeorder.CancelPlaceOrderCommand{})
+func (r *CommerceCheckoutMutationResolver) CommerceCheckoutCancelPlaceOrder(ctx context.Context, reason *dto.PaymentCancellationReason) (bool, error) {
+	err := r.placeorderHandler.CancelPlaceOrder(ctx, placeorder.CancelPlaceOrderCommand{
+		Reason: dto.MapPaymentCancellationReason(reason),
+	})
 
 	return err == nil, err
 }

--- a/checkout/interfaces/graphql/schema.graphql
+++ b/checkout/interfaces/graphql/schema.graphql
@@ -136,11 +136,16 @@ extend type Query {
     Commerce_Checkout_CurrentContext: Commerce_Checkout_PlaceOrderContext!
 }
 
+enum Commerce_Checkout_PaymentCancellationReason {
+    UNSPECIFIED
+    ABORTED_BY_CUSTOMER
+}
+
 extend type Mutation {
     # Starts a new process and will replace existing ones
     Commerce_Checkout_StartPlaceOrder(returnUrl: String!): Commerce_Checkout_StartPlaceOrder_Result!
     # Cancels to current running place order process, possible if state is not final
-    Commerce_Checkout_CancelPlaceOrder: Boolean!
+    Commerce_Checkout_CancelPlaceOrder(reason: Commerce_Checkout_PaymentCancellationReason): Boolean!
     # Clears the last stored place order process
     Commerce_Checkout_ClearPlaceOrder: Boolean!
     # Gets the last stored place order state and ensures that the state machine proceeds, non blocking

--- a/checkout/interfaces/graphql/service.go
+++ b/checkout/interfaces/graphql/service.go
@@ -48,6 +48,7 @@ func (*Service) Types(types *graphql.Types) {
 	types.Map("Commerce_Checkout_PlaceOrderState_State_FailedReason_CartValidationError", process.CartValidationErrorReason{})
 	types.Map("Commerce_Checkout_PlaceOrderState_State_FailedReason_CanceledByCustomer", process.CanceledByCustomerReason{})
 	types.Map("Commerce_Checkout_PlaceOrderState_State_FailedReason_PaymentCanceledByCustomer", process.PaymentCanceledByCustomerReason{})
+	types.Map("Commerce_Checkout_PaymentCancellationReason", new(dto.PaymentCancellationReason))
 
 	types.Resolve("Query", "Commerce_Checkout_ActivePlaceOrder", CommerceCheckoutQueryResolver{}, "CommerceCheckoutActivePlaceOrder")
 	types.Resolve("Query", "Commerce_Checkout_CurrentContext", CommerceCheckoutQueryResolver{}, "CommerceCheckoutCurrentContext")

--- a/payment/domain/cancellation_reason.go
+++ b/payment/domain/cancellation_reason.go
@@ -1,0 +1,12 @@
+package domain
+
+// CancellationReason describes why a payment was cancelled. It is optional at
+// every layer; the zero value (Unspecified) preserves legacy behaviour.
+type CancellationReason int
+
+const (
+	// CancellationReasonUnspecified is the default / legacy behaviour.
+	CancellationReasonUnspecified CancellationReason = iota
+	// CancellationReasonAbortedByCustomer marks an explicit customer abort.
+	CancellationReasonAbortedByCustomer
+)

--- a/payment/domain/cancellation_reason_test.go
+++ b/payment/domain/cancellation_reason_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestCancellationReason_Values(t *testing.T) {
+	t.Parallel()
+
 	// The zero value MUST be Unspecified — it is the gob default for old
 	// process bytes and the proto3 default-0 on the wire (spec §8).
 	assert.Equal(t, 0, int(domain.CancellationReasonUnspecified))

--- a/payment/domain/cancellation_reason_test.go
+++ b/payment/domain/cancellation_reason_test.go
@@ -1,0 +1,16 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"flamingo.me/flamingo-commerce/v3/payment/domain"
+)
+
+func TestCancellationReason_Values(t *testing.T) {
+	// The zero value MUST be Unspecified — it is the gob default for old
+	// process bytes and the proto3 default-0 on the wire (spec §8).
+	assert.Equal(t, 0, int(domain.CancellationReasonUnspecified))
+	assert.Equal(t, 1, int(domain.CancellationReasonAbortedByCustomer))
+}

--- a/payment/interfaces/mocks/web_cart_payment_gateway.go
+++ b/payment/interfaces/mocks/web_cart_payment_gateway.go
@@ -27,17 +27,17 @@ func (_m *WebCartPaymentGateway) EXPECT() *WebCartPaymentGateway_Expecter {
 	return &WebCartPaymentGateway_Expecter{mock: &_m.Mock}
 }
 
-// CancelOrderPayment provides a mock function with given fields: ctx, cartPayment
-func (_m *WebCartPaymentGateway) CancelOrderPayment(ctx context.Context, cartPayment *placeorder.Payment) error {
-	ret := _m.Called(ctx, cartPayment)
+// CancelOrderPayment provides a mock function with given fields: ctx, cartPayment, reason
+func (_m *WebCartPaymentGateway) CancelOrderPayment(ctx context.Context, cartPayment *placeorder.Payment, reason domain.CancellationReason) error {
+	ret := _m.Called(ctx, cartPayment, reason)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CancelOrderPayment")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *placeorder.Payment) error); ok {
-		r0 = rf(ctx, cartPayment)
+	if rf, ok := ret.Get(0).(func(context.Context, *placeorder.Payment, domain.CancellationReason) error); ok {
+		r0 = rf(ctx, cartPayment, reason)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -53,13 +53,14 @@ type WebCartPaymentGateway_CancelOrderPayment_Call struct {
 // CancelOrderPayment is a helper method to define mock.On call
 //   - ctx context.Context
 //   - cartPayment *placeorder.Payment
-func (_e *WebCartPaymentGateway_Expecter) CancelOrderPayment(ctx interface{}, cartPayment interface{}) *WebCartPaymentGateway_CancelOrderPayment_Call {
-	return &WebCartPaymentGateway_CancelOrderPayment_Call{Call: _e.mock.On("CancelOrderPayment", ctx, cartPayment)}
+//   - reason domain.CancellationReason
+func (_e *WebCartPaymentGateway_Expecter) CancelOrderPayment(ctx interface{}, cartPayment interface{}, reason interface{}) *WebCartPaymentGateway_CancelOrderPayment_Call {
+	return &WebCartPaymentGateway_CancelOrderPayment_Call{Call: _e.mock.On("CancelOrderPayment", ctx, cartPayment, reason)}
 }
 
-func (_c *WebCartPaymentGateway_CancelOrderPayment_Call) Run(run func(ctx context.Context, cartPayment *placeorder.Payment)) *WebCartPaymentGateway_CancelOrderPayment_Call {
+func (_c *WebCartPaymentGateway_CancelOrderPayment_Call) Run(run func(ctx context.Context, cartPayment *placeorder.Payment, reason domain.CancellationReason)) *WebCartPaymentGateway_CancelOrderPayment_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*placeorder.Payment))
+		run(args[0].(context.Context), args[1].(*placeorder.Payment), args[2].(domain.CancellationReason))
 	})
 	return _c
 }
@@ -69,7 +70,7 @@ func (_c *WebCartPaymentGateway_CancelOrderPayment_Call) Return(_a0 error) *WebC
 	return _c
 }
 
-func (_c *WebCartPaymentGateway_CancelOrderPayment_Call) RunAndReturn(run func(context.Context, *placeorder.Payment) error) *WebCartPaymentGateway_CancelOrderPayment_Call {
+func (_c *WebCartPaymentGateway_CancelOrderPayment_Call) RunAndReturn(run func(context.Context, *placeorder.Payment, domain.CancellationReason) error) *WebCartPaymentGateway_CancelOrderPayment_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/payment/interfaces/offlinePaymentGateway.go
+++ b/payment/interfaces/offlinePaymentGateway.go
@@ -122,6 +122,6 @@ func (o *OfflineWebCartPaymentGateway) OrderPaymentFromFlow(ctx context.Context,
 }
 
 // CancelOrderPayment nothing to cancel for offline payment
-func (o *OfflineWebCartPaymentGateway) CancelOrderPayment(ctx context.Context, cartPayment *placeorder.Payment) error {
+func (o *OfflineWebCartPaymentGateway) CancelOrderPayment(ctx context.Context, cartPayment *placeorder.Payment, _ domain.CancellationReason) error {
 	return nil
 }

--- a/payment/interfaces/webpayment.go
+++ b/payment/interfaces/webpayment.go
@@ -33,6 +33,6 @@ type (
 		OrderPaymentFromFlow(ctx context.Context, cart *cart.Cart, correlationID string) (*placeorder.Payment, error)
 
 		// CancelOrderPayment cancels the place order payment
-		CancelOrderPayment(ctx context.Context, cartPayment *placeorder.Payment) error
+		CancelOrderPayment(ctx context.Context, cartPayment *placeorder.Payment, reason domain.CancellationReason) error
 	}
 )

--- a/test/integrationtest/projecttest/graphql/generated.go
+++ b/test/integrationtest/projecttest/graphql/generated.go
@@ -1065,7 +1065,7 @@ type ComplexityRoot struct {
 		CommerceCartUpdateItemQty                  func(childComplexity int, itemID string, deliveryCode string, qty int) int
 		CommerceCartUpdatePersonalData             func(childComplexity int, personalData *forms.DefaultPersonalDataForm) int
 		CommerceCartUpdateSelectedPayment          func(childComplexity int, gateway string, method string) int
-		CommerceCheckoutCancelPlaceOrder           func(childComplexity int) int
+		CommerceCheckoutCancelPlaceOrder           func(childComplexity int, reason *dto1.PaymentCancellationReason) int
 		CommerceCheckoutClearPlaceOrder            func(childComplexity int) int
 		CommerceCheckoutRefreshPlaceOrder          func(childComplexity int) int
 		CommerceCheckoutRefreshPlaceOrderBlocking  func(childComplexity int) int
@@ -1132,7 +1132,7 @@ type MutationResolver interface {
 	CommerceCartUpdateAdditionalData(ctx context.Context, additionalData []*dto.KeyValue) (*dto.DecoratedCart, error)
 	CommerceCartUpdateDeliveriesAdditionalData(ctx context.Context, data []*dto.DeliveryAdditionalData) (*dto.DecoratedCart, error)
 	CommerceCheckoutStartPlaceOrder(ctx context.Context, returnURL string) (*dto1.StartPlaceOrderResult, error)
-	CommerceCheckoutCancelPlaceOrder(ctx context.Context) (bool, error)
+	CommerceCheckoutCancelPlaceOrder(ctx context.Context, reason *dto1.PaymentCancellationReason) (bool, error)
 	CommerceCheckoutClearPlaceOrder(ctx context.Context) (bool, error)
 	CommerceCheckoutRefreshPlaceOrder(ctx context.Context) (*dto1.PlaceOrderContext, error)
 	CommerceCheckoutRefreshPlaceOrderBlocking(ctx context.Context) (*dto1.PlaceOrderContext, error)
@@ -5138,7 +5138,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			break
 		}
 
-		return e.complexity.Mutation.CommerceCheckoutCancelPlaceOrder(childComplexity), true
+		args, err := ec.field_Mutation_Commerce_Checkout_CancelPlaceOrder_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CommerceCheckoutCancelPlaceOrder(childComplexity, args["reason"].(*dto1.PaymentCancellationReason)), true
 	case "Mutation.Commerce_Checkout_ClearPlaceOrder":
 		if e.complexity.Mutation.CommerceCheckoutClearPlaceOrder == nil {
 			break
@@ -5905,6 +5910,17 @@ func (ec *executionContext) field_Mutation_Commerce_Cart_UpdateSelectedPayment_a
 		return nil, err
 	}
 	args["method"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_Commerce_Checkout_CancelPlaceOrder_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "reason", ec.unmarshalOCommerce_Checkout_PaymentCancellationReason2ᚖflamingoᚗmeᚋflamingoᚑcommerceᚋv3ᚋcheckoutᚋinterfacesᚋgraphqlᚋdtoᚐPaymentCancellationReason)
+	if err != nil {
+		return nil, err
+	}
+	args["reason"] = arg0
 	return args, nil
 }
 
@@ -26691,7 +26707,8 @@ func (ec *executionContext) _Mutation_Commerce_Checkout_CancelPlaceOrder(ctx con
 		field,
 		ec.fieldContext_Mutation_Commerce_Checkout_CancelPlaceOrder,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Mutation().CommerceCheckoutCancelPlaceOrder(ctx)
+			fc := graphql.GetFieldContext(ctx)
+			return ec.resolvers.Mutation().CommerceCheckoutCancelPlaceOrder(ctx, fc.Args["reason"].(*dto1.PaymentCancellationReason))
 		},
 		nil,
 		ec.marshalNBoolean2bool,
@@ -26700,7 +26717,7 @@ func (ec *executionContext) _Mutation_Commerce_Checkout_CancelPlaceOrder(ctx con
 	)
 }
 
-func (ec *executionContext) fieldContext_Mutation_Commerce_Checkout_CancelPlaceOrder(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Mutation_Commerce_Checkout_CancelPlaceOrder(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Mutation",
 		Field:      field,
@@ -26709,6 +26726,17 @@ func (ec *executionContext) fieldContext_Mutation_Commerce_Checkout_CancelPlaceO
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Boolean does not have child fields")
 		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_Commerce_Checkout_CancelPlaceOrder_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -39205,6 +39233,15 @@ func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel a
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) unmarshalOCommerce_Checkout_PaymentCancellationReason2ᚖflamingoᚗmeᚋflamingoᚑcommerceᚋv3ᚋcheckoutᚋinterfacesᚋgraphqlᚋdtoᚐPaymentCancellationReason(ctx context.Context, v any) (*dto1.PaymentCancellationReason, error) {
+	if v == nil {
+		return nil, nil
+	}
+	tmp, err := graphql.UnmarshalString(v)
+	res := dto1.PaymentCancellationReason(tmp)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v any) (bool, error) {

--- a/test/integrationtest/projecttest/graphql/generated.go
+++ b/test/integrationtest/projecttest/graphql/generated.go
@@ -5138,7 +5138,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			break
 		}
 
-		args, err := ec.field_Mutation_Commerce_Checkout_CancelPlaceOrder_args(context.TODO(), rawArgs)
+		args, err := ec.field_Mutation_Commerce_Checkout_CancelPlaceOrder_args(ctx, rawArgs)
 		if err != nil {
 			return 0, false
 		}
@@ -39235,15 +39235,6 @@ func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel a
 	return res
 }
 
-func (ec *executionContext) unmarshalOCommerce_Checkout_PaymentCancellationReason2ᚖflamingoᚗmeᚋflamingoᚑcommerceᚋv3ᚋcheckoutᚋinterfacesᚋgraphqlᚋdtoᚐPaymentCancellationReason(ctx context.Context, v any) (*dto1.PaymentCancellationReason, error) {
-	if v == nil {
-		return nil, nil
-	}
-	tmp, err := graphql.UnmarshalString(v)
-	res := dto1.PaymentCancellationReason(tmp)
-	return &res, graphql.ErrorOnPath(ctx, err)
-}
-
 func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v any) (bool, error) {
 	res, err := graphql.UnmarshalBoolean(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -40309,6 +40300,25 @@ func (ec *executionContext) marshalOCommerce_Category_SearchResult2ᚖflamingo�
 		return graphql.Null
 	}
 	return ec._Commerce_Category_SearchResult(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOCommerce_Checkout_PaymentCancellationReason2ᚖflamingoᚗmeᚋflamingoᚑcommerceᚋv3ᚋcheckoutᚋinterfacesᚋgraphqlᚋdtoᚐPaymentCancellationReason(ctx context.Context, v any) (*dto1.PaymentCancellationReason, error) {
+	if v == nil {
+		return nil, nil
+	}
+	tmp, err := graphql.UnmarshalString(v)
+	res := dto1.PaymentCancellationReason(tmp)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOCommerce_Checkout_PaymentCancellationReason2ᚖflamingoᚗmeᚋflamingoᚑcommerceᚋv3ᚋcheckoutᚋinterfacesᚋgraphqlᚋdtoᚐPaymentCancellationReason(ctx context.Context, sel ast.SelectionSet, v *dto1.PaymentCancellationReason) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	_ = sel
+	_ = ctx
+	res := graphql.MarshalString(string(*v))
+	return res
 }
 
 func (ec *executionContext) marshalOCommerce_Checkout_PlaceOrderPaymentInfo2ᚕflamingoᚗmeᚋflamingoᚑcommerceᚋv3ᚋcheckoutᚋapplicationᚐPlaceOrderPaymentInfoᚄ(ctx context.Context, sel ast.SelectionSet, v []application.PlaceOrderPaymentInfo) graphql.Marshaler {

--- a/test/integrationtest/projecttest/graphql/resolver.go
+++ b/test/integrationtest/projecttest/graphql/resolver.go
@@ -237,7 +237,7 @@ type rootResolverMutation struct {
 	resolveCommerceCartUpdateAdditionalData           func(ctx context.Context, additionalData []*dto.KeyValue) (*dto.DecoratedCart, error)
 	resolveCommerceCartUpdateDeliveriesAdditionalData func(ctx context.Context, data []*dto.DeliveryAdditionalData) (*dto.DecoratedCart, error)
 	resolveCommerceCheckoutStartPlaceOrder            func(ctx context.Context, returnURL string) (*dto1.StartPlaceOrderResult, error)
-	resolveCommerceCheckoutCancelPlaceOrder           func(ctx context.Context) (bool, error)
+	resolveCommerceCheckoutCancelPlaceOrder           func(ctx context.Context, reason *dto1.PaymentCancellationReason) (bool, error)
 	resolveCommerceCheckoutClearPlaceOrder            func(ctx context.Context) (bool, error)
 	resolveCommerceCheckoutRefreshPlaceOrder          func(ctx context.Context) (*dto1.PlaceOrderContext, error)
 	resolveCommerceCheckoutRefreshPlaceOrderBlocking  func(ctx context.Context) (*dto1.PlaceOrderContext, error)
@@ -345,8 +345,8 @@ func (r *rootResolverMutation) CommerceCartUpdateDeliveriesAdditionalData(ctx co
 func (r *rootResolverMutation) CommerceCheckoutStartPlaceOrder(ctx context.Context, returnURL string) (*dto1.StartPlaceOrderResult, error) {
 	return r.resolveCommerceCheckoutStartPlaceOrder(ctx, returnURL)
 }
-func (r *rootResolverMutation) CommerceCheckoutCancelPlaceOrder(ctx context.Context) (bool, error) {
-	return r.resolveCommerceCheckoutCancelPlaceOrder(ctx)
+func (r *rootResolverMutation) CommerceCheckoutCancelPlaceOrder(ctx context.Context, reason *dto1.PaymentCancellationReason) (bool, error) {
+	return r.resolveCommerceCheckoutCancelPlaceOrder(ctx, reason)
 }
 func (r *rootResolverMutation) CommerceCheckoutClearPlaceOrder(ctx context.Context) (bool, error) {
 	return r.resolveCommerceCheckoutClearPlaceOrder(ctx)

--- a/test/integrationtest/projecttest/graphql/schema/flamingo.me_flamingo-commerce_v3_checkout_interfaces_graphql-Service.graphql
+++ b/test/integrationtest/projecttest/graphql/schema/flamingo.me_flamingo-commerce_v3_checkout_interfaces_graphql-Service.graphql
@@ -136,11 +136,16 @@ extend type Query {
     Commerce_Checkout_CurrentContext: Commerce_Checkout_PlaceOrderContext!
 }
 
+enum Commerce_Checkout_PaymentCancellationReason {
+    UNSPECIFIED
+    ABORTED_BY_CUSTOMER
+}
+
 extend type Mutation {
     # Starts a new process and will replace existing ones
     Commerce_Checkout_StartPlaceOrder(returnUrl: String!): Commerce_Checkout_StartPlaceOrder_Result!
     # Cancels to current running place order process, possible if state is not final
-    Commerce_Checkout_CancelPlaceOrder: Boolean!
+    Commerce_Checkout_CancelPlaceOrder(reason: Commerce_Checkout_PaymentCancellationReason): Boolean!
     # Clears the last stored place order process
     Commerce_Checkout_ClearPlaceOrder: Boolean!
     # Gets the last stored place order state and ensures that the state machine proceeds, non blocking

--- a/test/integrationtest/projecttest/modules/payment/fake_gateway.go
+++ b/test/integrationtest/projecttest/modules/payment/fake_gateway.go
@@ -233,6 +233,6 @@ func (g *FakeGateway) OrderPaymentFromFlow(ctx context.Context, cart *cart.Cart,
 }
 
 // CancelOrderPayment does nothing
-func (g *FakeGateway) CancelOrderPayment(ctx context.Context, cartPayment *placeorder.Payment) error {
+func (g *FakeGateway) CancelOrderPayment(ctx context.Context, cartPayment *placeorder.Payment, _ domain.CancellationReason) error {
 	return nil
 }


### PR DESCRIPTION
### Description

This pull request introduces an optional payment **cancellation reason** that is threaded end-to-end through the checkout and payment workflows. The reason is optional at every layer and defaults to `Unspecified`, preserving existing (legacy) behavior and keeping the change backward-compatible.

#### Checkout
- Added a new GraphQL enum `Commerce_Checkout_PaymentCancellationReason` (`UNSPECIFIED`, `ABORTED_BY_CUSTOMER`) and an optional `reason` argument to the `Commerce_Checkout_CancelPlaceOrder` mutation.
- Added a `dto.PaymentCancellationReason` type plus `MapPaymentCancellationReason` (nil/unknown → `Unspecified`), wired through the mutation resolver and registered via `types.Map`.
- Threaded the reason from the resolver into `CancelPlaceOrderCommand` → `Handler.CancelPlaceOrder` → `Coordinator.Cancel`.
- Carried the reason through the process context (new `Context.CancelReason`) and the rollback mechanism, so state rollbacks receive it via the context hop.
- Failure reasons (`CanceledByCustomerReason`, `PaymentCanceledByCustomerReason`) now carry the cancellation reason; the payment-aborted validation path now reports `ABORTED_BY_CUSTOMER` instead of an empty reason.

#### Payment
- Introduced `CancellationReason` as a domain enum for a consistent representation (zero value `Unspecified` = legacy behavior).
- Added the `reason` parameter to the `WebCartPaymentGateway.CancelOrderPayment` interface and updated all implementations and mocks (`OfflineWebCartPaymentGateway`, the projecttest fake gateway, and the generated mock).