### PR TITLE
fix(checkout): wrap payment validation error in custom error

### DIFF
--- a/checkout/application/placeorder/validate_payment.go
+++ b/checkout/application/placeorder/validate_payment.go
@@ -19,6 +19,10 @@ const (
 	ValidatePaymentErrorNoWalletDetails = "no wallet details set for action"
 	// ValidatePaymentErrorNoActionDisplayData used for errors when the needed DisplayData/HTML is missing from the ActionData struct
 	ValidatePaymentErrorNoActionDisplayData = "no display data / html set for action"
+	// ValidatePaymentErrorStatusFailed used for errors when the payment status is failed
+	ValidatePaymentErrorStatusFailed = "payment process failed"
+	// ValidatePaymentErrorStatusCancelled used for errors when the payment status is cancelled
+	ValidatePaymentErrorStatusCancelled = "payment process cancelled"
 )
 
 // PaymentValidator to decide over the next state
@@ -103,11 +107,21 @@ func PaymentValidator(ctx context.Context, p *process.Process, paymentService *a
 	case paymentDomain.PaymentFlowStatusCompleted:
 		// payment is done and confirmed, place order if not already placed
 		p.UpdateState(states.Success{}.Name(), nil)
-	case paymentDomain.PaymentFlowStatusFailed, paymentDomain.PaymentFlowStatusCancelled:
+	case paymentDomain.PaymentFlowStatusFailed:
 		err := ""
 		if flowStatus.Error != nil {
-			err = flowStatus.Error.Error()
+			err = ValidatePaymentErrorStatusFailed
 		}
+
+		return process.RunResult{
+			Failed: process.PaymentErrorOccurredReason{Error: err},
+		}
+	case paymentDomain.PaymentFlowStatusCancelled:
+		err := ""
+		if flowStatus.Error != nil {
+			err = ValidatePaymentErrorStatusCancelled
+		}
+
 		return process.RunResult{
 			Failed: process.PaymentErrorOccurredReason{Error: err},
 		}

--- a/checkout/application/placeorder/validate_payment.go
+++ b/checkout/application/placeorder/validate_payment.go
@@ -108,22 +108,12 @@ func PaymentValidator(ctx context.Context, p *process.Process, paymentService *a
 		// payment is done and confirmed, place order if not already placed
 		p.UpdateState(states.Success{}.Name(), nil)
 	case paymentDomain.PaymentFlowStatusFailed:
-		err := ""
-		if flowStatus.Error != nil {
-			err = ValidatePaymentErrorStatusFailed
-		}
-
 		return process.RunResult{
-			Failed: process.PaymentErrorOccurredReason{Error: err},
+			Failed: process.PaymentErrorOccurredReason{Error: ValidatePaymentErrorStatusFailed},
 		}
 	case paymentDomain.PaymentFlowStatusCancelled:
-		err := ""
-		if flowStatus.Error != nil {
-			err = ValidatePaymentErrorStatusCancelled
-		}
-
 		return process.RunResult{
-			Failed: process.PaymentErrorOccurredReason{Error: err},
+			Failed: process.PaymentErrorOccurredReason{Error: ValidatePaymentErrorStatusCancelled},
 		}
 	case paymentDomain.PaymentFlowStatusAborted:
 		return process.RunResult{

--- a/checkout/application/placeorder/validate_payment_test.go
+++ b/checkout/application/placeorder/validate_payment_test.go
@@ -383,6 +383,19 @@ func TestPaymentValidator(t *testing.T) {
 			},
 		},
 		{
+			name: "status: cancelled with error details",
+			flowStatus: flowStatusResult{
+				flowStatus: &domain.FlowStatus{
+					Status: domain.PaymentFlowStatusCancelled,
+					Error:  &domain.Error{ErrorMessage: "this flow has been cancelled", ErrorCode: "cancelledcode"},
+				},
+			},
+			want: want{
+				runResult: process.RunResult{Failed: process.PaymentErrorOccurredReason{Error: placeorder.ValidatePaymentErrorStatusCancelled}},
+				state:     states.New{}.Name(),
+			},
+		},
+		{
 			name: "status: failed",
 			flowStatus: flowStatusResult{
 				flowStatus: &domain.FlowStatus{
@@ -391,6 +404,19 @@ func TestPaymentValidator(t *testing.T) {
 			},
 			want: want{
 				runResult: process.RunResult{Failed: process.PaymentErrorOccurredReason{}},
+				state:     states.New{}.Name(),
+			},
+		},
+		{
+			name: "status: failed with error details",
+			flowStatus: flowStatusResult{
+				flowStatus: &domain.FlowStatus{
+					Status: domain.PaymentFlowStatusFailed,
+					Error:  &domain.Error{ErrorMessage: "this flow failed", ErrorCode: "failedcode"},
+				},
+			},
+			want: want{
+				runResult: process.RunResult{Failed: process.PaymentErrorOccurredReason{Error: placeorder.ValidatePaymentErrorStatusFailed}},
 				state:     states.New{}.Name(),
 			},
 		},

--- a/checkout/application/placeorder/validate_payment_test.go
+++ b/checkout/application/placeorder/validate_payment_test.go
@@ -378,7 +378,7 @@ func TestPaymentValidator(t *testing.T) {
 				},
 			},
 			want: want{
-				runResult: process.RunResult{Failed: process.PaymentErrorOccurredReason{}},
+				runResult: process.RunResult{Failed: process.PaymentErrorOccurredReason{Error: placeorder.ValidatePaymentErrorStatusCancelled}},
 				state:     states.New{}.Name(),
 			},
 		},
@@ -403,7 +403,7 @@ func TestPaymentValidator(t *testing.T) {
 				},
 			},
 			want: want{
-				runResult: process.RunResult{Failed: process.PaymentErrorOccurredReason{}},
+				runResult: process.RunResult{Failed: process.PaymentErrorOccurredReason{Error: placeorder.ValidatePaymentErrorStatusFailed}},
 				state:     states.New{}.Name(),
 			},
 		},

--- a/test/integrationtest/projecttest/tests/graphql/placeorder_test.go
+++ b/test/integrationtest/projecttest/tests/graphql/placeorder_test.go
@@ -46,7 +46,7 @@ func Test_PlaceOrderWithPaymentService(t *testing.T) {
 				"__typename": "Commerce_Checkout_PlaceOrderState_State_Failed",
 				"reason": map[string]interface{}{
 					"__typename": "Commerce_Checkout_PlaceOrderState_State_FailedReason_PaymentError",
-					"reason":     "",
+					"reason":     "payment process cancelled",
 				},
 			},
 		},
@@ -66,7 +66,7 @@ func Test_PlaceOrderWithPaymentService(t *testing.T) {
 				"__typename": "Commerce_Checkout_PlaceOrderState_State_Failed",
 				"reason": map[string]interface{}{
 					"__typename": "Commerce_Checkout_PlaceOrderState_State_FailedReason_PaymentError",
-					"reason":     "",
+					"reason":     "payment process failed",
 				},
 			},
 		},
@@ -178,7 +178,7 @@ func Test_PlaceOrderWithOrderService(t *testing.T) {
 			"__typename": "Commerce_Checkout_PlaceOrderState_State_Failed",
 			"reason": map[string]interface{}{
 				"__typename": "Commerce_Checkout_PlaceOrderState_State_FailedReason_PaymentError",
-				"reason":     "",
+				"reason":     "payment process failed",
 			},
 		}
 		helper.AsyncCheckWithTimeout(t, time.Second, func() error {
@@ -384,7 +384,7 @@ func Test_RestartStartPlaceOrder(t *testing.T) {
 	// payment selection should still be set, so we get the payment error (not PaymentSelection not set)
 	reason := state.Object().Value("reason").Object()
 	reason.Value("__typename").IsEqual("Commerce_Checkout_PlaceOrderState_State_FailedReason_PaymentError")
-	reason.Value("reason").IsEqual("")
+	reason.Value("reason").IsEqual("payment process failed")
 
 	// update payment selection
 	helper.GraphQlRequest(t, e, loadGraphQL(t, "update_payment_selection", map[string]string{"PAYMENT_METHOD": domain.PaymentFlowStatusCompleted})).Expect().Status(http.StatusOK)


### PR DESCRIPTION
The current payment validation risks exposing directly errors from the payment provider to the client. Here is a proposal to return custom flamingo-commerce errors instead. 